### PR TITLE
obj: type safety macros and API changes

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -37,14 +37,14 @@
 .\" or
 .\"	groff -man -Tascii libpmemobj.3
 .\"
-.TH libpmemobj 3 "pmemobj API version 0.4.4" "NVM Library"
+.TH libpmemobj 3 "pmemobj API version 0.4.5" "NVM Library"
 .SH NAME
 libpmemobj \- persistent memory transactional object store
 .SH SYNOPSIS
 .nf
 .B #include <libpmemobj.h>
 .sp
-.B cc ... -lpmemobj -lpmem
+.B cc -std=gnu99 ... -lpmemobj -lpmem
 .sp
 .B Most commonly used functions:
 .sp
@@ -80,7 +80,7 @@ libpmemobj \- persistent memory transactional object store
 .BI "int pmemobj_rwlock_timedwrlock(PMEMobjpool *" pop ,
 .BI "    PMEMrwlock *restrict " rwlockp ,
 .BI "    const struct timespec *restrict " abstime );
-.BI "int pmemobj_rwlock_tryrdlock(PMEMobjpool *" pop ", PMEMrwlock * "rwlockp );
+.BI "int pmemobj_rwlock_tryrdlock(PMEMobjpool *" pop ", PMEMrwlock *"rwlockp );
 .BI "int pmemobj_rwlock_trywrlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
 .BI "int pmemobj_rwlock_unlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
 .sp
@@ -92,49 +92,87 @@ libpmemobj \- persistent memory transactional object store
 .BI "int pmemobj_cond_wait(PMEMobjpool *" pop ", PMEMcond *" condp ,
 .BI "    PMEMmutex *restrict " mutexp );
 .sp
+.B Persistent object identifier:
+.sp
+.BI "OID_IS_NULL(PMEMoid " oid )
+.BI "OID_EQUALS(PMEMoid " lhs ", PMEMoid "  rhs )
+.sp
+.B Type-safety:
+.sp
+.BI "TOID(" TYPE )
+.BI "TOID_DECLARE(" TYPE ", unsigned int " type_num )
+.BI "TOID_DECLARE_ROOT(" ROOT_TYPE )
+.sp
+.BI "TOID_TYPE_NUM(" TYPE )
+.BI "TOID_TYPE_NUM_OF(TOID " oid ")
+.BI "TOID_VALID(TOID " oid ")
+.sp
+.BI "TOID_ASSIGN(TOID " oid ", " VALUE )
+.sp
+.BI "TOID_IS_NULL(TOID " oid )
+.BI "TOID_EQUALS(TOID " lhs ", TOID " rhs )
+.BI "DIRECT_RW(TOID " oid )
+.BI "DIRECT_RO(TOID " oid )
+.BI "D_RW(TOID " oid )
+.BI "D_RO(TOID " oid )
+.sp
+.B Layout declaration:
+.sp
+.BI "POBJ_LAYOUT_BEGIN(" layout )
+.BI "POBJ_LAYOUT_TOID(" layout ", " type )
+.BI "POBJ_LAYOUT_ROOT(" layout ", " root_type )
+.BI "POBJ_LAYOUT_END(" layout )
+.BI "POBJ_LAYOUT_NAME(" layout )
+.BI "POBJ_LAYOUT_TYPES_NUM(" layout )
+.sp
 .B Non-transactional atomic allocations:
 .sp
-.BI "PMEMoid pmemobj_alloc(PMEMobjpool *" pop ", size_t " size ", unsigned int " type_num );
-.BI "PMEMoid pmemobj_alloc_construct(PMEMobjpool *" pop ", size_t " size ", unsigned int " type_num ,
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
-.BI "PMEMoid pmemobj_zalloc(PMEMobjpool *" pop ", size_t " size ", unsigned int " type_num );
-.BI "PMEMoid pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid " oid ", size_t " size ,
+.BI "int pmemobj_alloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ",
+.BI "    unsigned int " type_num ", void (*" constructor ")(void *" ptr ", void *" arg "),
+.BI "    void *" arg );
+.BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ", "
 .BI "    unsigned int " type_num );
-.BI "PMEMoid pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid " oid ", size_t " size ,
+.BI "int pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .BI "    unsigned int " type_num );
-.BI "PMEMoid pmemobj_strdup(PMEMobjpool *" pop ", const char *" s ", unsigned int " type_num );
-.BI "void pmemobj_free(PMEMoid " oid );
+.BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
+.BI "    unsigned int " type_num );
+.BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ", "
+.BI "    unsigned int " type_num );
+.BI "void pmemobj_free(PMEMoid *" oidp );
 .BI "size_t pmemobj_alloc_usable_size(PMEMoid " oid );
 .BI "void *pmemobj_direct(PMEMoid " oid );
+.BI "unsigned int pmemobj_type_num(PMEMoid" oid );
 .sp
-.B Type-safety
-.sp
-.BI "OID_TYPE(" TYPE )
-.sp
-.BI "OID_ASSIGN(OID_TYPE " oid ", " VALUE )
-.BI "OID_ASSIGN_TYPED(OID_TYPE " lhs ", OID_TYPE " rhs )
-.sp
-.BI "OID_IS_NULL(OID_TYPE " oid )
-.BI "OID_EQUALS(OID_TYPE " lhs ", OID_TYPE " rhs )
-.BI "DIRECT_RW(OID_TYPE " oid )
-.BI "DIRECT_RO(OID_TYPE " oid )
-.BI "D_RW(OID_TYPE " oid )
-.BI "D_RO(OID_TYPE " oid )
+.BI "POBJ_NEW(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, "
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
+.BI "POBJ_ALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size ", "
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
+.BI "POBJ_ZNEW(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, "
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
+.BI "POBJ_ZALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size ")
+.BI "POBJ_REALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size )
+.BI "POBJ_ZREALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size )
+.BI "POBJ_FREE(PMEMobjpool *" pop ", TOID(TYPE) *" oidp " )
 .sp
 .B Root object management:
 .sp
 .BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size );
 .BI "size_t pmemobj_root_size(PMEMobjpool *" pop );
 .sp
+.BI "POBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
+.sp
 .B Object containers:
 .sp
 .BI "PMEMoid pmemobj_first(PMEMobjpool *" pop ", unsigned int " type_num );
 .BI "PMEMoid pmemobj_next(PMEMoid " oid );
 .sp
-.BI "PMEMOBJ_FOREACH(PMEMobjpool *" pop ", PMEMoid " varoid ", int " vartype_num );
-.BI "PMEMOBJ_FOREACH_SAFE(PMEMobjpool *" pop ", PMEMoid " varoid ", PMEMoid " nvaroid ", int " vartype_num );
-.BI "PMEMOBJ_FOREACH_TYPE(PMEMobjpool *" pop ", OID_TYPE " var ", unsigned int " type_num );
-.BI "PMEMOBJ_FOREACH_SAFE_TYPE(PMEMobjpool *" pop ", OID_TYPE " var ", OID_TYPE " nvar ", unsigned int " type_num );
+.BI "POBJ_FIRST(PMEMobjpool *" pop ", " TYPE )
+.BI "POBJ_NEXT(TOID " oid )
+.sp
+.BI "PMEMOBJ_FOREACH(PMEMobjpool *" pop ", PMEMoid " varoid ", int " vartype_num )
+.BI "PMEMOBJ_FOREACH_SAFE(PMEMobjpool *" pop ", PMEMoid " varoid ", PMEMoid " nvaroid ", int " vartype_num )
+.BI "PMEMOBJ_FOREACH_TYPE(PMEMobjpool *" pop ", TOID " var )
+.BI "PMEMOBJ_FOREACH_SAFE_TYPE(PMEMobjpool *" pop ", TOID " var ", TOID " nvar )
 .sp
 .B Non-transactional persistent atomic circular doubly-linked list:
 .sp
@@ -155,41 +193,41 @@ libpmemobj \- persistent memory transactional object store
 .BI "POBJ_LIST_FIRST(POBJ_LIST_HEAD *" head )
 .BI "POBJ_LIST_LAST(POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_EMPTY(POBJ_LIST_HEAD *" head )
