### PR TITLE
obj: fix tx locks handling in aborted transaction

### DIFF
--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -231,14 +231,14 @@ lane_recover(PMEMobjpool *pop)
 	int section_err;
 	int i; /* lane index */
 	int j; /* section index */
-	struct lane_layout *layout = NULL;
+	struct lane_layout *layout;
 
 	FOREACH_LANE_SECTION(pop, layout, i, j) {
 		section_err = section_ops[j]->recover(pop,
 				&layout->sections[j]);
-		if (section_err != 0) {
+		if (section_err) {
 			LOG(1, "!section_ops->recover %d %d %d",
-				i, j, section_err);
+					i, j, section_err);
 			err = section_err;
 		}
 	}
@@ -252,23 +252,23 @@ lane_recover(PMEMobjpool *pop)
 int
 lane_check(PMEMobjpool *pop)
 {
-	int ret = 1;
-	int section_ret;
+	int err = 0;
+	int section_err;
 	int i; /* lane index */
 	int j; /* section index */
-	struct lane_layout *layout = NULL;
+	struct lane_layout *layout;
 
 	FOREACH_LANE_SECTION(pop, layout, i, j) {
-		section_ret = section_ops[j]->check(pop,
+		section_err = section_ops[j]->check(pop,
 				&layout->sections[j]);
-		if (section_ret != 1) {
+		if (section_err) {
 			LOG(1, "!section_ops->check %d %d %d",
-				i, j, section_ret);
-			ret = section_ret;
+					i, j, section_err);
+			err = section_err;
 		}
 	}
 
-	return ret;
+	return err;
 }
 
 /*

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -544,7 +544,7 @@ constructor_alloc_bytype(void *ptr, void *arg)
 
 	pobj->internal_type = TYPE_ALLOCATED;
 	pobj->user_type = carg->user_type;
-	carg->pop->persist(pobj, OBJ_OOB_OFFSET);
+	carg->pop->persist(pobj, OBJ_OOB_SIZE);
 
 	if (carg->constructor)
 		carg->constructor(ptr, carg->arg);
@@ -862,8 +862,8 @@ pmemobj_alloc_usable_size(PMEMoid oid)
 
 	ASSERTne(pop, NULL);
 
-	return (pmalloc_usable_size(pop, oid.off - OBJ_OOB_OFFSET) -
-								OBJ_OOB_OFFSET);
+	return (pmalloc_usable_size(pop, oid.off - OBJ_OOB_SIZE) -
+			OBJ_OOB_SIZE);
 }
 
 /*
@@ -953,7 +953,7 @@ constructor_alloc_root(void *ptr, void *arg)
 	ro->internal_type = TYPE_ALLOCATED;
 	ro->user_type = POBJ_ROOT_TYPE_NUM;
 	ro->size = carg->size;
-	carg->pop->persist(ro, OBJ_OOB_OFFSET);
+	carg->pop->persist(ro, OBJ_OOB_SIZE);
 }
 
 /*

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -55,7 +55,7 @@
 #define	OBJ_LANES_OFFSET	8192	/* lanes offset (8kB) */
 #define	OBJ_NLANES		1024	/* number of lanes */
 
-#define	OBJ_OOB_OFFSET		(sizeof (struct oob_header))
+#define	OBJ_OOB_SIZE		(sizeof (struct oob_header))
 #define	OBJ_OFF_TO_PTR(pop, off) ((void *)((uintptr_t)(pop) + (off)))
 #define	OBJ_PTR_TO_OFF(pop, ptr) ((uintptr_t)(ptr) - (uintptr_t)(pop))
 #define	OBJ_OID_IS_NULL(oid)	((oid).off == 0)
@@ -66,13 +66,13 @@
 
 
 #define	OOB_HEADER_FROM_OID(pop, oid)\
-	((struct oob_header *)((uintptr_t)(pop) + (oid).off - OBJ_OOB_OFFSET))
+	((struct oob_header *)((uintptr_t)(pop) + (oid).off - OBJ_OOB_SIZE))
 
 #define	OOB_HEADER_FROM_PTR(ptr)\
-	((struct oob_header *)((uintptr_t)(ptr) - OBJ_OOB_OFFSET))
+	((struct oob_header *)((uintptr_t)(ptr) - OBJ_OOB_SIZE))
 
 #define	OOB_OFFSET_OF(oid, field)\
-	((oid).off - OBJ_OOB_OFFSET + offsetof(struct oob_header, field))
+	((oid).off - OBJ_OOB_SIZE + offsetof(struct oob_header, field))
 
 typedef void (*persist_fn)(void *, size_t);
 typedef void (*flush_fn)(void *, size_t);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -130,6 +130,8 @@ TEST = blk_nblock\
        obj_tx_add_range_direct\
        obj_tx_strdup\
        obj_tx_realloc\
+       obj_tx_locks\
+       obj_tx_locks_abort\
        obj_ctree\
        obj_bucket\
        obj_heap\

--- a/src/test/obj_tx_locks_abort/.gitignore
+++ b/src/test/obj_tx_locks_abort/.gitignore
@@ -1,0 +1,1 @@
+obj_tx_locks_abort

--- a/src/test/obj_tx_locks_abort/Makefile
+++ b/src/test/obj_tx_locks_abort/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_locks_abort/Makefile -- build obj_tx_locks_abort unit test
+#
+vpath %.c ../../libpmemobj
+vpath %.c ../../common
+
+TARGET = obj_tx_locks_abort
+OBJS = obj_tx_locks_abort.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc
+
+INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_tx_locks_abort/README
+++ b/src/test/obj_tx_locks_abort/README
@@ -1,0 +1,27 @@
+Linux NVM Library
+
+This is src/test/obj_tx_locks_abort/README.
+
+This directory contains a unit test for handling transaction locks in case
+of aborted nested transactions.
+
+At the beginning of each transaction, the user may provide an arbitrary number of mutexes
+and/or rwlocks, which will be taken before the transaction starts and released
+at transaction end.
+In case of nested transactions, it may happen that the snapshot of the object
+containing the lock passed to pmemobj_tx_begin() is already added to the undo log.
+If the transaction is aborted, the object data will be restored first (which also restores
+the PMEM lock in non-locked state.  Once the undo log processing is completed,
+all the transaction locks are unlocked.  So, this may result in calling the unlock()
+on the lock that is not held by current thread, which may lead to an undefined behavior.
+The libpmemobj library implements mechanisms to prevent such scenario, and this is
+what is tested here.
+
+The obj_tx_locks_abort application takes as command line arguments the file where the pool
+will be created and the type of test to be performed:
+
+$ obj_tx_locks_abort <file>
+
+Some of the tests are performed using valgrind and its following tools:
+	- drd
+	- helgrind

--- a/src/test/obj_tx_locks_abort/TEST0
+++ b/src/test/obj_tx_locks_abort/TEST0
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_locks_abort/TEST0 -- unit test for transaction locks
+#
+export UNITTEST_NAME=obj_tx_locks_abort/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+rm -f $DIR/testfile1
+
+expect_normal_exit ./obj_tx_locks_abort$EXESUFFIX $DIR/testfile1
+
+rm -f $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_tx_locks_abort/TEST1
+++ b/src/test/obj_tx_locks_abort/TEST1
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_locks_abort/TEST1 -- unit test for transaction locks
+#
+export UNITTEST_NAME=obj_tx_locks_abort/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+unset PMEM_LOG_LEVEL
+unset PMEM_LOG_FILE
+unset PMEMOBJ_LOG_LEVEL
+unset PMEMOBJ_LOG_FILE
+
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind_dev_3_10
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=drd\
+ ./obj_tx_locks_abort$EXESUFFIX $DIR/testfile1
+
+rm -f $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_tx_locks_abort/TEST2
+++ b/src/test/obj_tx_locks_abort/TEST2
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_locks_abort/TEST2 -- unit test for transaction locks
+#
+export UNITTEST_NAME=obj_tx_locks_abort/TEST2
+export UNITTEST_NUM=2
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+unset PMEM_LOG_LEVEL
+unset PMEM_LOG_FILE
+unset PMEMOBJ_LOG_LEVEL
+unset PMEMOBJ_LOG_FILE
+
+require_fs_type local
+require_build_type debug nondebug
+require_valgrind_dev_3_10
+
+setup
+
+expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --tool=helgrind ./obj_tx_locks_abort$EXESUFFIX $DIR/testfile1
+
+rm -f $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
+++ b/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_tx_locks_nested.c -- unit test for transaction locks
+ */
+#include "unittest.h"
+#include "libpmemobj.h"
+#include "util.h"
+
+#define	LAYOUT_NAME "locks"
+
+TOID_DECLARE(struct root_obj, POBJ_ROOT_TYPE_NUM);
+TOID_DECLARE(struct obj, 1);
+
+struct root_obj {
+	PMEMmutex lock;
+	TOID(struct obj) head;
+};
+
+struct obj {
+	int data;
+	PMEMmutex lock;
+	TOID(struct obj) next;
+};
+
+/*
+ * do_nested_tx-- (internal) nested transaction
+ */
+static void
+do_nested_tx(PMEMobjpool *pop, TOID(struct obj) o, int value)
+{
+	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(o)->lock, TX_LOCK_NONE) {
+		TX_ADD(o);
+		D_RW(o)->data = value;
+		if (!TOID_IS_NULL(D_RO(o)->next)) {
+			/*
+			 * Add the object to undo log, while the mutex
+			 * it contains is not locked.
+			 */
+			TX_ADD(D_RO(o)->next);
+			do_nested_tx(pop, D_RO(o)->next, value);
+		}
+	} TX_END;
+}
+
+/*
+ * do_aborted_nested_tx -- (internal) aborted nested transaction
+ */
+static void
+do_aborted_nested_tx(PMEMobjpool *pop, TOID(struct obj) oid, int value)
+{
+	TOID(struct obj) o = oid;
+
+	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(o)->lock, TX_LOCK_NONE) {
+		TX_ADD(o);
+		D_RW(o)->data = value;
+		if (!TOID_IS_NULL(D_RO(o)->next)) {
+			/*
+			 * Add the object to undo log, while the mutex
+			 * it contains is not locked.
+			 */
+			TX_ADD(D_RO(o)->next);
+			do_nested_tx(pop, D_RO(o)->next, value);
+		}
+		pmemobj_tx_abort(EINVAL);
+	} TX_FINALLY {
+		o = oid;
+
+		while (!TOID_IS_NULL(o)) {
+			if (pmemobj_mutex_trylock(pop, &D_RW(o)->lock)) {
+				OUT("trylock failed");
+			} else {
+				OUT("trylock succeeded");
+				pmemobj_mutex_unlock(pop, &D_RW(o)->lock);
+			}
+			o = D_RO(o)->next;
+		}
+	} TX_END;
+}
+
+/*
+ * do_check -- (internal) print 'data' value of each object on the list
+ */
+static void
+do_check(TOID(struct obj) o)
+{
+	while (!TOID_IS_NULL(o)) {
+		OUT("data = %d", D_RO(o)->data);
+		o = D_RO(o)->next;
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	PMEMobjpool *pop;
+
+	START(argc, argv, "obj_tx_locks_abort");
+
+	if (argc > 3)
+		FATAL("usage: %s <file>", argv[0]);
+
+	pop = pmemobj_create(argv[1], LAYOUT_NAME,
+			PMEMOBJ_MIN_POOL * 4, S_IWUSR | S_IRUSR);
+	if (pop == NULL)
+		FATAL("!pmemobj_create");
+
+	TOID(struct root_obj) root = POBJ_ROOT(pop, struct root_obj);
+
+	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
+		TX_ADD(root);
+		D_RW(root)->head = TX_NEW(struct obj);
+		TOID(struct obj) o;
+		o = D_RW(root)->head;
+		D_RW(o)->data = 100;
+		for (int i = 0; i < 3; i++) {
+			D_RW(o)->next = TX_NEW(struct obj);
+			o = D_RO(o)->next;
+			D_RW(o)->data = 101 + i;
+		}
+		TOID_ASSIGN(D_RW(o)->next, OID_NULL);
+	} TX_END;
+
+	OUT("initial state");
+	do_check(D_RO(root)->head);
+
+	OUT("nested tx");
+	do_nested_tx(pop, D_RW(root)->head, 200);
+	do_check(D_RO(root)->head);
+
+	OUT("aborted nested tx");
+	do_aborted_nested_tx(pop, D_RW(root)->head, 300);
+	do_check(D_RO(root)->head);
+
+	pmemobj_close(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_tx_locks_abort/out0.log.match
+++ b/src/test/obj_tx_locks_abort/out0.log.match
@@ -1,0 +1,22 @@
+obj_tx_locks_abort/TEST0: START: obj_tx_locks_abort
+ ./obj_tx_locks_abort$(nW) $(nW)/testfile1
+initial state
+data = 100
+data = 101
+data = 102
+data = 103
+nested tx
+data = 200
+data = 200
+data = 200
+data = 200
+aborted nested tx
+trylock failed
+trylock failed
+trylock failed
+trylock failed
+data = 200
+data = 200
+data = 200
+data = 200
+obj_tx_locks_abort/TEST0: Done

--- a/src/test/obj_tx_locks_abort/out1.log.match
+++ b/src/test/obj_tx_locks_abort/out1.log.match
@@ -1,0 +1,22 @@
+obj_tx_locks_abort/TEST1: START: obj_tx_locks_abort
+ ./obj_tx_locks_abort$(nW) $(nW)/testfile1
+initial state
+data = 100
+data = 101
+data = 102
+data = 103
+nested tx
+data = 200
+data = 200
+data = 200
+data = 200
+aborted nested tx
+trylock failed
+trylock failed
+trylock failed
+trylock failed
+data = 200
+data = 200
+data = 200
+data = 200
+obj_tx_locks_abort/TEST1: Done

--- a/src/test/obj_tx_locks_abort/out2.log.match
+++ b/src/test/obj_tx_locks_abort/out2.log.match
@@ -1,0 +1,22 @@
+obj_tx_locks_abort/TEST2: START: obj_tx_locks_abort
+ ./obj_tx_locks_abort$(nW) $(nW)/testfile1
+initial state
+data = 100
+data = 101
+data = 102
+data = 103
+nested tx
+data = 200
+data = 200
+data = 200
+data = 200
+aborted nested tx
+trylock failed
+trylock failed
+trylock failed
+trylock failed
+data = 200
+data = 200
+data = 200
+data = 200
+obj_tx_locks_abort/TEST2: Done

--- a/src/test/obj_tx_locks_abort/valgrind1.log.match
+++ b/src/test/obj_tx_locks_abort/valgrind1.log.match
@@ -1,0 +1,9 @@
+==$(N)== drd, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))

--- a/src/test/obj_tx_locks_abort/valgrind2.log.match
+++ b/src/test/obj_tx_locks_abort/valgrind2.log.match
@@ -1,0 +1,11 @@
+==$(N)== Helgrind, a thread error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+$(OPT)==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+$(OPT)==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --history-level=approx or =none to gain increased speed, at
+$(OPT)==$(N)== the cost of reduced accuracy of conflicting-access information
+$(OPT)==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))


### PR DESCRIPTION
Also renames *OBJ_OOB_OFFSET* to *OBJ_OOB_SIZE*.