### PR TITLE
obj: typo fix in examples

### DIFF
--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
@@ -57,7 +57,7 @@
 #include "libpmem.h"
 #include "libpmemblk.h"
 
-#define	USABLE_SIZE ((float)(9 / 10))
+#define	USABLE_SIZE (9.0 / 10)
 #define	POOL_SIZE ((size_t)(1024 * 1024 * 50))
 #define	MAX_POOL_SIZE ((size_t)(1024L * 1024 * 1024 * 16))
 #define	MAX_THREADS 256

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
@@ -60,7 +60,7 @@
 #include "libpmem.h"
 #include "libpmemlog.h"
 
-#define	USABLE_SIZE ((float)(9 / 10))
+#define	USABLE_SIZE (9.0 / 10)
 #define	MAX_POOL_SIZE ((size_t)(1024L * 1024 * 1024 * 16))
 #define	POOL_SIZE ((size_t)(1024 * 1024 * 100))
 


### PR DESCRIPTION
Revert changes made while correcting whitespace between operators.