### PR TITLE
obj: validate user-provided oids in debug builds

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -531,6 +531,8 @@ pmemobj_direct(PMEMoid oid)
 	if (p == NULL)
 		return NULL;
 
+	ASSERT(OBJ_OID_IS_VALID((PMEMobjpool *)p, oid));
+
 	return p + oid.off;
 }
 
@@ -743,6 +745,7 @@ pmemobj_realloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+	ASSERT(OBJ_OID_IS_VALID(pop, *oidp));
 
 	return obj_realloc_construct(pop, pop->store, oidp, size, type_num,
 					NULL, NULL);
@@ -760,6 +763,7 @@ pmemobj_zrealloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+	ASSERT(OBJ_OID_IS_VALID(pop, *oidp));
 
 	struct carg_zrealloc carg;
 
@@ -847,6 +851,7 @@ pmemobj_free(PMEMoid *oidp)
 	PMEMobjpool *pop = cuckoo_get(pools, oidp->pool_uuid_lo);
 
 	ASSERTne(pop, NULL);
+	ASSERT(OBJ_OID_IS_VALID(pop, *oidp));
 
 	struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, *oidp);
 
@@ -871,6 +876,7 @@ pmemobj_alloc_usable_size(PMEMoid oid)
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
 
 	ASSERTne(pop, NULL);
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
 
 	return (pmalloc_usable_size(pop, oid.off - OBJ_OOB_SIZE) -
 			OBJ_OOB_SIZE);
@@ -935,6 +941,7 @@ pmemobj_type_num(PMEMoid oid)
 
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
 	ASSERTne(pop, NULL);
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
 
 	struct oob_header *oobh = OOB_HEADER_FROM_OID(pop, oid);
 	return oobh->user_type;
@@ -1073,6 +1080,7 @@ pmemobj_next(PMEMoid oid)
 	PMEMobjpool *pop = cuckoo_get(pools, oid.pool_uuid_lo);
 
 	ASSERTne(pop, NULL);
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
 
 	struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, oid);
 	uint16_t user_type = pobj->user_type;
@@ -1100,6 +1108,8 @@ pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, void *head,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
+	ASSERT(OBJ_OID_IS_VALID(pop, dest));
 
 	return list_insert(pop, pe_offset, head, dest, before, oid);
 }
@@ -1120,6 +1130,7 @@ pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, void *head,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+	ASSERT(OBJ_OID_IS_VALID(pop, dest));
 
 	if (type_num >= PMEMOBJ_NUM_OID_TYPES) {
 		errno = EINVAL;
@@ -1155,6 +1166,7 @@ pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, void *head,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
 
 	if (free) {
 		struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, oid);
@@ -1183,6 +1195,9 @@ pmemobj_list_move(PMEMobjpool *pop, size_t pe_old_offset, void *head_old,
 
 	/* log notice message if used inside a transaction */
 	_POBJ_DEBUG_NOTICE_IN_TX();
+
+	ASSERT(OBJ_OID_IS_VALID(pop, oid));
+	ASSERT(OBJ_OID_IS_VALID(pop, dest));
 
 	return list_move(pop, pe_old_offset, head_old,
 				pe_new_offset, head_new,

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -64,6 +64,14 @@
 	(OBJ_PTR_TO_OFF(pop, ptr) >= (pop)->heap_offset &&\
 	OBJ_PTR_TO_OFF(pop, ptr) < (pop)->heap_offset + (pop)->heap_size)
 
+#define	OBJ_OID_IS_VALID(pop, oid) (\
+	{\
+		PMEMoid o = (oid);\
+		OBJ_OID_IS_NULL(o) ||\
+		(o.pool_uuid_lo == (pop)->uuid_lo &&\
+		o.off >= (pop)->heap_offset &&\
+		o.off < (pop)->heap_offset + (pop)->heap_size);\
+	})
 
 #define	OOB_HEADER_FROM_OID(pop, oid)\
 	((struct oob_header *)((uintptr_t)(pop) + (oid).off - OBJ_OOB_SIZE))

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -861,6 +861,8 @@ tx_realloc_common(PMEMoid oid, size_t size, unsigned int type_num,
 	if (OBJ_OID_IS_NULL(oid))
 		return tx_alloc_common(size, type_num, constructor_alloc);
 
+	ASSERT(OBJ_OID_IS_VALID(lane->pop, oid));
+
 	/* if size is 0 just free */
 	if (size == 0) {
 		if (pmemobj_tx_free(oid)) {
@@ -1241,6 +1243,7 @@ pmemobj_tx_add_range(PMEMoid oid, uint64_t hoff, size_t size)
 
 		return EINVAL;
 	}
+	ASSERT(OBJ_OID_IS_VALID(lane->pop, oid));
 
 	struct oob_header *oobh = OOB_HEADER_FROM_OID(lane->pop, oid);
 
@@ -1378,6 +1381,7 @@ pmemobj_tx_free(PMEMoid oid)
 		pmemobj_tx_abort(EINVAL);
 		return EINVAL;
 	}
+	ASSERT(OBJ_OID_IS_VALID(lane->pop, oid));
 
 	struct lane_tx_layout *layout =
 		(struct lane_tx_layout *)tx.section->layout;

--- a/src/test/obj_direct/obj_direct.c
+++ b/src/test/obj_direct/obj_direct.c
@@ -75,8 +75,9 @@ main(int argc, char *argv[])
 		oids[i] = (PMEMoid) {pops[i]->uuid_lo, 0};
 		ASSERTeq(pmemobj_direct(oids[i]), NULL);
 
-		oids[i] = (PMEMoid) {pops[i]->uuid_lo, 1};
-		ASSERTeq(pmemobj_direct(oids[i]) - 1, pops[i]);
+		uint64_t off = pops[i]->heap_offset;
+		oids[i] = (PMEMoid) {pops[i]->uuid_lo, off};
+		ASSERTeq(pmemobj_direct(oids[i]) - off, pops[i]);
 
 		r = pmemobj_alloc(pops[i], &tmpoids[i], 100, 1, NULL, NULL);
 		ASSERTeq(r, 0);


### PR DESCRIPTION
Otherwise, when user provides garbage oids, we hit crashes or assertion failures deep in the library and it's not easy for application developer to figure out what happened.

I was bitten by this when testing my new pmemobj example, which did not initialize dynamically allocated array of PMEMoids.