-.BI "POBJ_LIST_NEXT(OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
-.BI "POBJ_LIST_PREV(OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "POBJ_LIST_NEXT(TOID " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "POBJ_LIST_PREV(TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .sp
-.BI "POBJ_LIST_FOREACH(OID_TYPE " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
-.BI "POBJ_LIST_FOREACH_REVERSE(OID_TYPE " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
+.BI "POBJ_LIST_FOREACH(TOID " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
+.BI "POBJ_LIST_FOREACH_REVERSE(TOID " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
 .sp
 .BI "POBJ_LIST_INSERT_HEAD(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_INSERT_TAIL(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_INSERT_AFTER(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " listelm ", OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " listelm ", TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_INSERT_BEFORE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " listelm ", OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " listelm ", TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_INSERT_NEW_HEAD(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    POBJ_LIST_ENTRY " FIELD ", size_t " size ",
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .BI "POBJ_LIST_INSERT_NEW_TAIL(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    POBJ_LIST_ENTRY " FIELD ", size_t " size ",
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .BI "POBJ_LIST_INSERT_NEW_AFTER(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " listelm ", unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    TOID " listelm ", POBJ_LIST_ENTRY " FIELD ", size_t " size ",
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .BI "POBJ_LIST_INSERT_NEW_BEFORE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " listelm ", unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    TOID " listelm ", POBJ_LIST_ENTRY " FIELD ", size_t " size ",
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .BI "POBJ_LIST_REMOVE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_REMOVE_FREE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD )
+.BI "    TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_MOVE_ELEMENT_HEAD(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    POBJ_LIST_HEAD *" head_new ", OID_TYPE " elm ", POBJ_LIST_ENTRY " FIELD ",
+.BI "    POBJ_LIST_HEAD *" head_new ", TOID " elm ", POBJ_LIST_ENTRY " FIELD ",
 .BI "    POBJ_LIST_ENTRY " field_new )
 .BI "POBJ_LIST_MOVE_ELEMENT_TAIL(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
-.BI "    POBJ_LIST_HEAD *" head_new ", OID_TYPE " elm ",POBJ_LIST_ENTRY " FIELD ",
+.BI "    POBJ_LIST_HEAD *" head_new ", TOID " elm ", POBJ_LIST_ENTRY " FIELD ",
 .BI "    POBJ_LIST_ENTRY " field_new )
 .sp
 .B Transactional object manipulation:
@@ -218,19 +256,21 @@ libpmemobj \- persistent memory transactional object store
 .BI "TX_FINALLY
 .BI "TX_END
 .sp
-.BI "TX_ADD(OID_TYPE " o )
-.BI "TX_ADD_FIELD(OID_TYPE " o ", " FIELD )
+.BI "TX_ADD(TOID " o )
+.BI "TX_ADD_FIELD(TOID " o ", " FIELD )
 .sp
-.BI "TX_ALLOC(" TYPE ", unsigned int " type_num )
-.BI "TX_ZALLOC(" TYPE ", unsigned int " type_num )
-.BI "TX_REALLOC(OID_TYPE " o ", size_t " size ", unsigned int " type_num )
-.BI "TX_ZREALLOC(OID_TYPE " o ", size_t " size ", unsigned int " type_num )
+.BI "TX_NEW(" TYPE )
+.BI "TX_ALLOC(" TYPE ", size_t " size ")
+.BI "TX_ZNEW(" TYPE )
+.BI "TX_ZALLOC(" TYPE ", size_t " size ")
+.BI "TX_REALLOC(TOID " o ", size_t " size )
+.BI "TX_ZREALLOC(TOID " o ", size_t " size )
 .BI "TX_STRDUP(const char *" s ", unsigned int " type_num )
-.BI "TX_FREE(OID_TYPE " o )
+.BI "TX_FREE(TOID " o )
 .sp
-.BI "TX_SET(OID_TYPE " o ", " FIELD ", " VALUE )
-.BI "TX_MEMCPY(OID_TYPE " o ", " FIELD ", const void *" src ", size_t " num )
-.BI "TX_MEMSET(OID_TYPE " o ", " FIELD ", int " c ", size_t " num )
+.BI "TX_SET(TOID " o ", " FIELD ", " VALUE )
+.BI "TX_MEMCPY(TOID " o ", " FIELD ", const void *" src ", size_t " num )
+.BI "TX_MEMSET(TOID " o ", " FIELD ", int " c ", size_t " num )
 .sp
 .B Library API versioning:
 .sp
@@ -270,6 +310,11 @@ builds on this type of memory mapped file.
 .PP
 This library is for applications that need a transactions
 and persistent memory management.
+The
+.BR libpmemobj
+requires a
+.B -std=gnu99
+compilation flag to build properly.
 This library builds on the low-level pmem support provided by
 .BR libpmem ,
 handling the transactional updates, flushing changes to
@@ -940,6 +985,18 @@ section for more details.
 The
 .BR PMEMOBJ_NUM_OID_TYPES
 macro defines the limit of valid type numbers.
+.PP
+The
+.BR OID_IS_NULL
+macro checks if given
+.IR "PMEMoid"
+represents a NULL object.
+.PP
+The
+.BR OID_EQUALS
+macro compares two
+.IR "PMEMoid"
+objects.
 .SH TYPE-SAFETY
 .PP
 Operating on untyped object handles, as well as on direct untyped object
@@ -952,62 +1009,93 @@ For example, a compile-time error is generated when an attempt is made
 to assign a handle to an object of one type to the object handle variable
 of another type of object.
 .PP
-.BI "OID_TYPE(" TYPE )
+.BI "TOID_DECLARE(" TYPE ", unsigned int " type_num)
 .IP
 The
-.B OID_TYPE
+.B TOID_DECLARE
+macro declares a typed OID of user-defined type specified by argument
+.IR TYPE ,
+and with type number specified by argument
+.IR type_num .
+.PP
+.BI "TOID_DECLARE_ROOT(" ROOT_TYPE )
+.IP
+The
+.B TOID_DECLARE_ROOT
+macro declares a typed OID of user-defined type specified by argument
+.IR ROOT_TYPE ,
+and with type number for root object
+.BR POBJ_ROOT_TYPE_NUM .
+.PP
+.BI "TOID(" TYPE )
+.IP
+The
+.B TOID
 macro declares a handle to an object of type specified by argument
 .IR TYPE ,
 where
 .I TYPE
-is the name of a user-defined structure.
+is the name of a user-defined structure. The typed OID must be declared first
+using the
+.BR TOID_DECLARE ,
+.BR TOID_DECLARE_ROOT ,
+.BR POBJ_LAYOUT_TOID
+or
+.BR POBJ_LAYOUT_ROOT
+macros.
 .PP
-.BI "OID_ASSIGN(OID_TYPE " o ", " VALUE )
+.BI "TOID_TYPE_NUM(" TYPE )
 .IP
 The
-.B OID_ASSIGN
+.B TOID_TYPE_NUM
+macro returns a type number of the type specified by argument
+.IR TYPE .
+.PP
+.BI "TOID_TYPE_NUM_OF(TOID " oid ")
+.IP
+The
+.B TOID_TYPE_NUM_OF
+macro returns a type number of the object specified by argument
+.IR oid .
+The type number is read from the typed OID.
+.PP
+.BI "TOID_VALID(TOID " oid ")
+.IP
+The
+.B TOID_VALID
+macro validates whether the type number stored in object's metadata
+is equal to the type number read from typed OID.
+.PP
+.BI "TOID_ASSIGN(TOID " o ", " VALUE )
+.IP
+The
+.B TOID_ASSIGN
 macro assigns an object handle specified by
 .I VALUE
 to the variable
 .IR o .
 .PP
-.BI "OID_ASSIGN_TYPED(OID_TYPE " lhs ", OID_TYPE " rhs )
+.BI "TOID_IS_NULL(TOID " o )
 .IP
 The
-.B OID_ASSIGN_TYPED
-macro assigns an object handle specified by
-.I rhs
-to the object handle variable
-.I lhs
-with the static type checking.
-Both
-.I lhs
-and
-.I rhs
-must be the object handles of the same type.  Otherwise a compile-time error
-is generated.
-.PP
-.BI "OID_IS_NULL(OID_TYPE " o )
-.IP
-The
-.B OID_IS_NULL
+.B TOID_IS_NULL
 macro evaluates to true if the object handle represented by argument
 .I o
 has OID_NULL value.
 .PP
-.BI "OID_EQUALS(OID_TYPE " lhs ", OID_TYPE " rhs )
+.BI "TOID_EQUALS(TOID " lhs ", TOID " rhs )
 .IP
 The
-.B OID_EQUALS
+.B TOID_EQUALS
 macro evaluates to true if both
 .I lhs
 and
 .I rhs
 object handles are referencing the same persistent object.
 .PP
-.BI "DIRECT_RW(OID_TYPE " oid )
+.BI "DIRECT_RW(TOID " oid )
 .sp
-.BI "D_RW(OID_TYPE " oid )
+.BI "D_RW(TOID " oid )
 .IP
 The
 .BR DIRECT_RW ()
@@ -1018,9 +1106,9 @@ represented by
 .IR oid .
 If OID_NULL is passed as an argument, the macro evaluates to NULL.
 .PP
-.BI "DIRECT_RO(OID_TYPE " oid )
+.BI "DIRECT_RO(TOID " oid )
 .sp
-.BI "D_RO(OID_TYPE " oid )
+.BI "D_RO(TOID " oid )
 .IP
 The
 .BR DIRECT_RO ()
@@ -1030,6 +1118,99 @@ return a typed read-only (const) pointer (TYPE *) to an object
 represented by
 .IR oid .
 If OID_NULL is passed as an argument, the macro evaluates to NULL.
