### PR TITLE
pmemobj: initial synchronization implementation

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -130,12 +130,12 @@ typedef union padded_pmemcond {
 	} pmemcond;
 } PMEMcond;
 
-int pmemobj_mutex_zero(PMEMmutex *mutexp);
+void pmemobj_mutex_zero(PMEMobjpool *pop, PMEMmutex *mutexp);
 int pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp);
 int pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp);
 int pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp);
 
-int pmemobj_rwlock_zero(PMEMrwlock *rwlockp);
+void pmemobj_rwlock_zero(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_timedrdlock(PMEMobjpool *pop,
@@ -148,7 +148,7 @@ int pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 
-int pmemobj_cond_zero(PMEMcond *condp);
+void pmemobj_cond_zero(PMEMobjpool *pop, PMEMcond *condp);
 int pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp);
 int pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp);
 int pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -217,7 +217,9 @@ pmemobj_map_common(int fd, const char *layout, size_t poolsize, int rdonly,
 	}
 
 	/* run_id is made unique by incrementing the previous value */
-	pop->run_id++;
+	pop->run_id += 2;
+	if (pop->run_id == 0)
+		pop->run_id += 2;
 	pmem_msync(&pop->run_id, sizeof (pop->run_id));
 
 	/*
@@ -367,6 +369,11 @@ pmemobj_check(const char *path, const char *layout)
 
 	int consistent = 1;
 
+	if (pop->run_id % 2) {
+		LOG(1, "invalid run_id %ju", pop->run_id);
+		consistent = 0;
+	}
+
 	if ((errno = heap_check(pop)) != 0) {
 		LOG(1, "!heap_check");
 		consistent = 0;
@@ -387,179 +394,7 @@ pmemobj_check(const char *path, const char *layout)
 	return consistent;
 }
 
-/*
- * pmemobj_mutex_zero --
- */
-int
-pmemobj_mutex_zero(PMEMmutex *mutexp)
-{
-	/* XXX */
-	return 0;
-}
 
