### PR TITLE
obj: add dummy test to obj_list

### DIFF
--- a/src/test/obj_list/TEST0
+++ b/src/test/obj_list/TEST0
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_list/TEST0 -- unit test for list API
+#
+# Just run the unit test
+#
+export UNITTEST_NAME=obj_list/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+pass

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -1045,6 +1045,7 @@ main(int argc, char *argv[])
 
 	const char *path = argv[1];
 
+	ASSERTeq(OOB_OFF, 48);
 	PMEMobjpool *pop = pmemobj_open(path, NULL);
 	ASSERTne(pop, NULL);
 


### PR DESCRIPTION
Add some simple test to obj_list so it is possible to invoke
./RUNTESTS obj_* which runs all tests for pmemobj.
The dummy tests just opens the pool and checks the oob_header size.