+.SH LAYOUT DECLARATION
+.PP
+The
+.I libpmemobj
+defines a set of macros for convenient declaration of pool's layout.
+The declaration of layout consist of declaration of number of used types.
+The declared types will be assigned consecutive type numbers. Declared
+types may be used in conjunction with type safety macros.
+Once created the layout declaration shall not be changed unless the new types
+are added at the end of the existing layout declaration. Modifying any of existing declaration
+may lead to changes in type numbers of declared types which in consequence may cause
+data corruption.
+.PP
+.BI "POBJ_LAYOUT_BEGIN(" LAYOUT )
+.IP
+The
+.B POBJ_LAYOUT_BEGIN
+macro indicates a begin of declaration of layout. The
+.I LAYOUT
+argument is a name of layout. This argument must be passed to all macros related
+to the declaration of layout.
+.PP
+.BI "POBJ_LAYOUT_TOID(" LAYOUT ", " TYPE )
+.IP
+The
+.B POBJ_LAYOUT_TOID
+macro declares a typed OID for type passed as
+.I TYPE
+argument inside the declaration of layout. All types declared
+using this macro are assigned with consecutive type numbers. This macro must be used between
+the
+.B POBJ_LAYOUT_BEGIN
+and
+.B POBJ_LAYOUT_END
+macros, with the same name passed as
+.I LAYOUT
+argument.
+.PP
+.BI "POBJ_LAYOUT_ROOT(" LAYOUT ", " ROOT_TYPE )
+.IP
+The
+.B POBJ_LAYOUT_ROOT
+macro declares a typed OID for type passed as
+.I ROOT_TYPE
+argument inside the declaration of layout. The typed OID will be assigned
+with type number for root object
+.BR POBJ_ROOT_TYPE_NUM .
+.PP
+.BI "POBJ_LAYOUT_END(" LAYOUT )
+.IP
+The
+.B POBJ_LAYOUT_END
+macro ends the declaration of layout.
+.PP
+.BI "POBJ_LAYOUT_NAME(" LAYOUT )
+.IP
+The
+.B POBJ_LAYOUT_NAME
+macro returns the name of layout as a NULL-terminated string.
+.PP
+.BI "POBJ_LAYOUT_TYPES_NUM(" LAYOUT )
+.IP
+The
+.B POBJ_LAYOUT_TYPES_NUM
+macro returns number of types declared using the
+.B POBH_LAYOUT_TOID
+macro within the layout declaration.
+.PP
+This is an example of layout declaration:
+.IP
+.nf
+POBJ_LAYOUT_BEGIN(mylayout);
+POBJ_LAYOUT_ROOT(mylayout, struct root);
+POBJ_LAYOUT_TOID(mylayout, struct node);
+POBJ_LAYOUT_TOID(mylayout, struct foo);
+POBJ_LAYOUT_END(mylayout);
+
+struct root {
+	TOID(struct node) node;
+};
+
+struct node {
+	TOID(struct node) next;
+	TOID(struct foo) foo;
+};
+.fi
+.PP
+The name of layout and the number of declared types can be retrieved using the following code:
+.IP
+.nf
+const char *layout_name = POBJ_LAYOUT_NAME(mylayout);
+int num_of_types = POBJ_LAYOUT_TYPES_NUM(mylayout);
+.fi
 .SH OBJECT CONTAINERS
 .PP
 All the objects in the persistent memory pool are organized by their
@@ -1059,6 +1240,13 @@ If the value of
 argument exceeds the limit, an OID_NULL is returned and errno is
 set appropriately.
 .PP
+.BI "POBJ_FIRST(PMEMobjpool *" pop ", " TYPE )
+.IP
+The
+.B POBJ_FIRST
+macro returns the first object from the collection specified by the name of type
+.IR TYPE .
+.PP
 .BI "PMEMoid pmemobj_next(PMEMoid " oid );
 .IP
 The
@@ -1070,6 +1258,19 @@ If an object referenced by
 .I oid
 is the last object in the collection, or if the OID_NULL is passed as
 an argument, function returns OID_NULL.
+.PP
+.BI "POBJ_NEXT(TOID " oid )
+.IP
+The
+.B POBJ_NEXT
+macro returns the next object from the same collection as the object
+referenced by
+.IR oid .
+This macro works the same way as
+.B pmemobj_next()
+function with the difference that it takes typed OID instead of
+.B PMEMoid
+as an argument.
 .PP
 The following two macros provide more convenient way to iterate through
 the internal collections, performing a specific operation on each object.
@@ -1088,12 +1289,12 @@ and its type number to
 .I vartype_num
 variable.
 .PP
-.BI "PMEMOBJ_FOREACH_TYPE(PMEMobjpool *" pop ", OID_TYPE " var ", unsigned int " type_num )
+.BI "PMEMOBJ_FOREACH_TYPE(PMEMobjpool *" pop ", OID_TYPE " var )
 .IP
 .BR PMEMOBJ_FOREACH_TYPE ()
-macro allows to perform a specific operation on each allocated object
-of the type specified by
-.I type_num
+macro allows to perform a specific operation on each allocated object of the
+same type as object passed as
+.I var
 argument, stored in the persistent memory pool pointed by
 .IR pop .
 It traverses the internal collection of all the objects of the specified type,
@@ -1161,6 +1362,17 @@ is larger than the maximum allocation size supported for given pool,
 or if there is not enough free space in the pool to satisfy the reallocation
 of the root object.  In such case, OID_NULL is returned.
 .PP
+.BI "PMEMOBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
+.IP
+The
+.B PMEMOBJ_ROOT
+macro works the same way as the
+.BR pmemobj_root ()
+function except it returns a typed OID of type
+.I TYPE
+instead of
+.BR PMEMoid .
+.PP
 .BI "size_t pmemobj_root_size(PMEMobjpool *" pop );
 .IP
 The
@@ -1188,70 +1400,28 @@ will not be rolled-back if the transaction is aborted or interrupted.
 .PP
 The allocations are always aligned to the cache-line boundary.
 .PP
-.BI "PMEMoid pmemobj_alloc(PMEMobjpool *" pop ", size_t " size ", unsigned int " type_num );
-.IP
-The
-.BR pmemobj_alloc ()
-function allocates a new object of given
-.I size
-from the persistent memory heap associated with memory pool
-.IR pop .
-The memory is
-.I not
-initialized.
-The allocated object is added to the internal container associated with given
-.IR type_num .
-The
-.I size
-can be any non-zero value, however due to internal padding and object metadata,
-the actual size of the allocation will differ from the requested one by at least
-64 bytes.  For this reason, making the allocations of
-a size less than 64 bytes is extremely inefficient and discouraged.
-.IP
-In contrast to POSIX
-.BR malloc (3),
-the
-.BR pmemobj_alloc ()
-always return
-.I OID_NULL
-when called with
-.I size
-equal 0.
-.PP
-.BI "PMEMoid pmemobj_zalloc(PMEMobjpool *" pop ", size_t " size ", unsigned int " type_num );
-.IP
-The
-.BR pmemobj_zalloc ()
-function allocates a new zeroed object from the the persistent memory heap
-associated with memory pool
-.IR pop .
-The
-.I size
-can be any non-zero value, however due to internal padding and object metadata,
-the actual size of the allocation will differ from the requested one by at least
-64 bytes.  For this reason, making the allocations of a size
-less than 64 bytes is extremely inefficient and discouraged.
-If
-.I size
-is 0, then
-.BR pmemobj_zalloc ()
-returns
-.IR OID_NULL .
-The allocated object is added to the internal container associated with given
-.I type_num.
-.PP
-.BI "PMEMoid pmemobj_alloc_construct(PMEMobjpool *" pop ", size_t " size ",
+.BI "int pmemobj_alloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ",
 .br
-.BI "    unsigned int " type_num ,
+.BI "    unsigned int " type_num ", void (*" constructor ")(void *" ptr ", void *" arg "),
 .br
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    void *" arg );
 .IP
 The
-.BR pmemobj_alloc_construct
+.BR pmemobj_alloc
 function allocates a new object from the persistent memory heap
 associated with memory pool
 .IR pop .
-Before returning, it calls the
+The
+.B PMEMoid
+of allocated object is stored in
+.IR oidp .
+If the
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is modified atomically. Before returning, it calls the
 .BR constructor
 function passing the pointer to the newly allocated object in
 .I ptr
@@ -1270,13 +1440,48 @@ less than 64 bytes is extremely inefficient and discouraged.
 If
 .I size
 is 0, then
-.BR pmemobj_alloc_construct ()
+.BR pmemobj_alloc ()
 returns
 .IR OID_NULL .
 The allocated object is added to the internal container associated with given
 .IR type_num .
 .PP
-.BI "void pmemobj_free(PMEMoid " oid );
+.BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ", "
+.br
+.BI "    unsigned int " type_num );
+.IP
+The
+.BR pmemobj_zalloc ()
+function allocates a new zeroed object from the the persistent memory heap
+associated with memory pool
+.IR pop .
+The
+.B PMEMoid
+of allocated object is stored in
+.IR oidp .
+If the
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is modified atomically.
+The
+.I size
+can be any non-zero value, however due to internal padding and object metadata,
+the actual size of the allocation will differ from the requested one by at least
+64 bytes.  For this reason, making the allocations of a size
+less than 64 bytes is extremely inefficient and discouraged.
+If
+.I size
+is 0, then
+.BR pmemobj_zalloc ()
+returns
+.IR OID_NULL .
+The allocated object is added to the internal container associated with given
+.I type_num.
+.PP
+.BI "void pmemobj_free(PMEMoid *" oidp );
 .IP
 The
 .BR pmemobj_free ()
@@ -1285,7 +1490,7 @@ function provides the same semantics as
 but instead of the process heap supplied by the system, it operates on the
 persistent memory heap.
 It frees the memory space represented by
-.IR oid ,
+.IR oidp ,
 which must have been returned by a previous call to
 .BR pmemobj_alloc (),
 .BR pmemobj_alloc_construct (),
