### PR TITLE
pmemobj: fix util_pool_create hangup

### DIFF
--- a/src/test/util_pool_create/TEST2
+++ b/src/test/util_pool_create/TEST2
@@ -32,50 +32,27 @@
 #
 
 #
-# src/test/util_pool_create/TEST0 -- unit test for util_pool_create()
+# src/test/util_pool_create/TEST2 -- unit test for util_pool_create()
 #
-export UNITTEST_NAME=util_pool_create/TEST0
-export UNITTEST_NUM=0
+export UNITTEST_NAME=util_pool_create/TEST2
+export UNITTEST_NUM=2
 
 # standard unit test setup
 . ../unittest/unittest.sh
 
 require_fs_type local
+require_test_type long
 
 setup
 
 MIN_POOL=0x4000
 
-rm -f $DIR/testfile1
-rm -f $DIR/testfile2
-rm -f $DIR/testfile3
-rm -f $DIR/testlink1
-rm -f $DIR/testlink2
-rm -f $DIR/testlink3
-rm -f $DIR/testlink4
-rm -fr $DIR/testdir1
-
-truncate -s 32K $DIR/testfile1
-mkdir $DIR/testdir1
-ln -s $DIR/testfile0 $DIR/testlink1
-ln -s $DIR/testfile1 $DIR/testlink2
-ln -s $DIR/testdir1 $DIR/testlink3
-ln -s /dev/zero $DIR/testlink4
+rm -f $DIR/testfile
 
 expect_normal_exit ./util_pool_create$EXESUFFIX $MIN_POOL \
-    $MIN_POOL:$DIR/testdir1\
-    $MIN_POOL:/dev/zero\
-    $MIN_POOL:$DIR/testlink1\
-    $MIN_POOL:$DIR/testlink2\
-    $MIN_POOL:$DIR/testlink3\
-    $MIN_POOL:$DIR/testlink4\
-    $MIN_POOL:$DIR/testfile1\
-    0x1000:$DIR/testfile2\
-    $MIN_POOL:$DIR/testfile3
+    0x7FFFFFFFFFFFFFFF:$DIR/testfile
 
-rm -f $DIR/testfile[123]
-rm -f $DIR/testlink[1234]
-rm -fr $DIR/testdir1
+rm -f $DIR/testfile
 
 check
 

--- a/src/test/util_pool_create/out0.log.match
+++ b/src/test/util_pool_create/out0.log.match
@@ -1,5 +1,5 @@
 util_pool_create/TEST0: START: util_pool_create
- ./util_pool_create$(nW) 0x4000 0x4000:$(nW)/testdir1 0x4000:/dev/zero 0x4000:$(nW)/testlink1 0x4000:$(nW)/testlink2 0x4000:$(nW)/testlink3 0x4000:$(nW)/testlink4 0x4000:$(nW)/testfile1 0x1000:$(nW)/testfile2 0x4000:$(nW)/testfile4 0x7FFFFFFFFFFFFFFF:$(nW)/testfile3
+ ./util_pool_create$(nW) 0x4000 0x4000:$(nW)/testdir1 0x4000:/dev/zero 0x4000:$(nW)/testlink1 0x4000:$(nW)/testlink2 0x4000:$(nW)/testlink3 0x4000:$(nW)/testlink4 0x4000:$(nW)/testfile1 0x1000:$(nW)/testfile2 0x4000:$(nW)/testfile3
 $(nW)/testdir1: util_pool_create: File exists
 /dev/zero: util_pool_create: File exists
 $(nW)/testlink1: util_pool_create: File exists
@@ -8,6 +8,5 @@ $(nW)/testlink3: util_pool_create: File exists
 $(nW)/testlink4: util_pool_create: File exists
 $(nW)/testfile1: util_pool_create: File exists
 $(nW)/testfile2: util_pool_create: Invalid argument
-$(nW)/testfile4: created
-$(nW)/testfile3: util_pool_create: $(*)
+$(nW)/testfile3: created
 util_pool_create/TEST0: Done

--- a/src/test/util_pool_create/out2.log.match
+++ b/src/test/util_pool_create/out2.log.match
@@ -1,0 +1,4 @@
+util_pool_create/TEST2: START: util_pool_create
+ ./util_pool_create$(nW) 0x4000 0x7FFFFFFFFFFFFFFF:$(nW)/testfile
+$(nW)/testfile: util_pool_create: $(*)
+util_pool_create/TEST2: Done


### PR DESCRIPTION
On some systems, the creation of a very large file might hang the test
execution. This happens on travis which in consequence fails builds.