### PR TITLE
btt: update layout to match latest spec

### DIFF
--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -129,6 +129,7 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <endian.h>
+#include <uuid/uuid.h>
 
 #include "out.h"
 #include "util.h"
@@ -153,6 +154,11 @@ struct btt {
 	 */
 	pthread_mutex_t layout_write_mutex;
 	int laidout;
+
+	/*
+	 * UUID of the BTT
+	 */
+	uint8_t uuid[BTTINFO_UUID_LEN];
 
 	/*
 	 * UUID of the containing namespace, used to validate BTT metadata.
@@ -876,6 +882,12 @@ write_layout(struct btt *bttp, int lane, int write)
 	ASSERT(bttp->nfree);
 
 	/*
+	 * If a new layout is being written, generate the BTT's UUID.
+	 */
+	if (write)
+		uuid_generate(bttp->uuid);
+
+	/*
 	 * The number of arenas is the number of full arena of
 	 * size BTT_MAX_ARENA that fit into rawsize and then, if
 	 * the remainder is at least BTT_MIN_SIZE in size, then
@@ -1031,6 +1043,7 @@ write_layout(struct btt *bttp, int lane, int write)
 		struct btt_info info;
 		memset(&info, '\0', sizeof (info));
 		memcpy(info.sig, Sig, BTTINFO_SIG_LEN);
+		memcpy(info.uuid, bttp->uuid, BTTINFO_UUID_LEN);
 		memcpy(info.parent_uuid, bttp->parent_uuid, BTTINFO_UUID_LEN);
 		info.major = htole16(BTTINFO_MAJOR_VERSION);
 		info.minor = htole16(BTTINFO_MINOR_VERSION);

--- a/src/libpmemblk/btt_layout.h
+++ b/src/libpmemblk/btt_layout.h
@@ -44,6 +44,7 @@
 
 struct btt_info {
 	char sig[BTTINFO_SIG_LEN];	/* must be "BTT_ARENA_INFO\0\0" */
+	uint8_t uuid[BTTINFO_UUID_LEN];	/* BTT UUID */
 	uint8_t parent_uuid[BTTINFO_UUID_LEN];	/* UUID of container */
 	uint32_t flags;			/* see flag bits below */
 	uint16_t major;			/* major version */
@@ -65,7 +66,7 @@ struct btt_info {
 	uint64_t flogoff;		/* offset to area flog */
 	uint64_t infooff;		/* offset to backup info block */
 
-	char unused[3984];		/* must be zero */
+	char unused[3968];		/* must be zero */
 
 	uint64_t checksum;		/* Fletcher64 of all fields */
 };


### PR DESCRIPTION
Update the BTT info block to contain the BTT uuid field
and appropriate padding as defined by the NVDIMM Namespace
Specification at http://pmem.io/documents.