-/*
- * pmemobj_mutex_lock --
- */
-int
-pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_mutex_trylock --
- */
-int
-pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_mutex_unlock --
- */
-int
-pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_zero --
- */
-int
-pmemobj_rwlock_zero(PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_rdlock --
- */
-int
-pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_wrlock --
- */
-int
-pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_timedrdlock --
- */
-int
-pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
-	const struct timespec *restrict abs_timeout)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_timedwrlock --
- */
-int
-pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
-	const struct timespec *restrict abs_timeout)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_tryrdlock --
- */
-int
-pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_trywrlock --
- */
-int
-pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_rwlock_unlock --
- */
-int
-pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_cond_zero --
- */
-int
-pmemobj_cond_zero(PMEMcond *condp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_cond_broadcast --
- */
-int
-pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_cond_signal --
- */
-int
-pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_cond_timedwait --
- */
-int
-pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,
-	PMEMmutex *restrict mutexp, const struct timespec *restrict abstime)
-{
-	/* XXX */
-	return 0;
-}
-
-/*
- * pmemobj_cond_wait --
- */
-int
-pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
-	PMEMmutex *restrict mutexp)
-{
-	/* XXX */
-	return 0;
-}
 
 /*
  * pmemobj_off_by_uuid_lo -- (internal) returns offset of pool

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * sync.c -- persistent memory resident synchronization primitives
+ */
+
+#include <pthread.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "libpmem.h"
+#include "libpmemobj.h"
+#include "util.h"
+#include "obj.h"
+#include "out.h"
+
+#define	GET_MUTEX(pop, mutexp)\
+get_lock((pop)->run_id,\
+	&(mutexp)->pmemmutex.runid,\
+	&(mutexp)->pmemmutex.mutex,\
+	(void *)pthread_mutex_init)
+
+#define	GET_RWLOCK(pop, rwlockp)\
+get_lock((pop)->run_id,\
+	&(rwlockp)->pmemrwlock.runid,\
+	&(rwlockp)->pmemrwlock.rwlock,\
+	(void *)pthread_rwlock_init)
+
+
+#define	GET_COND(pop, condp)\
+get_lock((pop)->run_id,\
+	&(condp)->pmemcond.runid,\
+	&(condp)->pmemcond.cond,\
+	(void *)pthread_cond_init)
+
+/*
+ * get_lock -- (internal) atomically initialize and return a lock
+ */
+static void *
+get_lock(uint64_t pop_runid, uint64_t *runid, void *lock,
+				int (*init_lock)(void *lock, void *arg))
+{
+	LOG(15, "pop_runid %ju runid %ju lock %p init_lock %p", pop_runid,
+		*runid, lock, init_lock);
+
+	uint64_t tmp_runid;
+	while ((tmp_runid = *runid) != pop_runid) {
+		if ((tmp_runid != (pop_runid - 1)) &&
+			__sync_bool_compare_and_swap(runid,
+						tmp_runid, (pop_runid - 1))) {
+			if (init_lock(lock, NULL)) {
+				LOG(1, "error initializing lock");
+				__sync_fetch_and_and(runid, 0);
+				return NULL;
+			}
+
+			if (__sync_bool_compare_and_swap(
+					runid, (pop_runid - 1),
+					pop_runid) == 0) {
+				LOG(1, "error setting lock runid");
+				return NULL;
+			}
+		}
+	}
+	return lock;
+}
+
+/*
+ * pmemobj_mutex_zero -- zero-initialize a pmem resident mutex
+ *
+ * This function is not MT safe.
+ */
+void
+pmemobj_mutex_zero(PMEMobjpool *pop, PMEMmutex *mutexp)
+{
+	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	mutexp->pmemmutex.runid = 0;
+	pop->persist(&mutexp->pmemmutex.runid,
+				sizeof (&mutexp->pmemmutex.runid));
+}
+
+/*
+ * pmemobj_mutex_lock -- lock a pmem resident mutex
+ *
+ * Atomically initializes and locks a PMEMmutex, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp)
+{
+	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexp);
+	if (mutex == NULL)
+		return EINVAL;
+
+	return pthread_mutex_lock(mutex);
+}
+
+/*
+ * pmemobj_mutex_trylock -- trylock a pmem resident mutex
+ *
+ * Atomically initializes and trylocks a PMEMmutex, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp)
+{
+	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexp);
+	if (mutex == NULL)
+		return EINVAL;
+
+	return pthread_mutex_trylock(mutex);
+}
+
+/*
+ * pmemobj_mutex_unlock -- unlock a pmem resident mutex
+ */
+int
+pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp)
+{
+	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	/* XXX potential perf improvement - move GET to debug version */
+	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexp);
+	if (mutex == NULL)
+		return EINVAL;
+
+	return pthread_mutex_unlock(mutex);
+}
+
+/*
+ * pmemobj_rwlock_zero -- zero-initialize a pmem resident rwlock
+ *
+ * This function is not MT safe.
+ */
+void
+pmemobj_rwlock_zero(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	rwlockp->pmemrwlock.runid = 0;
+	pop->persist(&rwlockp->pmemrwlock.runid,
+				sizeof (&rwlockp->pmemrwlock.runid));
+}
+
+/*
+ * pmemobj_rwlock_rdlock -- rdlock a pmem resident mutex
+ *
+ * Atomically initializes and rdlocks a PMEMrwlock, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_rdlock(rwlock);
+}
+
+/*
+ * pmemobj_rwlock_wrlock -- wrlock a pmem resident mutex
+ *
+ * Atomically initializes and wrlocks a PMEMrwlock, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_wrlock(rwlock);
+}
+
+/*
+ * pmemobj_rwlock_timedrdlock -- timedrdlock a pmem resident mutex
+ *
+ * Atomically initializes and timedrdlocks a PMEMrwlock, otherwise behaves as
+ * its POSIX counterpart.
+ */
+int
+pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
+			const struct timespec *restrict abs_timeout)
+{
+	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
+		abs_timeout->tv_sec, abs_timeout->tv_nsec);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_timedrdlock(rwlock, abs_timeout);
+}
+
+/*
+ * pmemobj_rwlock_timedwrlock -- timedwrlock a pmem resident mutex
+ *
+ * Atomically initializes and timedwrlocks a PMEMrwlock, otherwise behaves as
+ * its POSIX counterpart.
+ */
+int
+pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
+			const struct timespec *restrict abs_timeout)
+{
+	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
+		abs_timeout->tv_sec, abs_timeout->tv_nsec);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_timedwrlock(rwlock, abs_timeout);
+}
+
+/*
+ * pmemobj_rwlock_tryrdlock -- tryrdlock a pmem resident mutex
+ *
+ * Atomically initializes and tryrdlocks a PMEMrwlock, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_tryrdlock(rwlock);
+}
+
+/*
+ * pmemobj_rwlock_trywrlock -- trywrlock a pmem resident mutex
+ *
+ * Atomically initializes and trywrlocks a PMEMrwlock, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_trywrlock(rwlock);
+}
+
+/*
+ * pmemobj_rwlock_unlock -- unlock a pmem resident rwlock
+ */
+int
+pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
+{
+	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	/* XXX potential perf improvement - move GET to debug version */
+	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockp);
+	if (rwlock == NULL)
+		return EINVAL;
+
+	return pthread_rwlock_unlock(rwlock);
+}
+
+/*
+ * pmemobj_cond_zero -- zero-initialize a pmem resident condition variable
+ *
+ * This function is not MT safe.
+ */
+void
+pmemobj_cond_zero(PMEMobjpool *pop, PMEMcond *condp)
+{
+	LOG(3, "pop %p cond %p", pop, condp);
+
+	condp->pmemcond.runid = 0;
+	pop->persist(&condp->pmemcond.runid, sizeof (&condp->pmemcond.runid));
+}
+
+/*
+ * pmemobj_cond_broadcast -- broadcast a pmem resident condition variable
+ *
+ * Atomically initializes and broadcast a PMEMcond, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp)
+{
+	LOG(3, "pop %p cond %p", pop, condp);
+
+	pthread_cond_t *cond = GET_COND(pop, condp);
+	if (cond == NULL)
+		return EINVAL;
+
+	return pthread_cond_broadcast(cond);
+}
+
+/*
+ * pmemobj_cond_signal -- signal a pmem resident condition variable
+ *
+ * Atomically initializes and signal a PMEMcond, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp)
+{
+	LOG(3, "pop %p cond %p", pop, condp);
+
+	pthread_cond_t *cond = GET_COND(pop, condp);
+	if (cond == NULL)
+		return EINVAL;
+
+	return pthread_cond_signal(cond);
+}
+
+/*
+ * pmemobj_cond_timedwait -- timedwait on a pmem resident condition variable
+ *
+ * Atomically initializes and timedwait on a PMEMcond, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,
+			PMEMmutex *restrict mutexp,
+			const struct timespec *restrict abstime)
+{
+	LOG(3, "pop %p cond %p mutex %p abstime sec %ld nsec %ld", pop, condp,
+		mutexp, abstime->tv_sec, abstime->tv_nsec);
+
+	pthread_cond_t *cond = GET_COND(pop, condp);
+	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexp);
+	if ((cond == NULL) || (mutex == NULL))
+		return EINVAL;
+
+	return pthread_cond_timedwait(cond, mutex, abstime);
+}
+
+/*
+ * pmemobj_cond_wait -- wait on a pmem resident condition variable
+ *
+ * Atomically initializes and wait on a PMEMcond, otherwise behaves as its
+ * POSIX counterpart.
+ */
+int
+pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp, PMEMmutex *restrict mutexp)
+{
+	LOG(3, "pop %p cond %p mutex %p", pop, condp, mutexp);
+
+	pthread_cond_t *cond = GET_COND(pop, condp);
+	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexp);
+	if ((cond == NULL) || (mutex == NULL))
+		return EINVAL;
+
+	return pthread_cond_wait(cond, mutex);
+}

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -104,7 +104,8 @@ TEST = blk_nblock\
        obj_redo_log\
        obj_basic_integration\
        obj_pmalloc_basic\