@@ -1294,10 +1499,22 @@ which must have been returned by a previous call to
 or
 .BR pmemobj_zrealloc ().
 If
-.I oid
-is OID_NULL, no operation is performed.
+.I oidp
+points to
+.IR OID_NULL ,
+no operation is performed. It sets the
+.I oidp
+to
+.IR OID_NULL
+value after freeing the memory. If the
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is changed atomically.
 .PP
-.BI "PMEMoid pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid " oid ", size_t " size ,
+.BI "int pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
 .BI "    unsigned int " type_num );
 .IP
@@ -1308,7 +1525,7 @@ function provide similar semantics to
 but operates on the persistent memory heap associated with memory pool
 .IR pop .
 It changes the size of the object represented by
-.IR oid ,
+.IR oidp ,
 to
 .I size
 bytes.  The resized object is also added or moved to the internal
@@ -1320,22 +1537,24 @@ If the new size is larger than the old size, the added memory will
 .I not
 be initialized.
 If
-.I oid
-is
+.I oidp
+points to
 .IR OID_NULL ,
 then the call is equivalent to
 .IR "pmemobj_alloc(pop, size, type_num)".
 If
 .I size
 is equal to zero, and
-.I oid
+.I oidp
 is not
 .IR OID_NULL ,
 then the call is equivalent to
 .IR "pmemobj_free(oid)".
 Unless
-.I oid
-is OID_NULL, it must have been returned by an earlier call to
+.I oidp
+is
+.IR OID_NULL ,
+it must have been returned by an earlier call to
 .BR pmemobj_alloc (),
 .BR pmemobj_alloc_construct (),
 .BR pmemobj_zalloc (),
@@ -1345,13 +1564,19 @@ or
 Note that the object handle value may change in result of reallocation.
 If the object was moved, a memory space represented by
 .I oid
-is reclaimed.
+is reclaimed. If
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is changed atomically.
 If
 .BR pmemobj_realloc ()
-is unable to satisfy the allocation request, a OID_NULL is
-returned and errno is set appropriately.
+is unable to satisfy the allocation request, a non-zero value is returned and
+errno is set appropriately.
 .PP
-.BI "PMEMoid pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid " oid ", size_t " size ,
+.BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
 .BI "    unsigned int " type_num );
 .IP
@@ -1367,27 +1592,29 @@ to
 .I size
 bytes.  The resized object is also added or moved to the internal
 container associated with given
-.I type_num .
+.IR type_num .
 The contents will be unchanged in the range from the start of the region
 up to the minimum of the old and new sizes.
 If the new size is larger than the old size, the added memory will be zeroed.
 If
-.I oid
-is
+.I oidp
+points to
 .I OID_NULL,
 then the call is equivalent to
 .IR "pmemobj_zalloc(poop, size, type_num)".
 If
 .I size
 is equal to zero, and
-.I oid
-is not
+.I oidp
+doesn't point to
 .IR OID_NULL ,
 then the call is equivalent to
 .IR "pmemobj_free(pop, oid)".
 Unless
-.I oid
-is OID_NULL, it must have been returned by an earlier call to
+.I oidp
+points to
+.IR OID_NULL ,
+it must have been returned by an earlier call to
 .BR pmemobj_alloc (),
 .BR pmemobj_alloc_construct (),
 .BR pmemobj_zalloc (),
@@ -1396,14 +1623,22 @@ or
 .BR pmemobj_zrealloc ().
 Note that the object handle value may change in result of reallocation.
 If the object was moved, a memory space represented by
-.I oid
-is reclaimed.
+.I oidp
+is reclaimed. If
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is changed atomically.
 If
 .BR pmemobj_zrealloc ()
-is unable to satisfy the allocation request, a OID_NULL is
+is unable to satisfy the allocation request, OID_NULL is
 returned and errno is set appropriately.
 .PP
-.BI "PMEMoid pmemobj_strdup(PMEMobjpool *" pop ", const char *" s ", unsigned int " type_num );
+.BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ", "
+.br
+.BI "    unsigned int " type_num );
 .IP
 The
 .BR pmemobj_strdup ()
@@ -1411,8 +1646,17 @@ function provides the same semantics as
 .BR strdup (3),
 but operates on the persistent memory heap associated with memory pool
 .IR pop .
-It returns a handle to a new object which is a duplicate of the string
+It stores a handle to a new object in
+.I oidp
+which is a duplicate of the string
 .IR s .
+If the
+.I oidp
+points to memory location from the
+.B pmemobj
+heap the
+.I oidp
+is changed atomically.
 The allocated string object is also added to the internal
 container associated with given
 .IR type_num .
@@ -1424,7 +1668,7 @@ on the given memory pool, and can be freed with
 on the same memory pool.
 If
 .BR pmemobj_strdup ()
-is unable to satisfy the allocation request, a OID_NULL is
+is unable to satisfy the allocation request, OID_NULL is
 returned and errno is set appropriately.
 .PP
 .BI "size_t pmemobj_alloc_usable_size(PMEMoid " oid );
@@ -1439,11 +1683,127 @@ It returns the number of usable bytes in the object represented
 by
 .IR oid ,
 a handle to an object allocated by
-.BR pmemobj_malloc ()
+.BR pmemobj_alloc ()
 or a related function.
 If
 .I oid
 is OID_NULL, 0 is returned.
+.PP
+.BI "POBJ_NEW(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, "
+.br
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
+.IP
+The
+.B POBJ_NEW
+macro is a wrapper around the
+.BR pmemobj_alloc ()
+function which takes the type name
+.B TYPE
+and passes the size and type number to the
+.BR pmemobj_alloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_ALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size "
+.br
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
+.IP
+The
+.B POBJ_ALLOC
+macro is a wrapper around the
+.BR pmemobj_alloc ()
+function which takes the type name
+.BR TYPE ,
+the size of allocation
+.IR size
+and passes the type number to the
+.BR pmemobj_alloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_ZNEW(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE )
+.IP
+The
+.B POBJ_ZNEW
+macro is a wrapper around the
+.BR pmemobj_zalloc ()
+function which takes the type name
+.BR TYPE
+and passes the size and type number to
+the
+.BR pmemobj_zalloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_ZALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size ")
+.IP
+The
+.B POBJ_ZALLOC
+macro is a wrapper around the
+.BR pmemobj_zalloc ()
+function which takes the type name
+.BR TYPE ,
+the size of allocation
+.IR size
+and passes the type number to the
+.BR pmemobj_zalloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_REALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size )
+.IP
+The
+.B POBJ_REALLOC
+macro is a wrapper around the
+.BR pmemobj_realloc ()
+function which takes the type name
+.BR TYPE
+and passes the type number to the
+.BR pmemobj_realloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_ZREALLOC(PMEMobjpool *" pop ", TOID(TYPE) *" oidp ", TYPE, size_t " size )
+.IP
+The
+.B POBJ_ZREALLOC
+macro is a wrapper around the
+.BR pmemobj_zrealloc ()
+function which takes the type name
+.BR TYPE
+and passes the type number to the
+.BR pmemobj_zrealloc ()
+function from the typed OID.
+Instead of taking a pointer to
+.B PMEMoid
+it takes a pointer to typed OID of
+.BR TYPE .
+.PP
+.BI "POBJ_FREE(PMEMobjpool *" pop ", TOID(TYPE) *" oidp " )
+.IP
+The
+.B POBJ_FREE
+macro is a wrapper around the
+.BR pmemobj_free ()
+function which takes pointer to typed OID
+.I oidp
+as an argument instead of
+.BR PMEMoid .
 .SH NON-TRANSACTIONAL PERSISTENT ATOMIC LISTS
 .PP
 Besides the internal objects collections described in section
@@ -1855,71 +2215,71 @@ before the element
 .PP
 .BI "POBJ_LIST_INSERT_NEW_HEAD(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
 .br
-.BI "    unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
+.BI "    POBJ_LIST_ENTRY " FIELD ", size_t " size ",
 .br
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .IP
 The macro
 .BR POBJ_LIST_INSERT_NEW_HEAD
-atomically allocates a new object of type
-.I type_num
+atomically allocates a new object of size
+.I size
 and inserts it at the head of the list referenced by
 .IR head .
 The newly allocated object is also added to the internal object
-container associated with
-.IR type_num .
+container associated with a type number which is retrieved from the typed OID of
+the first element on list.
 .PP
 .BI "POBJ_LIST_INSERT_NEW_TAIL(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
 .br
-.BI "    unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
+.BI "    POBJ_LIST_ENTRY " FIELD ", size_t " size ",
 .br
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .IP
 The macro
 .BR POBJ_LIST_INSERT_NEW_TAIL
-atomically allocates a new object of type
-.I type_num
+atomically allocates a new object of size
+.I size
 and inserts it at the tail of the list referenced by
 .IR head .
 The newly allocated object is also added to the internal object
-container associated with
-.IR type_num .
+container associated with with a type number which is retrieved from the typed OID of
+the first element on list.
 .PP
 .BI "POBJ_LIST_INSERT_NEW_AFTER(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
 .br
-.BI "    OID_TYPE " listelm ", unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
+.BI "    TOID " listelm ", POBJ_LIST_ENTRY " FIELD ", size_t " size ",
 .br
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .IP
 The macro
 .BR POBJ_LIST_INSERT_NEW_AFTER
-atomically allocates a new object of type
-.I type_num
+atomically allocates a new object of size
+.I size
 and inserts it into the list referenced by
 .I head
 after the element
 .IR listelm .
 The newly allocated object is also added to the internal object
-container associated with
-.IR type_num .
+container associated with with a type number which is retrieved from the typed OID of
+the first element on list.
 .PP
 .BI "POBJ_LIST_INSERT_NEW_BEFORE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
 .br
-.BI "    OID_TYPE " listelm ", unsigned int " type_num ", POBJ_LIST_ENTRY " FIELD ,
+.BI "    TOID " listelm ", POBJ_LIST_ENTRY " FIELD ", size_t " size ",
 .br
-.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg );
+.BI "    void (*" constructor ")(void *" ptr ", void *" arg "), void *" arg )
 .IP
 The macro
 .BR POBJ_LIST_INSERT_NEW_BEFORE
