### PR TITLE
code: Add pmem versions of memcpy, memmove and memset

### DIFF
--- a/src/test/pmem_memcpy/.gitignore
+++ b/src/test/pmem_memcpy/.gitignore
@@ -1,0 +1,1 @@
+pmem_memcpy

--- a/src/test/pmem_memcpy/Makefile
+++ b/src/test/pmem_memcpy/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +31,13 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memcpy/Makefile -- build pmem_memcpy unit test
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+TARGET = pmem_memcpy
+OBJS = pmem_memcpy.o
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+LIBPMEM=y
 
-all clean clobber test cstyle: $(TEST)
+include ../Makefile.inc
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
-
-unittest:
-	$(MAKE) -C $@ $(TARGET)
-
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+pmem_memcpy.o: pmem_memcpy.c

--- a/src/test/pmem_memcpy/README
+++ b/src/test/pmem_memcpy/README
@@ -1,0 +1,15 @@
+Linux NVM Library
+
+This is src/test/pmem_memcpy/README.
+
+This directory contains a unit test for pmem_memcpy().
+
+The program in pmem_memcpy.c requires 4 arguments to be specified:
+	file name
+	dest off
+	src off
+	num bytes
+
+A zero for the dest offset and src offset are valid.
+
+This test performs tests for dest > src, and src > dest.

--- a/src/test/pmem_memcpy/TEST0
+++ b/src/test/pmem_memcpy/TEST0
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memcpy/TEST0 -- unit test for pmem_memcpy
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memcpy/TEST0
+export UNITTEST_NUM=0
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# aligned everything
+expect_normal_exit ./pmem_memcpy$EXESUFFIX $DIR/testfile1 0 0 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memcpy/TEST1
+++ b/src/test/pmem_memcpy/TEST1
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,29 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memcpy/TEST1 -- unit test for pmem_memcpy
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memcpy/TEST1
+export UNITTEST_NUM=1
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# Parameters are: offset from start address for dest(1) and src(2) and
+# and the number of bytes to be used for anonymous mapped memory.
+
+# unaligned dest
+expect_normal_exit ./pmem_memcpy$EXESUFFIX $DIR/testfile1 7 0 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memcpy/TEST2
+++ b/src/test/pmem_memcpy/TEST2
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,29 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memcpy/TEST2 -- unit test for pmem_memcpy
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memcpy/TEST2
+export UNITTEST_NUM=2
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# Parameters are: offset from start address for dest(1) and src(2) and
+# and size of mmap'd file/anonymous memory.
+
+# unaligned dest, unaligned src
+expect_normal_exit ./pmem_memcpy$EXESUFFIX $DIR/testfile1 7 9 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memcpy/TEST3
+++ b/src/test/pmem_memcpy/TEST3
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,29 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memcpy/TEST3 -- unit test for pmem_memcpy
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memcpy/TEST3
+export UNITTEST_NUM=3
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# Parameters are: offset from start address for dest(1) and src(2) and
+# and size of mmap'd file/anonymous memory.
+
+# aligned dest, unaligned src
+expect_normal_exit ./pmem_memcpy$EXESUFFIX $DIR/testfile1 0 9 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memcpy/out0.log.match
+++ b/src/test/pmem_memcpy/out0.log.match
@@ -1,0 +1,3 @@
+pmem_memcpy/TEST0: START: pmem_memcpy
+ ./pmem_memcpy$(nW) $(nW)/testfile1 0 0 4096
+pmem_memcpy/TEST0: Done

--- a/src/test/pmem_memcpy/out1.log.match
+++ b/src/test/pmem_memcpy/out1.log.match
@@ -1,0 +1,3 @@
+pmem_memcpy/TEST1: START: pmem_memcpy
+ ./pmem_memcpy$(nW) $(nW)/testfile1 7 0 4096
+pmem_memcpy/TEST1: Done

--- a/src/test/pmem_memcpy/out2.log.match
+++ b/src/test/pmem_memcpy/out2.log.match
@@ -1,0 +1,3 @@
+pmem_memcpy/TEST2: START: pmem_memcpy
+ ./pmem_memcpy$(nW) $(nW)/testfile1 7 9 4096
+pmem_memcpy/TEST2: Done