-       obj_lane
+       obj_lane\
+       obj_sync
 
 all     : TARGET = all
 clean   : TARGET = clean

--- a/src/test/obj_sync/.gitignore
+++ b/src/test/obj_sync/.gitignore
@@ -1,0 +1,1 @@
+obj_sync

--- a/src/test/obj_sync/Makefile
+++ b/src/test/obj_sync/Makefile
@@ -1,4 +1,5 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +28,23 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/Makefile -- build obj_sync unit test
+#
+vpath %.c ../../libpmemobj
+vpath %.c ../../common
+
+TARGET = obj_sync
+OBJS = obj_sync.o sync.o util.o out.o
+
+out.o: CFLAGS += -DSRCVERSION=\"utversion\"
+
+LIBPMEM=y
 
 include ../Makefile.inc
 
-LIBS += -luuid -pthread -lpmem
+LDFLAGS += $(call extract_funcs, obj_sync.c)
+
+INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_sync/README
+++ b/src/test/obj_sync/README
@@ -1,0 +1,22 @@
+Linux NVM Library
+
+This is src/test/obj_sync/README.
+
+This directory contains a unit test for persistent synchronization mechanisms.
+The types of synchronization primitives tested are: mutexes, rwlocks and
+condition variables.
+
+The obj_sync application takes as command line arguments the primitive type to
+ be tested, the number of threads to be run and the number of times the test
+ will be restarted:
+
+$ obj_sync [mrc] <num_threads> <runs>
+
+Where:
+	m - test mutexes
+	r - test rwlocks
+	c - test condition variables
+
+The tests are performed using valgrind and its following tools:
+	- drd
+	- helgrind

