### PR TITLE
obj: change order of arguments in pmemobj_list_*()

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -327,18 +327,18 @@ struct name {\
 	PMEMmutex lock;\
 }
 
-int pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
-	void *head, int before, PMEMoid oid);
+int pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid dest, int before, PMEMoid oid);
 
-int pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
-	void *head, int before, size_t size, int type_num);
+int pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid dest, int before, size_t size, int type_num);
 
-int pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, PMEMoid oid,
-	void *head, int free);
+int pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid oid, int free);
 
 int pmemobj_list_move(PMEMobjpool *pop, size_t pe_old_offset,
-	size_t pe_new_offset, PMEMoid dest, void *head_old,
-	void *head_new, int before, PMEMoid oid);
+	size_t pe_new_offset, void *head_old, void *head_new,
+	PMEMoid dest, int before, PMEMoid oid);
 
 #define	POBJ_LIST_FIRST(head)	((head)->pe_first)
 #define	POBJ_LIST_LAST(head, field)	(D_RO((head)->pe_first)->field.pe_prev)
@@ -359,77 +359,77 @@ for (OID_ASSIGN_TYPED((var), POBJ_LIST_LAST((head), field));\
 #define	POBJ_LIST_INSERT_HEAD(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	POBJ_LIST_FIRST((head)).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), POBJ_LIST_FIRST((head)).oid,\
 	1 /* before */, (elm).oid);
 
 #define	POBJ_LIST_INSERT_TAIL(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	POBJ_LIST_LAST((head), field).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), POBJ_LIST_LAST((head), field).oid,\
 	0 /* after */, (elm).oid);
 
 #define	POBJ_LIST_INSERT_AFTER(pop, head, listelm, elm, field)\
 pmemobj_list_insert((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	(listelm).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), (listelm).oid,\
 	0 /* after */, (elm).oid);
 
 #define	POBJ_LIST_INSERT_BEFORE(pop, head, listelm, elm, field)\
 pmemobj_list_insert((pop), offsetof(typeof (*D_RO((elm))),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	(listelm).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), (listelm).oid,\
 	1 /* before */, (elm).oid);
 
 #define	POBJ_LIST_INSERT_NEW_HEAD(pop, head, type_num, field)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*((head)->pe_first._type)), field),\
-	POBJ_LIST_FIRST((head)).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), POBJ_LIST_FIRST((head)).oid,\
 	1 /* before */,	sizeof (*(POBJ_LIST_FIRST(head)._type)), type_num);
 
 #define	POBJ_LIST_INSERT_NEW_TAIL(pop, head, type_num, field)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*((head)->pe_first._type)), field),\
-	POBJ_LIST_LAST((head), field).oid, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), POBJ_LIST_LAST((head), field).oid,\
 	0 /* after */, sizeof (*(POBJ_LIST_FIRST(head)._type)), type_num);
 
 #define	POBJ_LIST_INSERT_NEW_AFTER(pop, head, listelm, type_num, field)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*((head)->pe_first._type)), field),\
-	(listelm).oid, &POBJ_LIST_FIRST((head)), 0 /* after */,\
+	&POBJ_LIST_FIRST((head)), (listelm).oid, 0 /* after */,\
 	sizeof (*(POBJ_LIST_FIRST(head)._type)), type_num);
 
 #define	POBJ_LIST_INSERT_NEW_BEFORE(pop, head, listelm, type_num, field)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	(listelm).oid, 1 /* before */, &POBJ_LIST_FIRST((head)),\
+	&POBJ_LIST_FIRST((head)), (listelm).oid, 1 /* before */,\
 	sizeof (*(POBJ_LIST_FIRST(head)._type)), type_num);
 
 #define	POBJ_LIST_REMOVE(pop, head, elm, field)\
 pmemobj_list_remove((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field), (elm).oid,\
-	&POBJ_LIST_FIRST((head)), 0 /* no free */);
+	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	&POBJ_LIST_FIRST((head)), (elm).oid, 0 /* no free */);
 
 #define	POBJ_LIST_REMOVE_FREE(pop, head, elm, field)\
 pmemobj_list_remove((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field), (elm).oid,\
-	&POBJ_LIST_FIRST((head)), 1 /* free */);
+	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	&POBJ_LIST_FIRST((head)), (elm).oid, 1 /* free */);
 
 #define	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, head, head_new, elm, field, field_new)\
 pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	POBJ_LIST_FIRST((head)).oid,\
 	&POBJ_LIST_FIRST((head)),\
 	&POBJ_LIST_FIRST((head_new)),\