--- a/src/test/pmem_memcpy/out3.log.match
+++ b/src/test/pmem_memcpy/out3.log.match
@@ -1,0 +1,3 @@
+pmem_memcpy/TEST3: START: pmem_memcpy
+ ./pmem_memcpy$(nW) $(nW)/testfile1 0 9 4096
+pmem_memcpy/TEST3: Done

--- a/src/test/pmem_memcpy/pmem_memcpy.c
+++ b/src/test/pmem_memcpy/pmem_memcpy.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * pmem_memcpy.c -- unit test for doing a memcpy
+ *
+ * usage: pmem_memcpy < dest addr, src addr, length>
+ *
+ */
+
+#include "unittest.h"
+#include "libpmem.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void do_memcpy(int fd, void *dest, int dest_off, void *src, int src_off,
+    size_t bytes, char *file_name)
+{
+
+
+	char buf[bytes];
+
+	memset(buf, 0, bytes);
+
+	memset(dest, 0, bytes);
+	memset(src, 0, bytes);
+
+	memset(src, 0x5A, bytes/4);
+	memset(src + bytes/4, 0x46, bytes/4);
+	pmem_memcpy(dest + dest_off, src + src_off, bytes/2);
+
+	/* memcmp will validate that what I expect in memory. */
+	if (memcmp(src + src_off, dest + dest_off, bytes/2))
+		OUT("%s: first %zu bytes do not match",
+			file_name, bytes/2);
+
+	/* Now validate the contents of the file */
+	LSEEK(fd, (off_t)dest_off, SEEK_SET);
+	if (READ(fd, buf, bytes/2) == bytes/2) {
+		if (memcmp(src + src_off, buf, bytes/2))
+			OUT("%s: first %zu bytes do not match",
+				file_name, bytes/2);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	int fd;
+	void *dest;
+	void *src;
+	struct stat stbuf;
+
+	START(argc, argv, "pmem_memcpy");
+
+	if (argc != 5)
+		FATAL("usage: %s dest offset, src offset, num bytes", argv[0]);
+
+	fd = OPEN(argv[1], O_RDWR);
+	int dest_off = atoi(argv[2]);
+	int src_off = atoi(argv[3]);
+	size_t bytes = strtoul(argv[4], NULL, 0);
+
+	FSTAT(fd, &stbuf);
+
+	/* Copy backward, src > dest */
+	dest = pmem_map(fd);
+	if (dest == NULL) {
+		OUT("Could not mmap %s: \n", argv[1]);
+		goto err;
+	}
+	src = ANON_MMAP(bytes);
+
+	do_memcpy(fd, dest, dest_off, src, src_off, bytes, argv[1]);
+	MUNMAP(src, bytes);
+	MUNMAP(dest, stbuf.st_size);
+
+	/* Copy forward, dest > src */
+	src =  ANON_MMAP(bytes);
+
+	dest = pmem_map(fd);
+	if (dest == NULL) {
+		OUT("Could not mmap %s: \n", argv[1]);
+		goto err;
+	}
+	do_memcpy(fd, dest, dest_off, src, src_off, bytes, argv[1]);
+	MUNMAP(src, 4096);
+	MUNMAP(dest, stbuf.st_size);
+
+err:
+	CLOSE(fd);
+
+	DONE(NULL);
+}

--- a/src/test/pmem_memmove/.gitignore
+++ b/src/test/pmem_memmove/.gitignore
@@ -1,0 +1,1 @@
+pmem_memmove

--- a/src/test/pmem_memmove/Makefile
+++ b/src/test/pmem_memmove/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +31,13 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/Makefile -- build pmem_memmove unit test
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+TARGET = pmem_memmove
+OBJS = pmem_memmove.o
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+LIBPMEM=y
 
-all clean clobber test cstyle: $(TEST)
+include ../Makefile.inc
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
-
-unittest:
-	$(MAKE) -C $@ $(TARGET)
-
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+pmem_memmove.o: pmem_memmove.c

--- a/src/test/pmem_memmove/README
+++ b/src/test/pmem_memmove/README
@@ -1,0 +1,15 @@
+Linux NVM Library
+
+This is src/test/pmem_memmove/README.
+
+This directory contains a unit test for pmem_memmove().
+
+The program in pmem_memmove.c takes a file name and a block size as
+required arguments. The optional arguments are:
+	d: destination offset
+	s: source offset
+	o: overlap, 1 == src overlap, 2 == dest overlap
+	S: with o, overlap amount(in bytes)
+
+In all cases it sets a pattern of Z's and T's of 1/2 the block size specified. It
+then tests for success by doing a memcmp and reading the file directly.

--- a/src/test/pmem_memmove/TEST0
+++ b/src/test/pmem_memmove/TEST0
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST0 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST0
+export UNITTEST_NUM=0
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# No offset, no overlap
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST1
+++ b/src/test/pmem_memmove/TEST1
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST1 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST1
+export UNITTEST_NUM=1
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# aligned dest, unaligned source, no overlap
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 s:7 b:4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST2
+++ b/src/test/pmem_memmove/TEST2
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST2 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST2
+export UNITTEST_NUM=2
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# unaligned dest, unaligned source, no overlap
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 d:7 s:13 b:4096
+
+#rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST3
+++ b/src/test/pmem_memmove/TEST3
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST3 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST3
+export UNITTEST_NUM=3
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# all aligned, src overlaps dest
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 S:23 o:1
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST4
+++ b/src/test/pmem_memmove/TEST4
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST4 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST4
+export UNITTEST_NUM=4
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# unaligned destination
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 d:21
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST5
+++ b/src/test/pmem_memmove/TEST5
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST5 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST5
+export UNITTEST_NUM=5
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# unaligned source and dest
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 d:21 s:7
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST6
+++ b/src/test/pmem_memmove/TEST6
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST6 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST6
+export UNITTEST_NUM=6
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# overlap of src, aligned src and dest
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 o:1 S:20
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST7
+++ b/src/test/pmem_memmove/TEST7
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST7 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST7
+export UNITTEST_NUM=7
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 4K $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# overlap of src, aligned src, unaligned dest
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 d:13 o:1 S:20
+
+#rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST8
+++ b/src/test/pmem_memmove/TEST8
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST8 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST8
+export UNITTEST_NUM=8
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 4K $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# dest overlaps src, unaligned dest, aligned src
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:2048 d:13 o:2 S:20
+
+#rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/TEST9
+++ b/src/test/pmem_memmove/TEST9
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,26 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memmove/TEST9 -- unit test for pmem_memmove
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memmove/TEST9
+export UNITTEST_NUM=9
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+# dest overlaps src, aligned dest and src
+expect_normal_exit ./pmem_memmove$EXESUFFIX $DIR/testfile1 b:4096 o:2 S:20
+
+#rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memmove/out0.log.match
+++ b/src/test/pmem_memmove/out0.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST0: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096
+pmem_memmove/TEST0: Done

--- a/src/test/pmem_memmove/out1.log.match
+++ b/src/test/pmem_memmove/out1.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST1: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 s:7 b:4096
+pmem_memmove/TEST1: Done

--- a/src/test/pmem_memmove/out2.log.match
+++ b/src/test/pmem_memmove/out2.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST2: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 d:7 s:13 b:4096
+pmem_memmove/TEST2: Done

--- a/src/test/pmem_memmove/out3.log.match
+++ b/src/test/pmem_memmove/out3.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST3: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 S:23 o:1
+pmem_memmove/TEST3: Done

--- a/src/test/pmem_memmove/out4.log.match
+++ b/src/test/pmem_memmove/out4.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST4: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 d:21
+pmem_memmove/TEST4: Done

--- a/src/test/pmem_memmove/out5.log.match
+++ b/src/test/pmem_memmove/out5.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST5: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 d:21 s:7
+pmem_memmove/TEST5: Done

--- a/src/test/pmem_memmove/out6.log.match
+++ b/src/test/pmem_memmove/out6.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST6: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 o:1 S:20
+pmem_memmove/TEST6: Done

--- a/src/test/pmem_memmove/out7.log.match
+++ b/src/test/pmem_memmove/out7.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST7: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 d:13 o:1 S:20
+pmem_memmove/TEST7: Done

--- a/src/test/pmem_memmove/out8.log.match
+++ b/src/test/pmem_memmove/out8.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST8: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:2048 d:13 o:2 S:20
+pmem_memmove/TEST8: Done

--- a/src/test/pmem_memmove/out9.log.match
+++ b/src/test/pmem_memmove/out9.log.match
@@ -1,0 +1,3 @@
+pmem_memmove/TEST9: START: pmem_memmove
+ ./pmem_memmove$(nW) $(nW)/testfile1 b:4096 o:2 S:20
+pmem_memmove/TEST9: Done

--- a/src/test/pmem_memmove/pmem_memmove.c
+++ b/src/test/pmem_memmove/pmem_memmove.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * pmem_memmove.c -- unit test for doing a memmove
+ *
+ * usage: pmem_memmove <dest addr, src addr, length>
+ *
+ */
+
+#include "unittest.h"
+#include "libpmem.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdbool.h>
+
+/*
+ * do_memmove: Worker function for memove.
+ *
+ * Always work within the boundary of bytes. Fill in 1/2 of the src
+ * memory with the pattern we want to write. This allows us to check
+ * that we did not overwrite anything we were not supposed to in the
+ * dest.  Use the non pmem version of the memset/memcpy commands
+ * so as not to introduce any possible side affects.
+ */
+void
+do_memmove(int fd, void *dest, void *src, char *file_name, off_t dest_off,
+	off_t src_off, off_t off, off_t bytes)
+{
+
+	void *src1 = malloc(bytes);
+	void *buf = malloc(bytes);
+
+	memset(buf, 0, bytes);
+	memset(src1, 0, bytes);
+	memset(src + src_off, 0x5A, bytes/4);
+	memset(src + src_off + bytes/4, 0x54, bytes/4);
+
+	/*
+	 * A side affect of the memmove call is that
+	 * src contents will be changed in the case of overlapping
+	 * addresses.
+	 */
+
+	memcpy(src1 + src_off, src + src_off, bytes/2);
+	pmem_memmove(dest + dest_off, src + src_off, bytes/2);
+
+	/* memcmp will validate that what I expect in memory. */
+	if (memcmp(src1 + src_off, dest + dest_off, bytes/2))
+		OUT("%s: %zu bytes do not match with memcmp",
+			file_name, bytes/2);
+
+	/*
+	 * This is a special case. An overlapping dest means that
+	 * src is a pointer to the file, and destination is src + dest_off +
+	 * overlap. This is the basis for the comparison.
+	 */
+	if (dest > src && off != 0) {
+		LSEEK(fd, (off_t)dest_off + off, SEEK_SET);
+		if (READ(fd, buf, bytes/2) == bytes/2) {
+			if (memcmp(src1 + src_off, buf, bytes/2))
+				OUT("%s: first %zu bytes do not match",
+					file_name, bytes/2);
+		}
+	} else {
+		LSEEK(fd, (off_t)dest_off, SEEK_SET);
+		if (READ(fd, buf, bytes/2) == bytes/2) {
+			if (memcmp(src1 + src_off, buf, bytes/2))
+				OUT("%s: first %zu bytes do not match",
+					file_name, bytes/2);
+		}
+	}
+}
+int
+main(int argc, char *argv[])
+{
+	int fd;
+	struct stat stbuf;
+	void *dest;
+	void *src;
+	off_t dest_off = 0;
+	off_t src_off = 0;
+	off_t bytes = 0;
+	int who = 0;
+	off_t overlap = 0;
+
+	START(argc, argv, "pmem_memmove");
+
+	fd = OPEN(argv[1], O_RDWR);
+	FSTAT(fd, &stbuf);
+
+	for (int arg = 2; arg < argc; arg++) {
+		if (strchr("dsboS",
+		    argv[arg][0]) == NULL || argv[arg][1] != ':')
+			FATAL("op must be d: or s: or b: or o: or S:");
+		off_t val = strtoul(&argv[arg][2], NULL, 0);
+
+		switch (argv[arg][0]) {
+		case 'd':
+			if (val <= 0)
+				FATAL("Invalid value for destination offset");
+			dest_off = val;
+			break;
+		case 's':
+			if (val <= 0)
+				FATAL("Invalid value for source offset");
+			src_off = val;
+			break;
+		case 'b':
+			if (val <= 0)
+				FATAL("Invalid value for bytes");
+			bytes = val;
+			break;
+		case 'o':
+			who = (int)val;
+			break;
+		case 'S':
+			overlap = val;
+			break;
+		}
+	}
+
+	if (who == 0 && overlap != 0)
+		FATAL("Invalid overlap and source");
+
+	/*
+	 * For overlap the src and dest must be created differently.
+	 */
+
+	if (who == 0) {
+		/* src > dest */
+		dest = pmem_map(fd);
+		if (dest == NULL) {
+			OUT("Could not mmap %s: \n", argv[1]);
+			goto err;
+		}
+
+		src = ANON_MMAP(bytes);
+		memset(dest, 0, bytes);
+		memset(src, 0, bytes);
+		do_memmove(fd, dest, src, argv[1], dest_off, src_off,
+			0, bytes);
+
+		MUNMAP(dest, stbuf.st_size);
+		MUNMAP(src, bytes);
+
+		/* dest > src */
+		src =  ANON_MMAP(bytes);
+		dest = pmem_map(fd);
+		if (dest == NULL) {
+			OUT("Could not mmap %s: \n", argv[1]);
+			goto err;
+		}
+
+		memset(dest, 0, bytes);
+		memset(src, 0, bytes);
+
+		do_memmove(fd, dest, src, argv[1], dest_off, src_off, 0,
+			bytes);
+		MUNMAP(dest, stbuf.st_size);
+		MUNMAP(src, bytes);
+	} else {
+		if (who == 1) {
+			/* src overlap with dest */
+			dest = pmem_map(fd);
+			if (dest == NULL) {
+				OUT("Could not mmap %s: \n", argv[1]);
+				goto err;
+			}
+			src = dest + overlap;
+			memset(dest, 0, bytes);
+			do_memmove(fd, dest, src, argv[1], dest_off, src_off,
+				overlap, bytes);
+			MUNMAP(dest, stbuf.st_size);
+		}
+		if (who == 2) {
+			/* dest overlap with src */
+			dest = pmem_map(fd);
+			if (dest == NULL) {
+				OUT("Could not mmap %s: \n", argv[1]);
+				goto err;
+			}
+			src = dest;
+			dest = src + overlap;
+			memset(src, 0, bytes);
+			do_memmove(fd, dest, src, argv[1], dest_off, src_off,
+				overlap, bytes);
+			MUNMAP(src, stbuf.st_size);
+		}
+	}
+
+err:
+	CLOSE(fd);
+
+	DONE(NULL);
+}

--- a/src/test/pmem_memset/.gitignore
+++ b/src/test/pmem_memset/.gitignore
@@ -1,0 +1,1 @@
+pmem_memset

--- a/src/test/pmem_memset/Makefile
+++ b/src/test/pmem_memset/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +31,13 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memset/Makefile -- build pmem_memset unit test
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+TARGET = pmem_memset
+OBJS = pmem_memset.o
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+LIBPMEM=y
 
-all clean clobber test cstyle: $(TEST)
+include ../Makefile.inc
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
-
-unittest:
-	$(MAKE) -C $@ $(TARGET)
-
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+pmem_memset.o: pmem_memset.c

--- a/src/test/pmem_memset/README
+++ b/src/test/pmem_memset/README
@@ -1,0 +1,13 @@
+Linux NVM Library
+
+This is src/test/pmem_memset/README.
+
+This directory contains a unit test for pmem_memset().
+
+The program in pmem_memset.c takes a file name as an argument. It
+tests two cases, aligned dest addr and unaligned dest addr.
+
+Initially the program maps the file to be used as the dest addr for the test.
+It fills in the buffer used for setting the destination file with Z's and T's.
+
+The file is read after processing the memset to ensure contains the correct values.

--- a/src/test/pmem_memset/TEST0
+++ b/src/test/pmem_memset/TEST0
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,25 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memset/TEST0 -- unit test for pmem_memset
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memset/TEST0
+export UNITTEST_NUM=0
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+expect_normal_exit ./pmem_memset$EXESUFFIX $DIR/testfile1 0 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memset/TEST1
+++ b/src/test/pmem_memset/TEST1
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,66 +32,25 @@
 #
 
 #
-# src/test/Makefile -- build all unit tests
+# src/test/pmem_memset/TEST1 -- unit test for pmem_memset
 #
-# Makefile -- build all unit tests
-#
-TEST = blk_nblock\
-       blk_recovery\
-       blk_rw\
-       blk_rw_mt\
-       checksum\
-       log_basic\
-       log_recovery\
-       log_walker\
-       pmem_isa_proc\
-       pmem_is_pmem\
-       pmem_is_pmem_proc\
-       pmem_map\
-       pmem_memcpy\
-       pmem_memmove\
-       pmem_memset\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_pool_create\
-       util_pool_open\
-       vmem_aligned_alloc\
-       vmem_calloc\
-       vmem_check_allocations\
-       vmem_check_version\
-       vmem_custom_alloc\
-       vmem_malloc\
-       vmem_malloc_usable_size\
-       vmem_mix_allocations\
-       vmem_multiple_pools\
-       vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
-       vmem_realloc\
-       vmem_stats\
-       vmem_strdup\
-       vmem_fork\
-       vmem_valgrind\
-       vmem_pages_purging
+export UNITTEST_NAME=pmem_memset/TEST1
+export UNITTEST_NUM=1
 
-all     : TARGET = all
-clean   : TARGET = clean
-clobber : TARGET = clobber
-test    : TARGET = test
-cstyle  : TARGET = cstyle
+# standard unit test setup
+. ../unittest/unittest.sh
 
-all clean clobber test cstyle: $(TEST)
+require_fs_type local
 
-$(TEST): unittest
-	$(MAKE) -C $@ $(TARGET)
+setup
 
-unittest:
-	$(MAKE) -C $@ $(TARGET)
+rm -f $DIR/testfile1
+truncate -s 2G $DIR/testfile1
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+expect_normal_exit ./pmem_memset$EXESUFFIX $DIR/testfile1 13 4096
+
+rm $DIR/testfile1
+
+check
+
+pass

--- a/src/test/pmem_memset/out0.log.match
+++ b/src/test/pmem_memset/out0.log.match
@@ -1,0 +1,3 @@
+pmem_memset/TEST0: START: pmem_memset
+ ./pmem_memset$(nW) $(nW)/testfile1 0 4096
+pmem_memset/TEST0: Done

--- a/src/test/pmem_memset/out1.log.match
+++ b/src/test/pmem_memset/out1.log.match
@@ -1,0 +1,3 @@
+pmem_memset/TEST1: START: pmem_memset
+ ./pmem_memset$(nW) $(nW)/testfile1 13 4096
+pmem_memset/TEST1: Done

--- a/src/test/pmem_memset/pmem_memset.c
+++ b/src/test/pmem_memset/pmem_memset.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * pmem_memset.c -- unit test for doing a memset
+ *
+ * usage: pmem_memset <dest addr, int c, num bytes>
+ *
+ */
+
+#include "unittest.h"
+#include "libpmem.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int
+main(int argc, char *argv[])
+{
+	int fd;
+	struct stat stbuf;
+	void *dest;
+
+	START(argc, argv, "pmem_memset");
+
+	if (argc != 4)
+		FATAL("usage: %s dest off, num bytes", argv[0]);
+
+	fd = OPEN(argv[1], O_RDWR);
+	int dest_off = atoi(argv[2]);
+	size_t bytes = strtoul(argv[3], NULL, 0);
+
+	char buf[bytes];
+
+	FSTAT(fd, &stbuf);
+
+	dest = pmem_map(fd);
+	if (dest == NULL) {
+		OUT("Could not mmap %s: \n", argv[1]);
+		goto err;
+	}
+
+	pmem_memset(dest + dest_off, 0x5A, bytes/2);
+	pmem_memset(dest + dest_off  + (bytes/2), 0x46, (bytes/2 - dest_off));
+
+	LSEEK(fd, (off_t)0, SEEK_SET);
+	if (READ(fd, buf, bytes) == bytes) {
+		if (memcmp(buf, dest, bytes))
+			OUT("%s: first %zu bytes do not match",
+				argv[1], bytes);
+	}
+	MUNMAP(dest, stbuf.st_size);
+
+err:
+
+	CLOSE(fd);
+
+	DONE(NULL);
+}

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -99,6 +99,7 @@
 #include <sys/mman.h>
 #include <sys/file.h>
 #include <sys/mount.h>
+#include <sys/param.h>
 #include <uuid/uuid.h>
 #include <fcntl.h>
 #include <signal.h>
@@ -281,6 +282,8 @@ void *ut_mmap(const char *file, int line, const char *func, void *addr,
 int ut_munmap(const char *file, int line, const char *func, void *addr,
     size_t length);
 
+void *ut_anon_mmap(const char *file, int line, const char *func, int len);
+
 int ut_mprotect(const char *file, int line, const char *func, void *addr,
     size_t len, int prot);
 
@@ -382,6 +385,10 @@ int ut_closedir(const char *file, int line, const char *func, DIR *dirp);
 /* a mmap() that can't return MAP_FAILED */
 #define	MMAP(addr, len, prot, flags, fd, offset)\
     ut_mmap(__FILE__, __LINE__, __func__, addr, len, prot, flags, fd, offset);
+
+/* an mmap of anonymous memory that can't return MAP_FAILED */
+#define	ANON_MMAP(length)\
+    ut_anon_mmap(__FILE__, __LINE__, __func__, length);
 
 /* a munmap() that can't return -1 */
 #define	MUNMAP(addr, length)\

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,11 @@ extern ssize_t readlinkat(int, const char *restrict, char *restrict, size_t);
 
 #define	MAXLOGNAME 100		/* maximum expected .log file name length */
 #define	MAXPRINT 8192		/* maximum expected single print length */
+
+#define	PROCMAXLEN 2048 /* maximum expected line length in /proc files */
+
+#define	GIGABYTE ((uintptr_t)1 << 30)
+#define	TERABYTE ((uintptr_t)1 << 40)
 
 /*
  * output gets replicated to these files
@@ -306,6 +311,64 @@ check_open_files()
 }
 
 /*
+ * ut_map_hint -- (internal) use /proc to determine a hint address for anon_mmap
+ *
+ * This is a helper function for ut_anon_mmap().  It opens up /proc/self/maps
+ * and looks for the first unused address in the process address space that is:
+ * - greater or equal 1TB,
+ * - large enough to hold range of given length,
+ * - 1GB aligned.
+ *
+ * Asking for aligned address like this will allow the DAX code to use large
+ * mappings.  It is not an error if anon_mmap() ignores the hint and chooses
+ * different address.
+ */
+char *
+ut_map_hint(size_t len)
+{
+	FILE *fp;
+	if ((fp = fopen("/proc/self/maps", "r")) == NULL) {
+		return NULL;
+	}
+
+	char line[PROCMAXLEN];	/* for fgets() */
+	char *lo = NULL;	/* beginning of current range in maps file */
+	char *hi = NULL;	/* end of current range in maps file */
+	char *raddr = (char *)TERABYTE; /* ignore regions below 1TB */
+	while (fgets(line, PROCMAXLEN, fp) != NULL) {
+		/* check for range line */
+		if (sscanf(line, "%p-%p", &lo, &hi) == 2) {
+			if (lo > raddr) {
+				if (lo - raddr >= len) {
+					break;
+				}
+			}
+
+			if (hi > raddr) {
+				/* align to 1GB */
+				raddr = (char *)roundup((uintptr_t)hi,
+				    GIGABYTE);
+			}
+
+			if (raddr == 0) {
+				break;
+			}
+		}
+	}
+	/*
+	 * Check for a case when this is the last unused range in the address
+	 * space, but is not large enough. (very unlikely)
+	 */
+	if ((raddr != NULL) && (UINTPTR_MAX - (uintptr_t)raddr < len)) {
+		raddr = NULL;
+	}
+
+	fclose(fp);
+
+	return raddr;
+}
+
+/*
  * ut_start -- initialize unit test framework, indicate test started
  */
 void
@@ -465,4 +528,20 @@ ut_err(const char *file, int line, const char *func,
 	va_end(ap);
 
 	errno = saveerrno;
+}
+
+void *
+ut_anon_mmap(const char *file, int line, const char *func, int len)
+{
+	void *base;
+
+	void *dest = ut_map_hint(len);
+
+	if ((base = mmap(dest, len, PROT_READ|PROT_WRITE,
+		MAP_SHARED | MAP_FIXED | MAP_ANONYMOUS, -1, 0))
+			== MAP_FAILED) {
+		ut_fatal(file, line, func, "!anonymous mmap: %d", len);
+	}
+
+	return base;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,6 +52,7 @@
 
 #define	GIGABYTE ((uintptr_t)1 << 30)
 #define	TERABYTE ((uintptr_t)1 << 40)
+
 
 /* library-wide page size */
 unsigned long Pagesize;
@@ -378,6 +379,29 @@ util_range_none(void *addr, size_t len)
 		LOG(1, "!mprotect: PROT_NONE");
 
 	return retval;
+}
+
+/*
+ * Calculate if there is overlap in with the addresses and length
+ */
+bool
+util_overlap(const void *start1, void *end1, const void *start2, void *end2)
+{
+	return (end1 >= start2 && end2 >= start1);
+}
+
+/*
+ * Calculate the non-overlap chunk size
+ */
+size_t
+util_nonoverlap_range(void *start1, void *start2, size_t len)
+{
+	if (util_overlap(start1, start1 + len, start2, start2 + len)) {
+		/* Return size of chunk of non-overlapped data */
+		return (start1 - start2);
+	} else {
+		return len;
+	}
 }
 
 /*

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,22 @@
  * util.h -- internal definitions for util module
  */
 
+#include <stdbool.h>
+
+/*
+ * Compiler aligns __m128, __m128d and __m128i local and global
+ * data 16 byte boundaries. MOVNT values below represent this alignment.
+ * MOVNTx is the assembly language command for moving data using
+ * non-temporal location.
+ */
+
+#define	MOVNT_SIZE	16
+#define	MOVNT_MASK	(MOVNT_SIZE -1)
+#define	MOVNT_SHIFT	4
+
+#define	UP	1
+#define	DOWN	0
+
 /*
  * overridable names for malloc & friends used by this library
  */
@@ -47,14 +63,16 @@ Free_func Free;
 Realloc_func Realloc;
 Strdup_func Strdup;
 
-void util_set_alloc_funcs(
+void	util_set_alloc_funcs(
 		void *(*malloc_func)(size_t size),
 		void (*free_func)(void *ptr),
 		void *(*realloc_func)(void *ptr, size_t size),
 		char *(*strdup_func)(const char *s));
-void *util_map(int fd, size_t len, int cow);
-int util_unmap(void *addr, size_t len);
-
+void	*util_map(int fd, size_t len, int cow);
+int	util_unmap(void *addr, size_t len);
+bool	util_overlap(const void *start1, void *end1, const void *start2,
+		void *end2);
+size_t	util_nonoverlap_range(void *start, void *end, size_t len);
 /*
  * header used at the beginning of all types of memory pools
  *


### PR DESCRIPTION
Added pmem functions for memcpy, memmove and memset. These functions
use non-temporal instructions.

Ref: pmem/issues#12