### PR TITLE
pmemobj: fix atomic lock acquire

### DIFF
--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -72,7 +72,7 @@ get_lock((pop)->run_id,\
  * get_lock -- (internal) atomically initialize and return a lock
  */
 static void *
-get_lock(uint64_t pop_runid, uint64_t *runid, void *lock,
+get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 	int (*init_lock)(void *lock, void *arg), size_t size)
 {
 	LOG(15, "pop_runid %ju runid %ju lock %p init_lock %p", pop_runid,

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -607,9 +607,6 @@ static void
 release_and_free_tx_locks(struct lane_tx_runtime *lane)
 {
 	LOG(15, NULL);
-	/* no locks taken */
-	if (SLIST_EMPTY(&lane->tx_locks))
-		return;
 
 	while (!SLIST_EMPTY(&lane->tx_locks)) {
 		struct tx_lock_data *tx_lock = SLIST_FIRST(&lane->tx_locks);


### PR DESCRIPTION
Due to possible compiler optimizations, the atomic lock acquisition
could be significantly altered, causing a multi-threaded program to
deadlock.