### PR TITLE
obj: fix OID_ASSIGN_TYPED macro for C++ compilers

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -178,6 +178,10 @@ union {\
 
 #define	OID_ASSIGN(o, value) ((o).oid = value)
 
+#ifdef __cplusplus
+#define	OID_ASSIGN_TYPED(lhs, rhs)\
+	((lhs).oid = (rhs).oid)
+#else
 #define	OID_ASSIGN_TYPED(lhs, rhs)\
 __builtin_choose_expr(\
 	__builtin_types_compatible_p(\
@@ -185,6 +189,7 @@ __builtin_choose_expr(\
 		typeof((rhs)._type)),\
 	(void) ((lhs).oid = (rhs).oid),\
 	(lhs._type = rhs._type))
+#endif /* __cplusplus */
 
 #define	OID_NULL		((PMEMoid) {0, 0})
 


### PR DESCRIPTION
To provide compile-time error checking the assign typed macro
uses a tricky gnu99 construct that has no direct C++ counterpart so
a simplified macro is used for cpp compilers.