### PR TITLE
obj: debug feature for pmemobj_tx_add_range

### DIFF
--- a/src/test/obj_debug/README
+++ b/src/test/obj_debug/README
@@ -24,3 +24,5 @@ The following characters and operations can be used:
 		- pmemobj_list_insert
 		- pmemobj_list_move
 		- pmemobj_list_remove
+	r - tests notice messages for the function:
+		- pmemobj_tx_add_common

--- a/src/test/obj_debug/TEST2
+++ b/src/test/obj_debug/TEST2
@@ -1,0 +1,58 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_debug/TEST2 -- unit test for debug features
+#
+export UNITTEST_NAME=obj_debug/TEST2
+export UNITTEST_NUM=2
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_build_type debug
+
+setup
+
+rm -f $DIR/testfile1
+
+export PMEMOBJ_LOG_LEVEL=4
+expect_normal_exit ./obj_debug$EXESUFFIX $DIR/testfile1 r
+
+rm -f $DIR/testfile1
+
+grep "is already in undo log" ./pmemobj$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
+
+check
+
+pass

--- a/src/test/obj_debug/grep2.log.match
+++ b/src/test/obj_debug/grep2.log.match
@@ -1,0 +1,2 @@
+<libpmemobj>: <4> [tx.c:$(N) pmemobj_tx_add_common] Notice: range: offset = 0x$(X) size = 4 is already in undo log as range: offset = 0x$(X) size = 4
+<libpmemobj>: <4> [tx.c:$(N) pmemobj_tx_add_common] Notice: a part of range: offset = 0x$(X) size = 12 is already in undo log as range: offset = 0x$(X) size = 4

--- a/src/test/obj_debug/out2.log.match
+++ b/src/test/obj_debug/out2.log.match
@@ -1,0 +1,3 @@
+obj_debug/TEST2: START: obj_debug
+ ./obj_debug$(nW) $(nW)/testfile1 r
+obj_debug/TEST2: Done


### PR DESCRIPTION
Log a debug notice message if the currently being added range
had already been added to the undo log earlier.