-atomically allocates a new object of type
-.I type_num
+atomically allocates a new object of size
+.I size
 and inserts it into the list referenced by
 .I head
 before the element
 .IR listelm .
 The newly allocated object is also added to the internal object
-container associated with
-.IR type_num .
+container associated with with a type number which is retrieved from the typed OID of
+the first element on list.
 .PP
 .BI "POBJ_LIST_REMOVE(PMEMobjpool *" pop ", POBJ_LIST_HEAD *" head ",
 .br
@@ -2501,26 +2861,16 @@ bytes of its memory area with the constant byte
 .IR c .
 In case of a failure or abort, the saved value will be restored.
 .PP
-.BI "TX_ALLOC(" TYPE ", unsigned int " type_num )
+.BI "TX_NEW(" TYPE )
 .IP
 The
-.BR TX_ALLOC ()
+.BR TX_NEW ()
 macro transactionally allocates an new object of given
 .I TYPE
-and assigns it a type number
-.IR type_num .
+and assigns it a type number read from the typed OID.
 The allocation size is determined from the size of the
 user-defined structure
 .IR TYPE .
-This macro may only be called from inside the
-.BR OID_ASSIGN
-macro, like in the following example:
-.IP
-.nf
-OID_TYPE(struct mytype) o;
-OID_ASSIGN(o, TX_ALLOC(struct mytype, MYTYPE_NUM));
-.fi
-.IP
 If successful and called during
 .I TX_STAGE_WORK
 it returns a handle to the newly allocated object.  Otherwise, stage
@@ -2528,23 +2878,49 @@ changes to
 .IR TX_STAGE_ONABORT ,
 OID_NULL is returned, and errno is set appropriately.
 .PP
-.BI "TX_ZALLOC(" TYPE ", unsigned int " type_num )
+.BI "TX_ALLOC(" TYPE , size_t " size ")
+.IP
+The
+.BR TX_ALLOC ()
+macro transactionally allocates an new object of given
+.I TYPE
+and assigns it a type number read from the typed OID.
+The allocation size is passed by
+.IR size
+parameter. If successful and called during
+.I TX_STAGE_WORK
+it returns a handle to the newly allocated object.  Otherwise, stage
+changes to
+.IR TX_STAGE_ONABORT ,
+OID_NULL is returned, and errno is set appropriately.
+.PP
+.BI "TX_NEW(" TYPE  )
+.IP
+The
+.BR TX_NEW ()
+macro transactionally allocates a new zeroed object of given
+.I TYPE
+and assigns it a type number read from the typed OID.
+The allocation size is determined from the size of the
+user-defined structure
+.IR TYPE .
+If successful and called during
+.I TX_STAGE_WORK
+it returns a handle to the newly allocated object.  Otherwise, stage
+changes to
+.IR TX_STAGE_ONABORT ,
+OID_NULL is returned, and errno is set appropriately.
+.PP
+.BI "TX_ZALLOC(" TYPE  )
 .IP
 The
 .BR TX_ZALLOC ()
 macro transactionally allocates a new zeroed object of given
 .I TYPE
-and assigns it a type number
-.IR type_num .
-The allocation size is determined from the size of the
-user-defined structure
-.IR TYPE .
-Similarly to
-.BR TX_ALLOC (),
-this macro may only be called from inside the
-.BR OID_ASSIGN
-macro.
-If successful and called during
+and assigns it a type number read from the typed OID.
+The allocation size is passed by
+.IR size
+argument. If successful and called during
 .I TX_STAGE_WORK
 it returns a handle to the newly allocated object.  Otherwise, stage
 changes to
@@ -2558,14 +2934,7 @@ The
 macro transactionally resizes an existing object referenced by a handle
 .I o
 to the given
-.I size
-and changes its type to
-.IR type_num .
-Similarly to
-.BR TX_ALLOC (),
-this macro may only be called from inside the
-.BR OID_ASSIGN
-macro.
+.I size .
 If successful and called during
 .I TX_STAGE_WORK
 it returns a handle to the reallocated object.  Otherwise, stage
@@ -2580,15 +2949,8 @@ The
 macro transactionally resizes an existing object referenced by a handle
 .I o
 to the given
-.I size
-and changes its type to
-.IR type_num .
+.I size .
 If the new size is larger than the old size, the extended new space is zeroed.
-Similarly to
-.BR TX_ALLOC (),
-this macro may only be called from inside the
-.BR OID_ASSIGN
-macro.
 If successful and called during
 .I TX_STAGE_WORK
 it returns a handle to the reallocated object.  Otherwise, stage
@@ -2605,11 +2967,6 @@ string
 .I s
 and assigns it a type
 .IR type_num .
-Similarly to
-.BR TX_ALLOC (),
-this macro may only be called from inside the
-.BR OID_ASSIGN
-macro.
 If successful and called during
 .I TX_STAGE_WORK
 it returns a handle to the newly allocated object.  Otherwise, stage

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -61,12 +61,12 @@ libpmemobj.so {
 		pmemobj_direct;
 		pmemobj_alloc;
 		pmemobj_zalloc;
-		pmemobj_alloc_construct;
 		pmemobj_realloc;
 		pmemobj_zrealloc;
 		pmemobj_strndup;
 		pmemobj_free;
 		pmemobj_alloc_usable_size;
+		pmemobj_type_num;
 		pmemobj_root;
 		pmemobj_root_size;
 		pmemobj_first;

--- a/src/libpmemobj/list.h
+++ b/src/libpmemobj/list.h
@@ -44,22 +44,23 @@ struct list_head {
 	PMEMmutex lock;
 };
 
-PMEMoid list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
+int list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head, PMEMoid dest, int before,
-	size_t size, void (*constructor)(void *ptr, void *arg), void *arg);
+	size_t size, void (*constructor)(void *ptr, void *arg), void *arg,
+	PMEMoid *oidp);
 
 int list_realloc(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head,
 	size_t size, void (*constructor)(void *ptr, void *arg), void *arg,
 	uint64_t field_offset, uint64_t field_value,
-	PMEMoid *oid);
+	PMEMoid *oidp);
 
 int list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 	struct list_head *oob_head_new, size_t pe_offset,
 	struct list_head *head, size_t size,
 	void (*constructor)(void *ptr, void *arg), void *arg,
 	uint64_t field_offset, uint64_t field_value,