+	POBJ_LIST_FIRST((head)).oid,\
 	1 /* before */, (elm).oid);
 
 #define	POBJ_LIST_MOVE_ELEMENT_TAIL(pop, head, head_new, elm, field, field_new)\
 pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	POBJ_LIST_LAST((head)).oid,\
 	&POBJ_LIST_FIRST((head)),\
 	&POBJ_LIST_FIRST((head_new)),\
+	POBJ_LIST_LAST((head)).oid,\
 	0 /* after */, (elm).oid);
 
 #define	POBJ_LIST_MOVE_ELEMENT_AFTER(pop,\
@@ -437,9 +437,9 @@ pmemobj_list_move((pop),\
 pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	(listelm).oid,\
 	&POBJ_LIST_FIRST((head)),\
 	&POBJ_LIST_FIRST((head_new)),\
+	(listelm).oid,\
 	0 /* after */, (elm).oid);
 
 #define	POBJ_LIST_MOVE_ELEMENT_BEFORE(pop,\
@@ -447,9 +447,9 @@ pmemobj_list_move((pop),\
 pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	(listelm).oid,\
 	&POBJ_LIST_FIRST((head)),\
 	&POBJ_LIST_FIRST((head_new)),\
+	(listelm).oid,\
 	1 /* before */, (elm).oid);
 
 /*

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -744,7 +744,7 @@ pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
 }
 
 /*
- * pmemobj_list_insert -- adds new object to a list
+ * pmemobj_list_insert_new -- adds new object to a list
  */
 int
 pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
@@ -756,7 +756,7 @@ pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
 }
 
 /*
- * pmemobj_list_insert -- removes object from a list
+ * pmemobj_list_remove -- removes object from a list
  */
 int
 pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, PMEMoid oid,
@@ -768,7 +768,7 @@ pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, PMEMoid oid,
 }
 
 /*
- * pmemobj_list_insert -- moves object between lists
+ * pmemobj_list_move -- moves object between lists
  */
 int
 pmemobj_list_move(PMEMobjpool *pop, size_t pe_old_offset,

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -735,8 +735,8 @@ pmemobj_next(PMEMoid oid)
  * pmemobj_list_insert -- adds object to a list
  */
 int
-pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
-	void *head, int before, PMEMoid oid)
+pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid dest, int before, PMEMoid oid)
 {
 	/* XXX */
 
@@ -747,8 +747,8 @@ pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
  * pmemobj_list_insert_new -- adds new object to a list
  */
 int
-pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
-	void *head, int before, size_t size, int type_num)
+pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid dest, int before, size_t size, int type_num)
 {
 	/* XXX */
 
@@ -759,8 +759,8 @@ pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, PMEMoid dest,
  * pmemobj_list_remove -- removes object from a list
  */
 int
-pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, PMEMoid oid,
-	void *head, int free)
+pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, void *head,
+	PMEMoid oid, int free)
 {
 	/* XXX */
 
@@ -772,8 +772,8 @@ pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, PMEMoid oid,
  */
 int
 pmemobj_list_move(PMEMobjpool *pop, size_t pe_old_offset,
-	size_t pe_new_offset, PMEMoid dest, void *head_old,
-	void *head_new, int before, PMEMoid oid)
+	size_t pe_new_offset, void *head_old, void *head_new,
+	PMEMoid dest, int before, PMEMoid oid)
 {
 	/* XXX */
 


### PR DESCRIPTION
"head" should be before "dest" - it is more natural.
The new order matches the order of arguments in API
of atomic lists.