### PR TITLE
pmemobj: fix condition variable test

### DIFF
--- a/src/test/obj_sync/TEST3
+++ b/src/test/obj_sync/TEST3
@@ -51,4 +51,11 @@ expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
 
 check
 
+ERR_FILE=err3.log
+if [ `wc -l < $ERR_FILE` -ne 1 ];
+    then
+        echo "error: $CHECK_LOG_FILE match failed"
+        exit 1
+fi
+
 pass

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -51,4 +51,11 @@ expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
 
 check
 
+ERR_FILE=err4.log
+if [ `wc -l < $ERR_FILE` -ne 1 ];
+    then
+        echo "error: $CHECK_LOG_FILE match failed"
+        exit 1
+fi
+
 pass

--- a/src/test/obj_sync/TEST5
+++ b/src/test/obj_sync/TEST5
@@ -51,4 +51,11 @@ expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
 
 check
 
+ERR_FILE=err5.log
+if [ `wc -l < $ERR_FILE` -ne 1 ];
+    then
+        echo "error: $CHECK_LOG_FILE match failed"
+        exit 1
+fi
+
 pass

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -51,4 +51,11 @@ expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
 
 check
 
+ERR_FILE=err6.log
+if [ `wc -l < $ERR_FILE` -ne 1 ];
+    then
+        echo "error: $CHECK_LOG_FILE match failed"
+        exit 1
+fi
+
 pass

--- a/src/test/obj_sync/err5.log.match
+++ b/src/test/obj_sync/err5.log.match
@@ -1,3 +1,2 @@
-obj_sync/TEST5: pmemobj_mutex_lock
 $(OPT)obj_sync/TEST5: pmemobj_cond_signal
 $(OPT)obj_sync/TEST5: pmemobj_cond_wait

--- a/src/test/obj_sync/err6.log.match
+++ b/src/test/obj_sync/err6.log.match
@@ -1,3 +1,2 @@
-obj_sync/TEST6: pmemobj_mutex_lock
 $(OPT)obj_sync/TEST6: pmemobj_cond_signal
 $(OPT)obj_sync/TEST6: pmemobj_cond_wait

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -137,16 +137,14 @@ mutex_check_worker(void *arg)
 static void *
 cond_write_worker(void *arg)
 {
-	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
-		ERR("pmemobj_mutex_lock");
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex))
 		return NULL;
-	}
+
 	memset(Test_obj->data, (int)(uintptr_t)arg, DATA_SIZE);
 	Test_obj->check_data = 1;
 	if (pmemobj_cond_signal(&Mock_pop, &Test_obj->cond))
 		ERR("pmemobj_cond_signal");
-	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
-		ERR("pmemobj_mutex_unlock");
+	pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex);
 
 	return NULL;
 }
@@ -157,10 +155,9 @@ cond_write_worker(void *arg)
 static void *
 cond_check_worker(void *arg)
 {
-	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex)) {
-		ERR("pmemobj_mutex_lock");
+	if (pmemobj_mutex_lock(&Mock_pop, &Test_obj->mutex))
 		return NULL;
-	}
+
 	while (Test_obj->check_data != 1) {
 		if (pmemobj_cond_wait(&Mock_pop, &Test_obj->cond,
 					&Test_obj->mutex))
@@ -169,8 +166,7 @@ cond_check_worker(void *arg)
 	uint8_t val = Test_obj->data[0];
 	for (int i = 1; i < DATA_SIZE; i++)
 		ASSERTeq(Test_obj->data[i], val);
-	if (pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex))
-		ERR("pmemobj_mutex_unlock");
+	pmemobj_mutex_unlock(&Mock_pop, &Test_obj->mutex);
 
 	return NULL;
 }


### PR DESCRIPTION
The test could fail randomly on a race condition on file output. Add
line count check to verify if mock failed to initialize each
synchronization primitive.