-	PMEMoid *oid);
+	PMEMoid *oidp);
 
 int list_insert(PMEMobjpool *pop,
 	size_t pe_offset, struct list_head *head, PMEMoid dest, int before,
@@ -67,7 +68,7 @@ int list_insert(PMEMobjpool *pop,
 
 int list_remove_free(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head,
-	PMEMoid oid);
+	PMEMoid *oidp);
 
 int list_remove(PMEMobjpool *pop,
 	size_t pe_offset, struct list_head *head,

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -60,6 +60,10 @@
 #define	OBJ_PTR_TO_OFF(pop, ptr) ((uintptr_t)(ptr) - (uintptr_t)(pop))
 #define	OBJ_OID_IS_NULL(oid)	((oid).off == 0)
 #define	OBJ_LIST_EMPTY(head)	OBJ_OID_IS_NULL((head)->pe_first)
+#define	OBJ_PTR_IS_VALID(pop, ptr)\
+	(OBJ_PTR_TO_OFF(pop, ptr) >= (pop)->heap_offset &&\
+	OBJ_PTR_TO_OFF(pop, ptr) < (pop)->heap_offset + (pop)->heap_size)
+
 
 #define	OOB_HEADER_FROM_OID(pop, oid)\
 	((struct oob_header *)((uintptr_t)(pop) + (oid).off - OBJ_OOB_OFFSET))

--- a/src/test/obj_basic_integration/TEST0
+++ b/src/test/obj_basic_integration/TEST0
@@ -39,8 +39,10 @@ export UNITTEST_NUM=0
 
 setup
 
+rm -rf $DIR/testfile1
+
 expect_normal_exit\
-    ./obj_basic_integration$EXESUFFIX $DIR/testfile1 2> /dev/null
+    ./obj_basic_integration$EXESUFFIX $DIR/testfile1
 
 rm -rf $DIR/testfile1
 

--- a/src/test/obj_store/obj_store.c
+++ b/src/test/obj_store/obj_store.c
@@ -53,6 +53,10 @@
 #define	ROOT_NAME "root object name"
 #define	ROOT_VALUE 77
 
+TOID_DECLARE_ROOT(struct root);
+TOID_DECLARE(struct tobject, 0);
+TOID_DECLARE(struct root_grown, 1);
+
 PLIST_HEAD(listhead, struct tobject);
 
 struct root {
@@ -67,6 +71,7 @@ struct root_grown {
 	struct listhead lhead;
 	char name2[MAX_ROOT_NAME];
 };
+
 
 struct tobject {
 	uint8_t value;
@@ -87,8 +92,8 @@ void
 test_root_object(const char *path)
 {
 	PMEMobjpool *pop = NULL;
-	OID_TYPE(struct root) root;
-	OID_TYPE(struct root_grown) rootg;
+	TOID(struct root) root;
+	TOID(struct root_grown) rootg;
 
 	/* create a pool */
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
@@ -100,8 +105,8 @@ test_root_object(const char *path)
 	ASSERTeq(pmemobj_root_size(pop), 0);
 
 	/* create root object */
-	OID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
-	ASSERT(OID_IS_NULL(root) == 0);
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 
 	/* fill in root object */
@@ -116,8 +121,8 @@ test_root_object(const char *path)
 
 	/* check size and offset of root object */
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
-	OID_ASSIGN(root, pmemobj_root(pop, 0));
-	ASSERT(OID_IS_NULL(root) == 0);
+	TOID_ASSIGN(root, pmemobj_root(pop, 0));
+	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 
 	/* verify content of root object */
@@ -125,10 +130,10 @@ test_root_object(const char *path)
 	ASSERTeq(D_RO(root)->value, ROOT_VALUE);
 
 	/* resize root object */
-	OID_ASSIGN(rootg, pmemobj_root(pop, sizeof (struct root_grown)));
+	TOID_ASSIGN(rootg, pmemobj_root(pop, sizeof (struct root_grown)));
 
 	/* check offset and size of resized root object */
-	ASSERT(OID_IS_NULL(rootg) == 0);
+	ASSERT(TOID_IS_NULL(rootg) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root_grown));
 
 	/* verify old content of resized root object */
@@ -145,8 +150,8 @@ test_root_object(const char *path)
 		FATAL("!pmemobj_open: %s", path);
 
 	/* check size and offset of resized root object */
-	OID_ASSIGN(rootg, pmemobj_root(pop, 0));
-	ASSERT(OID_IS_NULL(rootg) == 0);
+	TOID_ASSIGN(rootg, pmemobj_root(pop, 0));
+	ASSERT(TOID_IS_NULL(rootg) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root_grown));
 
 	/* verify content of resized root object */
@@ -163,7 +168,7 @@ test_alloc_free(const char *path)
 #define	_N_TEST_TYPES 3 /* number of types to test */
 
 	PMEMobjpool *pop = NULL;
-	OID_TYPE(struct tobject) tobj;
+	TOID(struct tobject) tobj;
 	uint64_t offsets[_N_TEST_TYPES];
 	PMEMoid poid;
 	int type_num;
@@ -182,9 +187,10 @@ test_alloc_free(const char *path)
 
 	/* write to object store */
 	for (type_num = 0; type_num < _N_TEST_TYPES; type_num++) {
-		OID_ASSIGN(tobj, pmemobj_alloc(pop,
-					sizeof (struct tobject), type_num));
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		pmemobj_alloc(pop, &tobj.oid,
+			sizeof (struct tobject),
+			type_num, NULL, NULL);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 
 		/* save offset to check it later */
 		offsets[type_num] = tobj.oid.off;
@@ -200,7 +206,7 @@ test_alloc_free(const char *path)
 
 	/* verify object store */
 	for (type_num = 0; type_num < _N_TEST_TYPES; type_num++) {
-		OID_ASSIGN(tobj, pmemobj_first(pop, type_num));
+		TOID_ASSIGN(tobj, pmemobj_first(pop, type_num));
 		ASSERTeq(tobj.oid.off, offsets[type_num]);
 		ASSERTeq(D_RO(tobj)->value, type_num);
 
@@ -212,7 +218,7 @@ test_alloc_free(const char *path)
 	for (type_num = 0; type_num < _N_TEST_TYPES; type_num++) {
 		poid = pmemobj_first(pop, type_num);
 		ASSERTne(poid.off, 0);
-		pmemobj_free(poid);
+		pmemobj_free(&poid);
 	}
 
 	/* re-open the pool */
@@ -239,7 +245,7 @@ test_FOREACH(const char *path)
 
 	char bitmap[32]; /* bitmap of values of type uint8_t (32 = 256/8) */
 	PMEMobjpool *pop = NULL;
-	OID_TYPE(struct tobject) tobj;
+	TOID(struct tobject) tobj;
 	uint8_t value;
 	int i, type;
 
@@ -254,9 +260,10 @@ test_FOREACH(const char *path)
 	/* write to object store */
 	for (type = 0; type < _MAX_TYPES; type++)
 		for (i = 0; i < _MAX_ELEMENTS; i++) {
-			OID_ASSIGN(tobj, pmemobj_alloc(pop,
-						sizeof (struct tobject), type));
-			ASSERT(OID_IS_NULL(tobj) == 0);
+			pmemobj_alloc(pop, &tobj.oid,
+				sizeof (struct tobject), type, NULL,
+				NULL);
+			ASSERT(TOID_IS_NULL(tobj) == 0);
 			value = _MAX_ELEMENTS * type + i;
 			ASSERT(isclr(bitmap, value));
 			setbit(bitmap, value);
@@ -274,8 +281,8 @@ test_FOREACH(const char *path)
 	PMEMoid varoid;
 	POBJ_FOREACH(pop, varoid, type) {
 		ASSERT(i < _MAX_TYPES * _MAX_ELEMENTS);
-		OID_ASSIGN(tobj, varoid);
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		TOID_ASSIGN(tobj, varoid);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 		ASSERT(isset(bitmap, D_RO(tobj)->value));
 		i++;
 	}
@@ -284,9 +291,9 @@ test_FOREACH(const char *path)
 	/* test POBJ_FOREACH_TYPE */
 	i = 0;
 	for (type = 0; type < _MAX_TYPES; type++) {
-		POBJ_FOREACH_TYPE(pop, tobj, type) {
+		POBJ_FOREACH_TYPE(pop, tobj) {
 			ASSERT(i < (type + 1) * _MAX_ELEMENTS);
-			ASSERT(OID_IS_NULL(tobj) == 0);
+			ASSERT(TOID_IS_NULL(tobj) == 0);
 			ASSERT(isset(bitmap, D_RO(tobj)->value));
 			i++;
 		}
@@ -299,7 +306,7 @@ test_FOREACH(const char *path)
 	i = 0;
 	POBJ_FOREACH_SAFE(pop, varoid, nvaroid, type) {
 		ASSERTne(varoid.off, 0);
-		pmemobj_free(varoid);
+		pmemobj_free(&varoid);
 		i++;
 	}
 	ASSERTeq(i, _MAX_TYPES * _MAX_ELEMENTS);
@@ -313,13 +320,12 @@ test_FOREACH(const char *path)
 void
 test_user_lists(const char *path)
 {
-#define	_USER_TYPE 7
 #define	_N_OBJECTS 5
 
 	char bitmap[32]; /* bitmap of values of type uint8_t (32 = 256/8) */
 	PMEMobjpool *pop = NULL;
-	OID_TYPE(struct root) root;
-	OID_TYPE(struct tobject) tobj;
+	TOID(struct root) root;
+	TOID(struct tobject) tobj;
 	uint8_t value;
 	int i;
 
@@ -332,8 +338,8 @@ test_user_lists(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	/* create root object */
-	OID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
-	ASSERT(OID_IS_NULL(root) == 0);
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 
 	/* fill in root object */
@@ -346,10 +352,11 @@ test_user_lists(const char *path)
 		value = i + 1;
 		ASSERT(isclr(bitmap, value));
 		setbit(bitmap, value);
-		OID_ASSIGN(tobj, POBJ_LIST_INSERT_NEW_HEAD(pop,
-				&D_RW(root)->lhead, _USER_TYPE, next,
+		TOID_ASSIGN(tobj, POBJ_LIST_INSERT_NEW_HEAD(pop,
+				&D_RW(root)->lhead, next,
+				sizeof (struct tobject),
 				tobject_construct, &value));
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 	}
 
 	/* re-open the pool */
@@ -359,24 +366,24 @@ test_user_lists(const char *path)
 
 	/* test POBJ_FOREACH_TYPE */
 	i = 0;
-	POBJ_FOREACH_TYPE(pop, tobj, _USER_TYPE) {
+	POBJ_FOREACH_TYPE(pop, tobj) {
 		ASSERT(i <= _N_OBJECTS);
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 		ASSERT(isset(bitmap, D_RO(tobj)->value));
 		i++;
 	}
 	ASSERTeq(i, _N_OBJECTS);
 
 	/* get root object */
-	OID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
-	ASSERT(OID_IS_NULL(root) == 0);
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 
 	/* test POBJ_LIST_FOREACH_REVERSE */
 	i = 0;
 	POBJ_LIST_FOREACH_REVERSE(tobj, &D_RW(root)->lhead, next) {
 		ASSERT(i <= _N_OBJECTS);
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 		ASSERT(isset(bitmap, D_RO(tobj)->value));
 		i++;
 	}
@@ -386,7 +393,7 @@ test_user_lists(const char *path)
 	i = _N_OBJECTS - 1;
 	POBJ_LIST_FOREACH(tobj, &D_RW(root)->lhead, next) {
 		ASSERT(i <= _N_OBJECTS);
-		ASSERT(OID_IS_NULL(tobj) == 0);
+		ASSERT(TOID_IS_NULL(tobj) == 0);
 		ASSERT(isset(bitmap, D_RO(tobj)->value));
 		i--;
 	}
@@ -398,7 +405,8 @@ test_user_lists(const char *path)
 void
 test_null_oids(void)
 {
-	pmemobj_free(OID_NULL);
+	PMEMoid nulloid = OID_NULL;
+	pmemobj_free(&nulloid);
 
 	ASSERTeq(pmemobj_alloc_usable_size(OID_NULL), 0);
 
@@ -414,7 +422,7 @@ test_strdup(const char *path)
 
 #define	TEST_STRING(str)\
 	do {\
-	stroid = pmemobj_strdup(pop, str, 0);\
+	pmemobj_strdup(pop, &stroid, str, 0);\
 	ASSERTne(stroid.off, 0);\
 	ASSERTeq(memcmp(pmemobj_direct(stroid), str, strlen(str) + 1), 0);\
 	} while (0)
@@ -425,8 +433,8 @@ test_strdup(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	/* test NULL argument */
-	stroid = pmemobj_strdup(pop, NULL, 0);
-	ASSERTeq(stroid.off, 0);
+	int ret = pmemobj_strdup(pop, &stroid, NULL, 0);
+	ASSERTne(ret, 0);
 
 	TEST_STRING("");
 	TEST_STRING("Test non-empty string");

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -50,6 +50,8 @@ enum type_number {
 	TYPE_OBJ_ABORT,
 };
 
+TOID_DECLARE(struct object, 0);
+
 struct object {
 	size_t value;
 	char data[OBJ_SIZE - sizeof (size_t)];
@@ -85,10 +87,10 @@ static void
 do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-		ASSERT(!OID_IS_NULL(obj));
+		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+		ASSERT(!TOID_IS_NULL(obj));
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
 		ASSERTeq(ret, 0);
@@ -119,10 +121,10 @@ static void
 do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
-		ASSERT(!OID_IS_NULL(obj));
+		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
+		ASSERT(!TOID_IS_NULL(obj));
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
 		ASSERTeq(ret, 0);
@@ -140,8 +142,8 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_OBJ_ABORT));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_OBJ_ABORT));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -152,10 +154,10 @@ static void
 do_tx_add_range_twice_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
@@ -182,10 +184,10 @@ static void
 do_tx_add_range_twice_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
@@ -214,10 +216,10 @@ static void
 do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
@@ -256,10 +258,10 @@ static void
 do_tx_add_range_abort_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
@@ -297,10 +299,10 @@ static void
 do_tx_add_range_commit_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
@@ -336,8 +338,8 @@ static void
 do_tx_add_range_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
@@ -360,8 +362,8 @@ static void
 do_tx_add_range_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
@@ -382,8 +384,8 @@ static void
 do_tx_add_range_no_tx(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
 	ASSERTne(ret, 0);

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -50,6 +50,8 @@ enum type_number {
 	TYPE_OBJ_ABORT,
 };
 
+TOID_DECLARE(struct object, 0);
+
 struct object {
 	size_t value;
 	char data[OBJ_SIZE - sizeof (size_t)];
@@ -85,10 +87,10 @@ static void
 do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-		ASSERT(!OID_IS_NULL(obj));
+		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+		ASSERT(!TOID_IS_NULL(obj));
 
 		void *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
@@ -122,10 +124,10 @@ static void
 do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
-		ASSERT(!OID_IS_NULL(obj));
+		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
+		ASSERT(!TOID_IS_NULL(obj));
 
 		void *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
@@ -146,8 +148,8 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_OBJ_ABORT));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_OBJ_ABORT));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -158,10 +160,10 @@ static void
 do_tx_add_range_twice_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		void *ptr = pmemobj_direct(obj.oid);
@@ -191,10 +193,10 @@ static void
 do_tx_add_range_twice_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		void *ptr = pmemobj_direct(obj.oid);
@@ -226,10 +228,10 @@ static void
 do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		void *ptr1 = pmemobj_direct(obj1.oid);
@@ -271,10 +273,10 @@ static void
 do_tx_add_range_abort_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		void *ptr1 = pmemobj_direct(obj1.oid);
@@ -315,10 +317,10 @@ static void
 do_tx_add_range_commit_nested(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj1;
-	OID_TYPE(struct object) obj2;
-	OID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
-	OID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj1;
+	TOID(struct object) obj2;
+	TOID_ASSIGN(obj1, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		void *ptr1 = pmemobj_direct(obj1.oid);
@@ -357,8 +359,8 @@ static void
 do_tx_add_range_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		void *ptr = pmemobj_direct(obj.oid);
@@ -383,8 +385,8 @@ static void
 do_tx_add_range_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
 		void *ptr = pmemobj_direct(obj.oid);
@@ -407,8 +409,8 @@ static void
 do_tx_add_range_no_tx(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	void *ptr = pmemobj_direct(obj.oid);
 	ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF, VALUE_SIZE);

--- a/src/test/obj_tx_free/obj_tx_free.c
+++ b/src/test/obj_tx_free/obj_tx_free.c
@@ -61,6 +61,7 @@ enum type_number {
 	TYPE_FREE_ALLOC,
 };
 
+TOID_DECLARE(struct object, 0);
 
 struct object {
 	size_t value;
@@ -94,9 +95,9 @@ do_tx_free_no_tx(PMEMobjpool *pop)
 	ret = pmemobj_tx_free(oid);
 	ASSERTne(ret, 0);
 
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_NO_TX));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_NO_TX));
+	ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -118,9 +119,9 @@ do_tx_free_wrong_uuid(PMEMobjpool *pop)
 
 	ASSERTeq(ret, -1);
 
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_WRONG_UUID));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_WRONG_UUID));
+	ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -157,9 +158,9 @@ do_tx_free_commit(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT));
-	ASSERT(OID_IS_NULL(obj));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -180,9 +181,9 @@ do_tx_free_abort(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT));
+	ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -210,13 +211,13 @@ do_tx_free_commit_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT_NESTED1));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT_NESTED1));
+	ASSERT(TOID_IS_NULL(obj));
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT_NESTED2));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_COMMIT_NESTED2));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -245,13 +246,13 @@ do_tx_free_abort_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_NESTED1));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_NESTED1));
+	ASSERT(!TOID_IS_NULL(obj));
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_NESTED2));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_NESTED2));
+	ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -279,13 +280,13 @@ do_tx_free_abort_after_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_AFTER_NESTED1));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_AFTER_NESTED1));
+	ASSERT(!TOID_IS_NULL(obj));
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_AFTER_NESTED2));
-	ASSERT(!OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ABORT_AFTER_NESTED2));
+	ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -314,9 +315,9 @@ do_tx_free_oom(PMEMobjpool *pop)
 
 	ASSERTeq(alloc_cnt, free_cnt);
 
