### PR TITLE
obj: use __restrict keyword in sync API

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -141,11 +141,11 @@ void pmemobj_rwlock_zero(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_timedrdlock(PMEMobjpool *pop,
-	PMEMrwlock *restrict rwlockp,
-	const struct timespec *restrict abs_timeout);
+	PMEMrwlock *__restrict rwlockp,
+	const struct timespec *__restrict abs_timeout);
 int pmemobj_rwlock_timedwrlock(PMEMobjpool *pop,
-	PMEMrwlock *restrict rwlockp,
-	const struct timespec *restrict abs_timeout);
+	PMEMrwlock *__restrict rwlockp,
+	const struct timespec *__restrict abs_timeout);
 int pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 int pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
@@ -153,10 +153,11 @@ int pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
 void pmemobj_cond_zero(PMEMobjpool *pop, PMEMcond *condp);
 int pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp);
 int pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp);
-int pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,
-	PMEMmutex *restrict mutexp, const struct timespec *restrict abstime);
+int pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *__restrict condp,
+	PMEMmutex *__restrict mutexp,
+	const struct timespec *__restrict abstime);
 int pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
-	PMEMmutex *restrict mutexp);
+	PMEMmutex *__restrict mutexp);
 
 /*
  * Persistent memory object

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -229,8 +229,8 @@ pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
  * its POSIX counterpart.
  */
 int
-pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
-			const struct timespec *restrict abs_timeout)
+pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
+			const struct timespec *__restrict abs_timeout)
 {
 	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
 		abs_timeout->tv_sec, abs_timeout->tv_nsec);
@@ -249,8 +249,8 @@ pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
  * its POSIX counterpart.
  */
 int
-pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *restrict rwlockp,
-			const struct timespec *restrict abs_timeout)
+pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
+			const struct timespec *__restrict abs_timeout)
 {
 	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
 		abs_timeout->tv_sec, abs_timeout->tv_nsec);
@@ -371,9 +371,9 @@ pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp)
  * POSIX counterpart.
  */
 int
-pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,
-			PMEMmutex *restrict mutexp,
-			const struct timespec *restrict abstime)
+pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *__restrict condp,
+			PMEMmutex *__restrict mutexp,
+			const struct timespec *__restrict abstime)
 {
 	LOG(3, "pop %p cond %p mutex %p abstime sec %ld nsec %ld", pop, condp,
 		mutexp, abstime->tv_sec, abstime->tv_nsec);
@@ -393,7 +393,8 @@ pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *restrict condp,
  * POSIX counterpart.
  */
 int
-pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp, PMEMmutex *restrict mutexp)
+pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
+			PMEMmutex *__restrict mutexp)
 {
 	LOG(3, "pop %p cond %p mutex %p", pop, condp, mutexp);
 


### PR DESCRIPTION
Unlike C99 there's no restrict keyword in C++, but most
compilers have extension to workaround that problem.