--- a/src/test/obj_sync/TEST0
+++ b/src/test/obj_sync/TEST0
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,25 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST0 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST0
+export UNITTEST_NUM=0
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit ./obj_sync$EXESUFFIX m 50 300
+
+check
+
+pass

--- a/src/test/obj_sync/TEST1
+++ b/src/test/obj_sync/TEST1
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST1 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST1
+export UNITTEST_NUM=1
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
+ ./obj_sync$EXESUFFIX m 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/TEST2
+++ b/src/test/obj_sync/TEST2
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST2 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST2
+export UNITTEST_NUM=2
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --tool=helgrind ./obj_sync$EXESUFFIX m 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/TEST3
+++ b/src/test/obj_sync/TEST3
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST3 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST3
+export UNITTEST_NUM=3
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
+ ./obj_sync$EXESUFFIX r 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST4 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST4
+export UNITTEST_NUM=4
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --tool=helgrind ./obj_sync$EXESUFFIX r 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/TEST5
+++ b/src/test/obj_sync/TEST5
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST5 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST5
+export UNITTEST_NUM=5
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
+ ./obj_sync$EXESUFFIX c 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2015, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemobj/Makefile -- Makefile for libpmemobj
 #
 
-LIBRARY_NAME = pmemobj
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c sync.c $(COMMON)/util.c\
-    $(COMMON)/out.c
+#
+# src/test/obj_sync/TEST6 -- unit test for PMEM-resident locks
+#
+export UNITTEST_NAME=obj_sync/TEST6
+export UNITTEST_NUM=6
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -luuid -pthread -lpmem
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --tool=helgrind ./obj_sync$EXESUFFIX c 10 50
+
+check
+
+pass

--- a/src/test/obj_sync/err0.log.match
+++ b/src/test/obj_sync/err0.log.match
@@ -1,0 +1,1 @@
+obj_sync/TEST0: pmemobj_mutex_lock

--- a/src/test/obj_sync/err1.log.match
+++ b/src/test/obj_sync/err1.log.match
@@ -1,0 +1,1 @@
+obj_sync/TEST1: pmemobj_mutex_lock

--- a/src/test/obj_sync/err2.log.match
+++ b/src/test/obj_sync/err2.log.match
@@ -1,0 +1,1 @@
+obj_sync/TEST2: pmemobj_mutex_lock

--- a/src/test/obj_sync/err3.log.match
+++ b/src/test/obj_sync/err3.log.match
@@ -1,0 +1,1 @@
+obj_sync/TEST3: pmemobj_rwlock_wrlock

--- a/src/test/obj_sync/err4.log.match
+++ b/src/test/obj_sync/err4.log.match
@@ -1,0 +1,1 @@
+obj_sync/TEST4: pmemobj_rwlock_wrlock

--- a/src/test/obj_sync/err5.log.match
+++ b/src/test/obj_sync/err5.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST5: pmemobj_mutex_lock
+$(OPT)obj_sync/TEST5: pmemobj_cond_signal
+$(OPT)obj_sync/TEST5: pmemobj_cond_wait

