### PR TITLE
obj: fix return value in list_realloc_move function

### DIFF
--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -1655,6 +1655,9 @@ list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 		redo_log_store(pop, redo, redo_index,
 				sec_off_off, obj_offset);
 		redo_index += 1;
+
+		/* return new oid */
+		oid->off = new_obj_doffset;
 	} else {
 		/*
 		 * The following steps may be in consistency with the recovery

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -981,6 +981,9 @@ do_realloc(PMEMobjpool *pop, const char *arg)
 	} else {
 		FATAL_USAGE_REALLOC();
 	}
+	OID_TYPE(struct item) item;
+	OID_ASSIGN(item, oid);
+	OUT("realloc(id = %d)", D_RO(item)->id);
 }
 
 /*
@@ -1017,6 +1020,9 @@ do_realloc_move(PMEMobjpool *pop, const char *arg)
 		&oid)) {
 		FATAL("list_realloc_move(List_oob, List_oob_sec) failed");
 	}
+	OID_TYPE(struct item) item;
+	OID_ASSIGN(item, oid);
+	OUT("realloc_move(id = %d)", D_RO(item)->id);
 }
 
 /*

--- a/src/test/obj_list_realloc/out0.log.match
+++ b/src/test/obj_list_realloc/out0.log.match
@@ -7,6 +7,7 @@ oob list reverse:
 id = 0
 pgrow(id = 0, size = 2) = true
 constructor(id = 0, arg = 1)
+realloc(id = 1)
 oob list:
 id = 1
 oob list reverse:

--- a/src/test/obj_list_realloc/out1.log.match
+++ b/src/test/obj_list_realloc/out1.log.match
@@ -9,6 +9,7 @@ pgrow(id = 0, size = 3) = false
 pmalloc(id = 1)
 constructor(id = 0, arg = 2)
 pfree(id = 0)
+realloc(id = 2)
 oob list:
 id = 2
 oob list reverse:

--- a/src/test/obj_list_realloc/out2.log.match
+++ b/src/test/obj_list_realloc/out2.log.match
@@ -9,6 +9,7 @@ oob list reverse:
 id = 1
 id = 0
 pgrow(id = 0, size = 2) = true
+realloc(id = 2)
 oob list:
 id = 2
 id = 1
@@ -17,6 +18,7 @@ id = 1
 id = 2
 pgrow(id = 1, size = 2) = true
 constructor(id = 1, arg = 3)
+realloc(id = 3)
 oob list:
 id = 2
 id = 3

--- a/src/test/obj_list_realloc/out3.log.match
+++ b/src/test/obj_list_realloc/out3.log.match
@@ -11,6 +11,7 @@ id = 0
 pgrow(id = 0, size = 3) = false
 pmalloc(id = 2)
 pfree(id = 0)
+realloc(id = 4)
 oob list:
 id = 4
 id = 1
@@ -21,6 +22,7 @@ pgrow(id = 1, size = 3) = false
 pmalloc(id = 3)
 constructor(id = 1, arg = 5)
 pfree(id = 1)
+realloc(id = 5)
 oob list:
 id = 4
 id = 5

--- a/src/test/obj_list_realloc/out4.log.match
+++ b/src/test/obj_list_realloc/out4.log.match
@@ -10,6 +10,7 @@ id = 0
 list reverse:
 id = 0
 pgrow(id = 0, size = 2) = true
+realloc(id = 1)
 oob list:
 id = 1
 oob list reverse:

--- a/src/test/obj_list_realloc/out5.log.match
+++ b/src/test/obj_list_realloc/out5.log.match
@@ -12,6 +12,7 @@ id = 0
 pgrow(id = 0, size = 3) = false
 pmalloc(id = 1)
 pfree(id = 0)
+realloc(id = 2)
 oob list:
 id = 2
 oob list reverse:

--- a/src/test/obj_list_realloc/out6.log.match
+++ b/src/test/obj_list_realloc/out6.log.match
@@ -15,6 +15,7 @@ list reverse:
 id = 0
 id = 1
 pgrow(id = 0, size = 2) = true
+realloc(id = 2)
 oob list:
 id = 2
 id = 1
@@ -29,6 +30,7 @@ id = 2
 id = 1
 pgrow(id = 1, size = 2) = true
 constructor(id = 1, arg = 3)
+realloc(id = 3)
 oob list:
 id = 2
 id = 3

--- a/src/test/obj_list_realloc/out7.log.match
+++ b/src/test/obj_list_realloc/out7.log.match
@@ -17,6 +17,7 @@ id = 1
 pgrow(id = 0, size = 3) = false
 pmalloc(id = 2)
 pfree(id = 0)
+realloc(id = 4)
 oob list:
 id = 4
 id = 1
@@ -33,6 +34,7 @@ pgrow(id = 1, size = 3) = false
 pmalloc(id = 3)
 constructor(id = 1, arg = 5)
 pfree(id = 1)
+realloc(id = 5)
 oob list:
 id = 4
 id = 5

--- a/src/test/obj_list_realloc_move/out0.log.match
+++ b/src/test/obj_list_realloc_move/out0.log.match
@@ -19,9 +19,12 @@ list reverse:
 oob list sec:
 oob list sec reverse:
 pgrow(id = 3, size = 2) = true
+realloc_move(id = 10)
 pgrow(id = 1, size = 2) = true
+realloc_move(id = 11)
 pgrow(id = 0, size = 2) = true
 constructor(id = 0, arg = 12)
+realloc_move(id = 12)
 oob list:
 id = 2
 oob list reverse:

--- a/src/test/obj_list_realloc_move/out1.log.match
+++ b/src/test/obj_list_realloc_move/out1.log.match
@@ -30,12 +30,15 @@ pgrow(id = 0, size = 3) = false
 pmalloc(id = 4)
 constructor(id = 0, arg = 10)
 pfree(id = 0)
+realloc_move(id = 10)
 pgrow(id = 3, size = 3) = false
 pmalloc(id = 5)
 pfree(id = 3)
+realloc_move(id = 11)
 pgrow(id = 2, size = 3) = false
 pmalloc(id = 6)
 pfree(id = 2)
+realloc_move(id = 12)
 oob list:
 id = 1
 oob list reverse:

--- a/src/test/obj_list_valgrind/out7.log.match
+++ b/src/test/obj_list_valgrind/out7.log.match
@@ -4,9 +4,12 @@ pmalloc(id = 0)
 pmalloc(id = 1)
 pmalloc(id = 2)
 pgrow(id = 0, size = 2) = true
+realloc(id = 10)
 pgrow(id = 1, size = 2) = true
 constructor(id = 1, arg = 11)
+realloc(id = 11)
 pgrow(id = 2, size = 2) = true
+realloc(id = 12)
 oob list:
 id = 10
 id = 11
@@ -26,13 +29,16 @@ id = 10
 pgrow(id = 10, size = 3) = false
 pmalloc(id = 3)
 pfree(id = 10)
+realloc(id = 20)
 pgrow(id = 11, size = 3) = false
 pmalloc(id = 4)
 constructor(id = 11, arg = 21)
 pfree(id = 11)
+realloc(id = 21)
 pgrow(id = 12, size = 3) = false
 pmalloc(id = 5)
 pfree(id = 12)
+realloc(id = 22)
 oob list:
 id = 20
 id = 21

--- a/src/test/obj_list_valgrind/out8.log.match
+++ b/src/test/obj_list_valgrind/out8.log.match
@@ -29,13 +29,17 @@ oob list sec reverse:
 pgrow(id = 3, size = 3) = false
 pmalloc(id = 4)
 pfree(id = 3)
+realloc_move(id = 10)
 pgrow(id = 1, size = 2) = true
+realloc_move(id = 11)
 pgrow(id = 0, size = 3) = false
 pmalloc(id = 5)
 constructor(id = 0, arg = 12)
 pfree(id = 0)
+realloc_move(id = 12)
 pgrow(id = 2, size = 2) = true
 constructor(id = 2, arg = 13)
+realloc_move(id = 13)
 oob list:
 oob list reverse:
 list:


### PR DESCRIPTION
If the realloc was performed not in place the old PMEMoid was returned.