-	OID_TYPE(struct object) obj;
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_OOM));
-	ASSERT(OID_IS_NULL(obj));
+	TOID(struct object) obj;
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_OOM));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -327,12 +328,12 @@ static void
 do_tx_free_alloc_abort(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, pmemobj_tx_alloc(
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(
 				sizeof (struct object), TYPE_FREE_ALLOC));
-		ASSERT(!OID_IS_NULL(obj));
+		ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
 		ASSERTeq(ret, 0);
 		pmemobj_tx_abort(-1);
@@ -340,8 +341,8 @@ do_tx_free_alloc_abort(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ALLOC));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ALLOC));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -352,20 +353,20 @@ static void
 do_tx_free_alloc_commit(PMEMobjpool *pop)
 {
 	int ret;
-	OID_TYPE(struct object) obj;
+	TOID(struct object) obj;
 
 	TX_BEGIN(pop) {
-		OID_ASSIGN(obj, pmemobj_tx_alloc(
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(
 				sizeof (struct object), TYPE_FREE_ALLOC));
-		ASSERT(!OID_IS_NULL(obj));
+		ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
 		ASSERTeq(ret, 0);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ALLOC));
-	ASSERT(OID_IS_NULL(obj));
+	TOID_ASSIGN(obj, pmemobj_first(pop, TYPE_FREE_ALLOC));
+	ASSERT(TOID_IS_NULL(obj));
 }
 
 int

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -42,6 +42,8 @@
 
 #define	LAYOUT_NAME "tx_strdup"
 
+TOID_DECLARE(char, 0);
+
 enum type_number {
 	TYPE_NO_TX,
 	TYPE_COMMIT,
@@ -65,12 +67,12 @@ enum type_number {
 static void
 do_tx_strdup_no_tx(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str;
-	OID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_NO_TX));
-	ASSERT(OID_IS_NULL(str));
+	TOID(char) str;
+	TOID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_NO_TX));
+	ASSERT(TOID_IS_NULL(str));
 
