### PR TITLE
obj: handle OID_NULL in 3 pmemobj functions

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -790,7 +790,12 @@ pmemobj_free(PMEMoid oid)
 {
 	LOG(3, "oid.off 0x%016jx", oid.off);
 
+	if (oid.off == 0)
+		return;
+
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
+
+	ASSERTne(pop, NULL);
 
 	struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, oid);
 
@@ -810,7 +815,12 @@ pmemobj_alloc_usable_size(PMEMoid oid)
 {
 	LOG(3, "oid.off 0x%016jx", oid.off);
 
+	if (oid.off == 0)
+		return 0;
+
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
+
+	ASSERTne(pop, NULL);
 
 	return (pmalloc_usable_size(pop, oid.off - OBJ_OOB_OFFSET) -
 								OBJ_OOB_OFFSET);
@@ -944,7 +954,12 @@ pmemobj_next(PMEMoid oid)
 {
 	LOG(3, "oid.off 0x%016jx", oid.off);
 
+	if (oid.off == 0)
+		return OID_NULL;
+
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
+
+	ASSERTne(pop, NULL);
 
 	struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, oid);
 	uint16_t user_type = pobj->user_type;

--- a/src/test/obj_store/README
+++ b/src/test/obj_store/README
@@ -26,3 +26,7 @@ The following characters and operations can be used:
 		- POBJ_LIST_INSERT_NEW_HEAD
 		- POBJ_LIST_FOREACH
 		- POBJ_LIST_FOREACH_REVERSE
+	n - test handling OID_NULL by 3 pmemobj functions:
+		- pmemobj_free
+		- pmemobj_alloc_usable_size
+		- pmemobj_next

--- a/src/test/obj_store/TEST4
+++ b/src/test/obj_store/TEST4
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_store/TEST4 -- unit test for handling OID_NULL
+#                             by 3 pmemobj functions:
+#	- pmemobj_free
+#	- pmemobj_alloc_usable_size
+#	- pmemobj_next
+#
+export UNITTEST_NAME=obj_store/TEST4
+export UNITTEST_NUM=4
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+rm -f $DIR/testfile1
+
+expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 n
+
+rm -f $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_store/obj_store.c
+++ b/src/test/obj_store/obj_store.c
@@ -35,7 +35,7 @@
  *
  * usage: obj_store file operation:...
  *
- * operations are 'r' or 'a' or 'f' or 'u'
+ * operations are 'r' or 'a' or 'f' or 'u' or 'n'
  *
  */
 #include <stddef.h>
@@ -386,18 +386,29 @@ test_user_lists(const char *path)
 	pmemobj_close(pop);
 }
 
+void
+test_null_oids(void)
+{
+	pmemobj_free(OID_NULL);
+
+	ASSERTeq(pmemobj_alloc_usable_size(OID_NULL), 0);
+
+	PMEMoid next = pmemobj_next(OID_NULL);
+	ASSERT(next.off == 0 && next.pool_uuid_lo == 0);
+}
+
 int
 main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_store");
 
 	if (argc != 3)
-		FATAL("usage: %s file-name op:r|a|f|u", argv[0]);
+		FATAL("usage: %s file-name op:r|a|f|u|n", argv[0]);
 
 	const char *path = argv[1];
 
-	if (strchr("rafu", argv[2][0]) == NULL || argv[2][1] != '\0')
-		FATAL("op must be r or a or f or u");
+	if (strchr("rafun", argv[2][0]) == NULL || argv[2][1] != '\0')
+		FATAL("op must be r or a or f or u or n");
 
 	switch (argv[2][0]) {
 		case 'r':
@@ -411,6 +422,9 @@ main(int argc, char *argv[])
 			break;
 		case 'u':
 			test_user_lists(path);
+			break;
+		case 'n':
+			test_null_oids();
 			break;
 	}
 

--- a/src/test/obj_store/out4.log.match
+++ b/src/test/obj_store/out4.log.match
@@ -1,0 +1,3 @@
+obj_store/TEST4: START: obj_store
+ ./obj_store$(nW) $(nW)/testfile1 n
+obj_store/TEST4: Done


### PR DESCRIPTION
Handle OID_NULL in 3 pmemobj functions:
- pmemobj_free, pmemobj_alloc_usable_size and pmemobj_next