### PR TITLE
common: add test timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ To run a specific subset of tests, run for example:
 	$ make check TEST_TYPE=short TEST_BUILD=debug TEST_FS=pmem
 ```
 
+To modify the timeout which is available for **check** type tests, run:
+```
+	$ make check TEST_TIME=1m
+```
+This will set the timeout to 1 minute.
+
 Please refer to the **src/test/README** for more details on how to
 run different types of tests.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,7 @@ SCOPEFILES = $(SCOPE_SRC_FILES) $(SCOPE_HDR_FILES)
 TEST_TYPE = check
 TEST_BUILD = all
 TEST_FS = all
+TEST_TIME = 3m
 
 all: $(ALL_TARGETS)
 install: $(INSTALL_TARGETS:=-install)
@@ -115,7 +116,7 @@ test: all jemalloc-test
 	$(MAKE) -C test all
 
 check: test jemalloc-check
-	cd test && ./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS)
+	cd test && ./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME)
 
 jemalloc jemalloc-clean jemalloc-clobber jemalloc-test jemalloc-check:
 	$(MAKE) -C jemalloc -f Makefile.nvml $@

--- a/src/test/README
+++ b/src/test/README
@@ -56,11 +56,15 @@ file system type, and build type to test.
 
 RUNTESTS takes options to limit what it runs.  The usage is:
 
- RUNTESTS [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ] [test...]
+ RUNTESTS [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
+	  [ -o timeout ] [test...]
 
  Build types are: debug, nondebug, static-debug, static-nondebug, all (default)
  Test types are: check (default), short, long
  File system types are: local, pmem, non-pmem, all (default)
+ Timeout is: a floating point number with an optional suffix: 's' for seconds
+		 (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+		 Default value is 3 minutes.
 
 For example:
 

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,10 +45,14 @@ usage()
 {
 	[ "$1" ] && echo Error: $1
 	cat <<EOF
-Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ] [tests...]
+Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
+	    [ -o timeout ] [tests...]
     build-types: debug, nondebug, static-debug, static-nondebug, all (default)
      test-types: check (default), short, long
        fs-types: local, pmem, non-pmem, all (default)
+        timeout: floating point number with an optional suffix: 's' for seconds
+		 (the default), 'm' for minutes, 'h' for hours or 'd' for days.
+		 Default value is 3 minutes.
 EOF
 	exit 1
 }
@@ -101,14 +105,23 @@ runtest() {
 				if [ "$dryrun" ]
 				then
 					echo "(in ./$1) TEST=$testtype FS=$fs BUILD=$build ./$runscript"
+				# set timeout for "check" tests
+				elif [ "$testtype" = "check" ]
+				then
+					[ "$verbose" ] && echo "RUNTESTS: Running: (in ./$1) TEST=$testtype FS=$fs BUILD=$build ./$runscript"
+					TEST=$testtype FS=$fs BUILD=$build timeout -k 10s $time ./$runscript
 				else
 					[ "$verbose" ] && echo "RUNTESTS: Running: (in ./$1) TEST=$testtype FS=$fs BUILD=$build ./$runscript"
 					TEST=$testtype FS=$fs BUILD=$build ./$runscript
 				fi
 
-				[ $? != 0 ] && {
+				retval=$?
+				errmsg='failed'
+				[ $retval = 124 -o $retval = 137 ] && errmsg='timed out'
+
+				[ $retval != 0 ] && {
 					echo RUNTESTS: stopping:
-					echo "    $1/$runscript failed"
+					echo "    $1/$runscript $errmsg"
 					echo "    TEST=$testtype FS=$fs BUILD=$build"
 					exit 1
 				}
@@ -138,11 +151,12 @@ buildtype=all
 testtype=check
 fstype=all
 testconfig="./testconfig.sh"
+time='3m'
 
 #
 # command-line argument processing...
 #
-args=`getopt nvb:t:f: $*`
+args=`getopt nvb:t:f:o: $*`
 [ $? != 0 ] && usage
 set -- $args
 for arg
@@ -193,6 +207,10 @@ do
 			usage "bad fs-type: $fstype"
 			;;
 		esac
+		;;
+	-o)
+		time="$2"
+		shift 2
 		;;
 	--)
 		shift


### PR DESCRIPTION
All check test are run with a default timeout of 3 minutes. This can be
overridden by either providing the RUNTESTS script with the new value
using the -o flag, or by setting the TEST_TIME value in the make
check command.