-	OID_ASSIGN(str, pmemobj_first(pop, TYPE_NO_TX));
-	ASSERT(OID_IS_NULL(str));
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_NO_TX));
+	ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -79,16 +81,16 @@ do_tx_strdup_no_tx(PMEMobjpool *pop)
 static void
 do_tx_strdup_commit(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str;
+	TOID(char) str;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_COMMIT));
-		ASSERT(!OID_IS_NULL(str));
+		TOID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_COMMIT));
+		ASSERT(!TOID_IS_NULL(str));
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str, pmemobj_first(pop, TYPE_COMMIT));
-	ASSERT(!OID_IS_NULL(str));
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_COMMIT));
+	ASSERT(!TOID_IS_NULL(str));
 	ASSERTeq(strcmp(TEST_STR_1, D_RO(str)), 0);
 }
 
@@ -98,17 +100,17 @@ do_tx_strdup_commit(PMEMobjpool *pop)
 static void
 do_tx_strdup_abort(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str;
+	TOID(char) str;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_ABORT));
-		ASSERT(!OID_IS_NULL(str));
+		TOID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_ABORT));
+		ASSERT(!TOID_IS_NULL(str));
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str, pmemobj_first(pop, TYPE_ABORT));
-	ASSERT(OID_IS_NULL(str));
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_ABORT));
+	ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -118,19 +120,19 @@ do_tx_strdup_abort(PMEMobjpool *pop)
 static void
 do_tx_strdup_free_commit(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str;
+	TOID(char) str;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1,
+		TOID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1,
 					TYPE_FREE_COMMIT));
-		ASSERT(!OID_IS_NULL(str));
+		ASSERT(!TOID_IS_NULL(str));
 		int ret = pmemobj_tx_free(str.oid);
 		ASSERTeq(ret, 0);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str, pmemobj_first(pop, TYPE_FREE_COMMIT));
-	ASSERT(OID_IS_NULL(str));
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_FREE_COMMIT));
+	ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -140,10 +142,11 @@ do_tx_strdup_free_commit(PMEMobjpool *pop)
 static void
 do_tx_strdup_free_abort(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str;
+	TOID(char) str;
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str, pmemobj_tx_strdup(TEST_STR_1, TYPE_FREE_ABORT));
-		ASSERT(!OID_IS_NULL(str));
+		TOID_ASSIGN(str,
+			pmemobj_tx_strdup(TEST_STR_1, TYPE_FREE_ABORT));
+		ASSERT(!TOID_IS_NULL(str));
 		int ret = pmemobj_tx_free(str.oid);
 		ASSERTeq(ret, 0);
 		pmemobj_tx_abort(-1);
@@ -151,8 +154,8 @@ do_tx_strdup_free_abort(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str, pmemobj_first(pop, TYPE_FREE_ABORT));
-	ASSERT(OID_IS_NULL(str));
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_FREE_ABORT));
+	ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -162,17 +165,17 @@ do_tx_strdup_free_abort(PMEMobjpool *pop)
 static void
 do_tx_strdup_commit_nested(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str1;
-	OID_TYPE(char) str2;
+	TOID(char) str1;
+	TOID(char) str2;
 
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
+		TOID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
 				TYPE_COMMIT_NESTED1));
-		ASSERT(!OID_IS_NULL(str1));
+		ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
-			OID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
+			TOID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
 					TYPE_COMMIT_NESTED2));
-			ASSERT(!OID_IS_NULL(str2));
+			ASSERT(!TOID_IS_NULL(str2));
 		} TX_ONABORT {
 			ASSERT(0);
 		} TX_END
@@ -180,12 +183,12 @@ do_tx_strdup_commit_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str1, pmemobj_first(pop, TYPE_COMMIT_NESTED1));
-	ASSERT(!OID_IS_NULL(str1));
+	TOID_ASSIGN(str1, pmemobj_first(pop, TYPE_COMMIT_NESTED1));
+	ASSERT(!TOID_IS_NULL(str1));
 	ASSERTeq(strcmp(TEST_STR_1, D_RO(str1)), 0);
 
-	OID_ASSIGN(str2, pmemobj_first(pop, TYPE_COMMIT_NESTED2));
-	ASSERT(!OID_IS_NULL(str2));
+	TOID_ASSIGN(str2, pmemobj_first(pop, TYPE_COMMIT_NESTED2));
+	ASSERT(!TOID_IS_NULL(str2));
 	ASSERTeq(strcmp(TEST_STR_2, D_RO(str2)), 0);
 }
 
@@ -196,17 +199,17 @@ do_tx_strdup_commit_nested(PMEMobjpool *pop)
 static void
 do_tx_strdup_abort_nested(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str1;
-	OID_TYPE(char) str2;
+	TOID(char) str1;
+	TOID(char) str2;
 
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
+		TOID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
 				TYPE_ABORT_NESTED1));
-		ASSERT(!OID_IS_NULL(str1));
+		ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
-			OID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
+			TOID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
 					TYPE_ABORT_NESTED2));
-			ASSERT(!OID_IS_NULL(str2));
+			ASSERT(!TOID_IS_NULL(str2));
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
 			ASSERT(0);
@@ -215,11 +218,11 @@ do_tx_strdup_abort_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str1, pmemobj_first(pop, TYPE_ABORT_NESTED1));
-	ASSERT(OID_IS_NULL(str1));
+	TOID_ASSIGN(str1, pmemobj_first(pop, TYPE_ABORT_NESTED1));
+	ASSERT(TOID_IS_NULL(str1));
 
-	OID_ASSIGN(str2, pmemobj_first(pop, TYPE_ABORT_NESTED2));
-	ASSERT(OID_IS_NULL(str2));
+	TOID_ASSIGN(str2, pmemobj_first(pop, TYPE_ABORT_NESTED2));
+	ASSERT(TOID_IS_NULL(str2));
 }
 
 /*
@@ -229,17 +232,17 @@ do_tx_strdup_abort_nested(PMEMobjpool *pop)
 static void
 do_tx_strdup_abort_after_nested(PMEMobjpool *pop)
 {
-	OID_TYPE(char) str1;
-	OID_TYPE(char) str2;
+	TOID(char) str1;
+	TOID(char) str2;
 
 	TX_BEGIN(pop) {
-		OID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
+		TOID_ASSIGN(str1, pmemobj_tx_strdup(TEST_STR_1,
 				TYPE_ABORT_AFTER_NESTED1));
-		ASSERT(!OID_IS_NULL(str1));
+		ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
-			OID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
+			TOID_ASSIGN(str2, pmemobj_tx_strdup(TEST_STR_2,
 					TYPE_ABORT_AFTER_NESTED2));
-			ASSERT(!OID_IS_NULL(str2));
+			ASSERT(!TOID_IS_NULL(str2));
 		} TX_ONABORT {
 			ASSERT(0);
 		} TX_END
@@ -249,11 +252,11 @@ do_tx_strdup_abort_after_nested(PMEMobjpool *pop)
 		ASSERT(0);
 	} TX_END
 
-	OID_ASSIGN(str1, pmemobj_first(pop, TYPE_ABORT_AFTER_NESTED1));
-	ASSERT(OID_IS_NULL(str1));
+	TOID_ASSIGN(str1, pmemobj_first(pop, TYPE_ABORT_AFTER_NESTED1));
+	ASSERT(TOID_IS_NULL(str1));
 
-	OID_ASSIGN(str2, pmemobj_first(pop, TYPE_ABORT_AFTER_NESTED2));
-	ASSERT(OID_IS_NULL(str2));
+	TOID_ASSIGN(str2, pmemobj_first(pop, TYPE_ABORT_AFTER_NESTED2));
+	ASSERT(TOID_IS_NULL(str2));
 }
 
 int

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -2,7 +2,6 @@ scope/TEST4:
 $(*)debug/libpmemobj.so:
 _pobj_debug_notice
 pmemobj_alloc
-pmemobj_alloc_construct
 pmemobj_alloc_usable_size
 pmemobj_check
 pmemobj_check_version
@@ -58,12 +57,12 @@ pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
+pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)nondebug/libpmemobj.so:
 _pobj_debug_notice
 pmemobj_alloc
-pmemobj_alloc_construct
 pmemobj_alloc_usable_size
 pmemobj_check
 pmemobj_check_version
@@ -119,12 +118,12 @@ pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
+pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)debug/libpmemobj.a:
 _pobj_debug_notice
 pmemobj_alloc
-pmemobj_alloc_construct
 pmemobj_alloc_usable_size
 pmemobj_check
 pmemobj_check_version
@@ -180,12 +179,12 @@ pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
+pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)nondebug/libpmemobj.a:
 _pobj_debug_notice
 pmemobj_alloc
-pmemobj_alloc_construct
 pmemobj_alloc_usable_size
 pmemobj_check
 pmemobj_check_version
@@ -241,5 +240,6 @@ pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_tx_zalloc
 pmemobj_tx_zrealloc
+pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc


### PR DESCRIPTION
- new type safety macros with named unions
- atomic allocation API changes:
-- remove pmemobj_alloc_construct()
-- change return values to int
-- return PMEMoid using reference
-- change PMEMoid atomically using redo log
- add TX_NEW, TX_ZNEW, POBJ_NEW and POBJ_ZNEW macros
- add size parameter to TX_ALLOC, TX_ZALLOC, POBJ_ALLOC and POBJ_ZALLOC
- update manpage