### PR TITLE
vmmalloc: distinguish clang from gcc

### DIFF
--- a/src/include/libvmmalloc.h
+++ b/src/include/libvmmalloc.h
@@ -59,7 +59,7 @@ extern "C" {
 /*
  * check compiler support for various function attributes
  */
-#if defined __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 
 #define	GCC_VER (__GNUC__ * 100 + __GNUC_MINOR__)
 


### PR DESCRIPTION
clang v.3.5.0 (x86_64-redhat-linux-gnu) defines __GNUC__ (4)
and __GNUC_MINOR__ (3), so we have to check if __clang__
is defined in order to distinguish clang from gcc.