### PR TITLE
obj: change return value for allocations with zero size

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -1439,10 +1439,11 @@ the actual size of the allocation will differ from the requested one by at least
 less than 64 bytes is extremely inefficient and discouraged.
 If
 .I size
-is 0, then
+equals 0, then
 .BR pmemobj_alloc ()
-returns
-.IR OID_NULL .
+returns non-zero value, sets the errno and leaves the
+.I oidp
+untouched.
 The allocated object is added to the internal container associated with given
 .IR type_num .
 .PP
@@ -1474,10 +1475,11 @@ the actual size of the allocation will differ from the requested one by at least
 less than 64 bytes is extremely inefficient and discouraged.
 If
 .I size
-is 0, then
+equals 0, then
 .BR pmemobj_zalloc ()
-returns
-.IR OID_NULL .
+returns non-zero value, sets the errno and leaves the
+.I oidp
+untouched.
 The allocated object is added to the internal container associated with given
 .I type_num.
 .PP
@@ -2612,7 +2614,7 @@ changes to
 OID_NULL is returned, and errno is set appropriately.
 If
 .I size
-is 0, OID_NULL is returned.
+equals 0, OID_NULL is returned and errno is set appropriately.
 .PP
 .BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", unsigned int " type_num );
 .IP
@@ -2628,6 +2630,9 @@ function returns a handle to the newly allocated object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
 OID_NULL is returned, and errno is set appropriately.
+If
+.I size
+equals 0, OID_NULL is returned and errno is set appropriately.
 .PP
 .BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ", unsigned int " type_num );
 .IP

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -586,6 +586,12 @@ pmemobj_alloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
 
+	if (size == 0) {
+		LOG(1, "allocation with size 0");
+		errno = EINVAL;
+		return -1;
+	}
+
 	return obj_alloc_construct(pop, oidp, size, type_num, constructor, arg);
 }
 
@@ -623,6 +629,12 @@ pmemobj_zalloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+
+	if (size == 0) {
+		LOG(1, "allocation with size 0");
+		errno = EINVAL;
+		return -1;
+	}
 
 	struct carg_zalloc carg;
 	carg.pop = pop;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1147,6 +1147,12 @@ pmemobj_tx_alloc(size_t size, unsigned int type_num)
 {
 	LOG(3, NULL);
 
+	if (size == 0) {
+		LOG(1, "allocation with size 0");
+		errno = EINVAL;
+		return OID_NULL;
+	}
+
 	return tx_alloc_common(size, type_num, constructor_tx_alloc);
 }
 
@@ -1157,6 +1163,12 @@ PMEMoid
 pmemobj_tx_zalloc(size_t size, unsigned int type_num)
 {
 	LOG(3, NULL);
+
+	if (size == 0) {
+		LOG(1, "allocation with size 0");
+		errno = EINVAL;
+		return OID_NULL;
+	}
 
 	return tx_alloc_common(size, type_num, constructor_tx_zalloc);
 }


### PR DESCRIPTION
- pmemobj_alloc and pmemobj_zalloc return error
- pmemobj_tx_alloc and pmemobj_tx_zalloc return OID_NULL
- update manpage

Ref: pmem/issues#71