--- a/src/test/obj_sync/err6.log.match
+++ b/src/test/obj_sync/err6.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST6: pmemobj_mutex_lock
+$(OPT)obj_sync/TEST6: pmemobj_cond_signal
+$(OPT)obj_sync/TEST6: pmemobj_cond_wait

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_sync.c -- unit test for PMEM-resident locks
+ */
+#include <pthread.h>
+
+#include "unittest.h"
+#include "libpmemobj.h"
+#include "util.h"
+#include "obj.h"
+
+#define	DATA_SIZE 128
+
+#define	FATAL_USAGE() FATAL("usage: obj_sync [mrc] <num_threads> <runs>\n")
+
+/* posix thread worker typedef */
+typedef void *(*worker)(void *);
+
+/* the mock pmemobj pool */
+static PMEMobjpool Mock_pop;
+
+/* the tested object containing persistent synchronization primitives */
+static struct mock_obj {
+	PMEMmutex mutex;
+	PMEMcond cond;
+	PMEMrwlock rwlock;
+	int check_data;
+	uint8_t data[DATA_SIZE];
+} *Test_obj;
+
+FUNC_MOCK(pthread_mutex_init, int,
+		pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+	FUNC_MOCK_RUN_RET_DEFAULT_REAL(pthread_mutex_init, mutex, attr)
+	FUNC_MOCK_RUN(1) {
+		return -1;
+	}
+} FUNC_MOCK_END
+
+FUNC_MOCK(pthread_rwlock_init, int,
+		pthread_rwlock_t *rwlock, const pthread_rwlockattr_t *attr)
+{
+	FUNC_MOCK_RUN_RET_DEFAULT_REAL(pthread_rwlock_init, rwlock, attr)
+	FUNC_MOCK_RUN(1) {
+		return -1;
+	}
+} FUNC_MOCK_END
+
+FUNC_MOCK(pthread_cond_init, int,
+		pthread_cond_t *cond, const pthread_condattr_t  *attr)
+{
+	FUNC_MOCK_RUN_RET_DEFAULT_REAL(pthread_cond_init, cond, attr)
+	FUNC_MOCK_RUN(1) {
+		return -1;
+	}
+} FUNC_MOCK_END
+
+/*
+ * mock_open_pool -- (internal) simulate pool opening
+ */
+static void
+mock_open_pool(PMEMobjpool *pop)
+{
+	__sync_fetch_and_add(&pop->run_id, 2);
+}
+
+/*
+ * mutex_write_worker -- (internal) write data with mutex
+ */
+static void *
+mutex_write_worker(void *arg)
+{
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
+		ERR("pmemobj_mutex_lock");
+		return NULL;
+	}
+	memset(Test_obj->data, (int)(uintptr_t)arg, DATA_SIZE);
+	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
+		ERR("pmemobj_mutex_unlock");
+
+	return NULL;
+}
+
+/*
+ * mutex_check_worker -- (internal) check consistency with mutex
+ */
+static void *
+mutex_check_worker(void *arg)
+{
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
+		ERR("pmemobj_mutex_lock");
+		return NULL;
+	}
+	uint8_t val = Test_obj->data[0];
+	for (int i = 1; i < DATA_SIZE; i++)
+		ASSERTeq(Test_obj->data[i], val);
+	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
+		ERR("pmemobj_mutex_unlock");
+
+	return NULL;
+}
+
+/*
+ * cond_write_worker -- (internal) write data with cond variable
+ */
+static void *
+cond_write_worker(void *arg)
+{
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
+		ERR("pmemobj_mutex_lock");
+		return NULL;
+	}
+	memset(Test_obj->data, (int)(uintptr_t)arg, DATA_SIZE);
+	Test_obj->check_data = 1;
+	if (pmemobj_cond_signal(&Mock_pop, &Test_obj->cond))
+		ERR("pmemobj_cond_signal");
+	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
+		ERR("pmemobj_mutex_unlock");
+
+	return NULL;
+}
+
+/*
+ * cond_check_worker -- (internal) check consistency with cond variable
+ */
+static void *
+cond_check_worker(void *arg)
+{
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
+		ERR("pmemobj_mutex_lock");
+		return NULL;
+	}
+	while (Test_obj->check_data != 1) {
+		if (pmemobj_cond_wait(&Mock_pop, &Test_obj->cond,
+					&Test_obj->mutex))
+			ERR("pmemobj_cond_wait");
+	}
+	uint8_t val = Test_obj->data[0];
+	for (int i = 1; i < DATA_SIZE; i++)
+		ASSERTeq(Test_obj->data[i], val);
+	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
+		ERR("pmemobj_mutex_unlock");
+
+	return NULL;
+}
+
+/*
+ * rwlock_write_worker -- (internal) write data with rwlock
+ */
+static void *
+rwlock_write_worker(void *arg)
+{
+	if (pmemobj_rwlock_wrlock(&Mock_pop, &Test_obj->rwlock)) {
+		ERR("pmemobj_rwlock_wrlock");
+		return NULL;
+	}
+	memset(Test_obj->data, (int)(uintptr_t)arg, DATA_SIZE);
+	if (pmemobj_rwlock_unlock(&Mock_pop, &Test_obj->rwlock))
+		ERR("pmemobj_rwlock_unlock");
+
+	return NULL;
+}
+
+/*
+ * rwlock_check_worker -- (internal) check consistency with rwlock
+ */
+static void *
+rwlock_check_worker(void *arg)
+{
+	if (pmemobj_rwlock_rdlock(&Mock_pop, &Test_obj->rwlock)) {
+		ERR("pmemobj_rwlock_rdlock");
+		return NULL;
+	}
+	uint8_t val = Test_obj->data[0];
+	for (int i = 1; i < DATA_SIZE; i++)
+		ASSERTeq(Test_obj->data[i], val);
+	if (pmemobj_rwlock_unlock(&Mock_pop, &Test_obj->rwlock))
+		ERR("pmemobj_rwlock_unlock");
+
+	return NULL;
+}
+
+/*
+ * cleanup -- (internal) clean up after each run
+ */
+static void
+cleanup(char test_type)
+{
+	switch (test_type) {
+		case 'm':
+			pthread_mutex_destroy(&Test_obj->mutex.pmemmutex.mutex);
+			break;
+		case 'r':
+			pthread_rwlock_destroy(&Test_obj->rwlock.pmemrwlock
+					.rwlock);
+			break;
+		case 'c':
+			pthread_mutex_destroy(&Test_obj->mutex.pmemmutex.mutex);
+			pthread_cond_destroy(&Test_obj->cond.pmemcond.cond);
+			break;
+		default:
+			FATAL_USAGE();
+	}
+
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_sync");
+
+	if (argc < 4)
+		FATAL_USAGE();
+
+	worker writer;
+	worker checker;
+
+	char test_type = argv[1][0];
+	switch (test_type) {
+		case 'm':
+			writer = mutex_write_worker;
+			checker = mutex_check_worker;
+			break;
+		case 'r':
+			writer = rwlock_write_worker;
+			checker = rwlock_check_worker;
+			break;
+		case 'c':
+			writer = cond_write_worker;
+			checker = cond_check_worker;
+			break;
+		default:
+			FATAL_USAGE();
+
+	}
+
+	unsigned long num_threads = strtoul(argv[2], NULL, 10);
+	if (num_threads > 200)
+		FATAL("Do not use more than 200 threads.\n");
+
+	unsigned long runs = strtoul(argv[3], NULL, 10);
+
+	pthread_t *write_threads = MALLOC(num_threads * sizeof (pthread_t));
+	pthread_t *check_threads = MALLOC(num_threads * sizeof (pthread_t));
+
+	/* first pool open */
+	mock_open_pool(&Mock_pop);
+	Mock_pop.persist = (persist_fn)pmem_msync;
+	Test_obj = MALLOC(sizeof (struct mock_obj));
+	/* zero-initialize the test object */
+	pmemobj_mutex_zero(&Mock_pop, &Test_obj->mutex);
+	pmemobj_cond_zero(&Mock_pop, &Test_obj->cond);
+	pmemobj_rwlock_zero(&Mock_pop, &Test_obj->rwlock);
+	Test_obj->check_data = 0;
+	memset(&Test_obj->data, 0, DATA_SIZE);
+
+	for (int run = 0; run < runs; run++) {
+		for (int i = 0; i < num_threads; i++) {
+			PTHREAD_CREATE(&write_threads[i], NULL, writer,
+				(void *)(uintptr_t)i);
+			PTHREAD_CREATE(&check_threads[i], NULL, checker,
+				NULL);
+		}
+		for (int i = 0; i < num_threads; i++) {
+			PTHREAD_JOIN(write_threads[i], NULL);
+			PTHREAD_JOIN(check_threads[i], NULL);
+		}
+		/* up the run_id counter and cleanup */
+		mock_open_pool(&Mock_pop);
+		cleanup(test_type);
+	}
+
+	FREE(check_threads);
+	FREE(write_threads);
+	FREE(Test_obj);
+	DONE(NULL);
+}

