### PR TITLE
benchmarks: fix log_mt benchmark

### DIFF
--- a/src/benchmarks/log_mt/RUN.sh
+++ b/src/benchmarks/log_mt/RUN.sh
@@ -33,9 +33,12 @@
 OPS_COUNT=100
 MAX_THREADS=32
 RUNS=`seq $MAX_THREADS`
-LOG_IN="./log_mt.tmp"
+DIR="."
 PMEMLOG_OUT=pmemlog_mt.out
 FILEIOLOG_OUT=fileiolog_mt.out
+[ -n "$1" ] && DIR=$1
+[ -n "$2" ] && OPS_COUNT=$2
+LOG_IN="${DIR}/log_mt.tmp"
 
 rm -f $FILEIOLOG_OUT
 rm -f $LOG_IN

--- a/src/benchmarks/log_mt/threads.c
+++ b/src/benchmarks/log_mt/threads.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,16 +105,16 @@ run_threads(struct prog_args *args, thread_f task, void *arg, double *exec_time)
 		};
 
 		if ((thread_info[i].buf = (char *)
-				calloc(args->el_size *
-					args->vec_size * args->ops_count,
-					sizeof (char))) == NULL) {
+				malloc(args->el_size *
+				args->vec_size *
+				sizeof (char))) == NULL) {
 			return EXIT_FAILURE;
 		}
 
-		thread_info[i].buf_size = args->el_size * args->vec_size
-				* args->ops_count;
+		thread_info[i].buf_size = args->el_size * args->vec_size;
 
-		if ((thread_info[i].iov = (struct iovec *)calloc(args->vec_size,
+		if ((thread_info[i].iov = (struct iovec *)
+				malloc(args->vec_size *
 				sizeof (struct iovec))) == NULL) {
 			return EXIT_FAILURE;
 		}
@@ -297,8 +297,8 @@ process_data(const void *buf, size_t len, void *arg)
 {
 	struct thread_info *thread_info = arg;
 
-	if ((thread_info->buf_ptr + len) <= thread_info->buf_size) {
-		memcpy(&thread_info->buf[thread_info->buf_ptr], buf, len);
+	if (len <= thread_info->buf_size) {
+		memcpy(thread_info->buf, buf, len);
 		thread_info->buf_ptr += len;
 
 		return 1;


### PR DESCRIPTION
- pmemlog_rewind required after warm up
- take DIR and OPS_COUNT from command line options in RUN.sh
- don't allocate separate buffer for each operation
- check for fails
- use malloc instead of calloc