### PR TITLE
common: add check valgrind version 3.10

### DIFF
--- a/src/test/obj_sync/TEST1
+++ b/src/test/obj_sync/TEST1
@@ -42,7 +42,7 @@ export UNITTEST_NUM=1
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_sync/TEST2
+++ b/src/test/obj_sync/TEST2
@@ -42,7 +42,7 @@ export UNITTEST_NUM=2
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_sync/TEST3
+++ b/src/test/obj_sync/TEST3
@@ -42,7 +42,7 @@ export UNITTEST_NUM=3
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -42,7 +42,7 @@ export UNITTEST_NUM=4
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_sync/TEST5
+++ b/src/test/obj_sync/TEST5
@@ -42,7 +42,7 @@ export UNITTEST_NUM=5
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -42,7 +42,7 @@ export UNITTEST_NUM=6
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_tx_locks/TEST1
+++ b/src/test/obj_tx_locks/TEST1
@@ -47,7 +47,7 @@ unset PMEMOBJ_LOG_FILE
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/obj_tx_locks/TEST2
+++ b/src/test/obj_tx_locks/TEST2
@@ -47,7 +47,7 @@ unset PMEMOBJ_LOG_FILE
 
 require_fs_type local
 require_build_type debug nondebug
-require_valgrind
+require_valgrind_dev_3_10
 
 setup
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -315,6 +315,25 @@ function require_valgrind_dev_3_8() {
 }
 
 #
+# require_valgrind_dev_3_10 -- continue script execution only if
+#	version 3.10 (or later) of valgrind-devel package is installed
+#
+function require_valgrind_dev_3_10() {
+	require_valgrind
+	echo "
+        #include <valgrind/valgrind.h>
+        #if defined (__VALGRIND_MAJOR__) && defined (__VALGRIND_MINOR__)
+        #if (__VALGRIND_MAJOR__ > 3) || \
+             ((__VALGRIND_MAJOR__ == 3) && (__VALGRIND_MINOR__ >= 10))
+        VALGRIND_VERSION_3_10_OR_LATER
+        #endif
+        #endif" | gcc -E - 2>&1 | \
+		grep -q "VALGRIND_VERSION_3_10_OR_LATER" && return
+	echo "$UNITTEST_NAME: SKIP valgrind-devel package (ver 3.10 or later) required"
+	exit 0
+}
+
+#
 # setup -- print message that test setup is commencing
 #
 function setup() {


### PR DESCRIPTION
On some OSes with older versions of valgrind installed, some tests
reported problems with msync not being thread safe. Newer versions of
valgrind do not report this issue - probably a false-positive.