--- a/src/test/obj_sync/out0.log.match
+++ b/src/test/obj_sync/out0.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST0: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST0: Done

--- a/src/test/obj_sync/out1.log.match
+++ b/src/test/obj_sync/out1.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST1: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST1: Done

--- a/src/test/obj_sync/out2.log.match
+++ b/src/test/obj_sync/out2.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST2: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST2: Done

--- a/src/test/obj_sync/out3.log.match
+++ b/src/test/obj_sync/out3.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST3: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST3: Done

--- a/src/test/obj_sync/out4.log.match
+++ b/src/test/obj_sync/out4.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST4: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST4: Done

--- a/src/test/obj_sync/out5.log.match
+++ b/src/test/obj_sync/out5.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST5: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST5: Done

--- a/src/test/obj_sync/out6.log.match
+++ b/src/test/obj_sync/out6.log.match
@@ -1,0 +1,3 @@
+obj_sync/TEST6: START: obj_sync
+ ./obj_sync$(nW) $(nW) $(N) $(N)
+obj_sync/TEST6: Done

--- a/src/test/obj_sync/valgrind1.log.match
+++ b/src/test/obj_sync/valgrind1.log.match
@@ -1,0 +1,9 @@
+==$(N)== drd, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_sync/valgrind2.log.match
+++ b/src/test/obj_sync/valgrind2.log.match
@@ -1,0 +1,11 @@
+==$(N)== Helgrind, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+$(OPT)==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --history-level=approx or =none to gain increased speed, at
+$(OPT)==$(N)== the cost of reduced accuracy of conflicting-access information
+$(OPT)==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_sync/valgrind3.log.match
+++ b/src/test/obj_sync/valgrind3.log.match
@@ -1,0 +1,9 @@
+==$(N)== drd, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_sync/valgrind4.log.match
+++ b/src/test/obj_sync/valgrind4.log.match
@@ -1,0 +1,11 @@
+==$(N)== Helgrind, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+$(OPT)==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --history-level=approx or =none to gain increased speed, at
+$(OPT)==$(N)== the cost of reduced accuracy of conflicting-access information
+$(OPT)==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_sync/valgrind5.log.match
+++ b/src/test/obj_sync/valgrind5.log.match
@@ -1,0 +1,9 @@
+==$(N)== drd, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_sync/valgrind6.log.match
+++ b/src/test/obj_sync/valgrind6.log.match
@@ -1,0 +1,11 @@
+==$(N)== Helgrind, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+$(OPT)==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --history-level=approx or =none to gain increased speed, at
+$(OPT)==$(N)== the cost of reduced accuracy of conflicting-access information
+$(OPT)==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -478,11 +478,17 @@ int ut_pthread_join(const char *file, int line, const char *func,
 #define	_FUNC_REAL(name)\
 	__real_##name
 
+#define	RCOUNTER(name)\
+	_rcounter##name
+
+#define	FUNC_MOCK_RCOUNTER_SET(name, val)\
+    RCOUNTER(name) = val;
+
 #define	FUNC_MOCK(name, ret_type, ...)\
 	_FUNC_REAL_DECL(name, ret_type, ##__VA_ARGS__);\
+	static int RCOUNTER(name);\
 	ret_type __wrap_##name(__VA_ARGS__) {\
-		static int __rcounter = 0;\
-		switch (__rcounter++) {
+		switch (__sync_fetch_and_add(&RCOUNTER(name), 1)) {
 
 #define	FUNC_MOCK_END\
 	}}
@@ -497,7 +503,7 @@ int ut_pthread_join(const char *file, int line, const char *func,
 	case run: return (ret);
 
 #define	FUNC_MOCK_RUN_RET_DEFAULT_REAL(name, ...)\
-	default: return _FUNC_REAL(name)(##__VA_ARGS__);
+	default: return _FUNC_REAL(name)(__VA_ARGS__);
 
 #define	FUNC_MOCK_RUN_RET_DEFAULT(ret)\
 	default: return (ret);


### PR DESCRIPTION
Add persistent memory resident synchronization primitives. They are self
initializing after each pool open, there is no need to reinitialize them
by hand.