### PR TITLE
obj: remove assert on pool_uuid_lo from list_insert_user

### DIFF
--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -491,7 +491,6 @@ list_insert_user(PMEMobjpool *pop,
 	LOG(15, NULL);
 	if (args->dest.off == 0) {
 		/* inserting the first element on list */
-		ASSERTeq(args->dest.pool_uuid_lo, 0);
 		ASSERTeq(args->head->pe_first.off, 0);
 
 		/* set loop on current element */

--- a/src/test/obj_list_remove/TEST3
+++ b/src/test/obj_list_remove/TEST3
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_list_remove/TEST3 -- unit test for list_remove
+#
+# Add 3 elements to lists, remove them all and add one element to the lists
+#
+export UNITTEST_NAME=obj_list_remove/TEST3
+export UNITTEST_NUM=3
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+rm -f $DIR/testfile
+truncate -s1M $DIR/testfile
+expect_abnormal_exit ../obj_list/obj_list$EXESUFFIX $DIR/testfile\
+	n:1:0 n:1:0 n:1:0 P:1 R:1 P:2 R:2\
+	f:1:0:2 f:1:0:2 f:1:0:2 P:1 R:1 P:2 R:2\
+	n:1:0 P:1 R:1 P:2 R:2
+
+rm -f $DIR/testfile
+
+check
+
+pass

--- a/src/test/obj_list_remove/out3.log.match
+++ b/src/test/obj_list_remove/out3.log.match
@@ -1,0 +1,38 @@
+obj_list_remove/TEST3: START: obj_list
+ ../obj_list/obj_list$(nW) $(nW)testfile n:1:0 n:1:0 n:1:0 P:1 R:1 P:2 R:2 f:1:0:2 f:1:0:2 f:1:0:2 P:1 R:1 P:2 R:2 n:1:0 P:1 R:1 P:2 R:2
+pmalloc(id = 0)
+pmalloc(id = 1)
+pmalloc(id = 2)
+oob list:
+id = 0
+id = 1
+id = 2
+oob list reverse:
+id = 2
+id = 1
+id = 0
+list:
+id = 2
+id = 1
+id = 0
+list reverse:
+id = 0
+id = 1
+id = 2
+pfree(id = 0)
+pfree(id = 1)
+pfree(id = 2)
+oob list:
+oob list reverse:
+list:
+list reverse:
+pmalloc(id = 3)
+oob list:
+id = 3
+oob list reverse:
+id = 3
+list:
+id = 3
+list reverse:
+id = 3
+obj_list_remove/TEST3: Done


### PR DESCRIPTION
The pool_uuid_lo is not cleared when removing from list,
because the the object is OID_NULL if offset is zero. Thus
there cannot be an assert on pool_uuid_lo because it is
not possible to insert element to a list which the last
element was removed from.