### PR TITLE
test/vmem: align mmaped anonymous memory to 4MB and add guard pages around it

### DIFF
--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -203,6 +203,8 @@ void *ut_pagealignmalloc(const char *file, int line, const char *func,
     size_t size);
 void *ut_memalign(const char *file, int line, const char *func,
     size_t alignment, size_t size);
+void *ut_mmap_anon_aligned(const char *file, int line, const char *func,
+    size_t alignment, size_t size);
 
 /* a malloc() that can't return NULL */
 #define	MALLOC(size)\
@@ -235,6 +237,12 @@ void *ut_memalign(const char *file, int line, const char *func,
 #define	MEMALIGN(alignment, size)\
     ut_memalign(__FILE__, __LINE__, __func__, alignment, size)
 
+/*
+ * A mmap() that returns anonymous memory with given alignment and guard
+ * pages.
+ */
+#define	MMAP_ANON_ALIGNED(size, alignment)\
+    ut_mmap_anon_aligned(__FILE__, __LINE__, __func__, alignment, size)
 
 /*
  * file operations

--- a/src/test/vmem_aligned_alloc/vmem_aligned_alloc.c
+++ b/src/test/vmem_aligned_alloc/vmem_aligned_alloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -117,8 +117,7 @@ main(int argc, char *argv[])
 	}
 
 	/* allocate memory for function vmem_create_in_region() */
-	void *mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	/* use custom alloc functions to check for memory leaks */
 	vmem_set_funcs(malloc_custom, free_custom,

--- a/src/test/vmem_calloc/vmem_calloc.c
+++ b/src/test/vmem_calloc/vmem_calloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,8 +56,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_check/vmem_check.c
+++ b/src/test/vmem_check/vmem_check.c
@@ -55,8 +55,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL * 2, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL * 2, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_check_allocations/vmem_check_allocations.c
+++ b/src/test/vmem_check_allocations/vmem_check_allocations.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,9 +66,7 @@ main(int argc, char *argv[])
 		size_t j;
 
 		if (dir == NULL) {
-			mem_pool = MMAP(NULL, VMEM_MIN_POOL,
-					PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+			mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 			vmp = vmem_create_in_region(mem_pool,
 				VMEM_MIN_POOL);

--- a/src/test/vmem_create_in_region/vmem_create_in_region.c
+++ b/src/test/vmem_create_in_region/vmem_create_in_region.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,8 +54,7 @@ main(int argc, char *argv[])
 		FATAL("usage: %s", argv[0]);
 
 	/* allocate memory for function vmem_create_in_region() */
-	void *mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 

--- a/src/test/vmem_custom_alloc/vmem_custom_alloc.c
+++ b/src/test/vmem_custom_alloc/vmem_custom_alloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,8 +128,7 @@ pool_test(const char *dir)
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 	} else {
 		/* allocate memory for function vmem_create_in_region() */
-		void *mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	}

--- a/src/test/vmem_delete/vmem_delete.c
+++ b/src/test/vmem_delete/vmem_delete.c
@@ -66,8 +66,7 @@ main(int argc, char *argv[])
 		FATAL("usage: %s op:h|f|m|c|r|a|s|d", argv[0]);
 
 	/* allocate memory for function vmem_create_in_region() */
-	void *mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp == NULL)

--- a/src/test/vmem_fork/vmem_fork.c
+++ b/src/test/vmem_fork/vmem_fork.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,8 +109,7 @@ create_pool(const char *dir)
 	if (dir == NULL) {
 		void *mem_pool;
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_malloc/vmem_malloc.c
+++ b/src/test/vmem_malloc/vmem_malloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,8 +56,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_malloc_usable_size/vmem_malloc_usable_size.c
+++ b/src/test/vmem_malloc_usable_size/vmem_malloc_usable_size.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,8 +83,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, POOL_SIZE, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(POOL_SIZE, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, POOL_SIZE);
 		if (vmp == NULL)

--- a/src/test/vmem_mix_allocations/vmem_mix_allocations.c
+++ b/src/test/vmem_mix_allocations/vmem_mix_allocations.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,8 +58,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_multiple_pools/vmem_multiple_pools.c
+++ b/src/test/vmem_multiple_pools/vmem_multiple_pools.c
@@ -63,8 +63,7 @@ main(int argc, char *argv[])
 
 	for (pool_id = 0; pool_id < mem_pools_size; ++pool_id) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pools[pool_id] = MMAP(NULL, VMEM_MIN_POOL,
-			PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pools[pool_id] = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 	}
 
 	for (repeat = 0; repeat < TEST_REPEAT_CREATE_POOLS; ++repeat) {

--- a/src/test/vmem_out_of_memory/vmem_out_of_memory.c
+++ b/src/test/vmem_out_of_memory/vmem_out_of_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,8 +54,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_realloc/vmem_realloc.c
+++ b/src/test/vmem_realloc/vmem_realloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,8 +56,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_stats/vmem_stats.c
+++ b/src/test/vmem_stats/vmem_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,15 +119,13 @@ main(int argc, char *argv[])
 		vmem_set_funcs(malloc_custom, free_custom,
 				realloc_custom, strdup_custom, NULL);
 
-	mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-				MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp_unused = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp_unused == NULL)
 		FATAL("!vmem_create_in_region");
 
-	mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+	mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp_used = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp_used == NULL)

--- a/src/test/vmem_strdup/vmem_strdup.c
+++ b/src/test/vmem_strdup/vmem_strdup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,8 +57,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)

--- a/src/test/vmem_valgrind/vmem_valgrind.c
+++ b/src/test/vmem_valgrind/vmem_valgrind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014-2015, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -135,8 +135,7 @@ main(int argc, char *argv[])
 
 	if (dir == NULL) {
 		/* allocate memory for function vmem_create_in_region() */
-		void *mem_pool = MMAP(NULL, VMEM_MIN_POOL, PROT_READ|PROT_WRITE,
-					MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+		void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)


### PR DESCRIPTION
It lets tests be deterministic wrt how much memory is available from the pool and may catch some memory corruption bugs.