### PR TITLE
rpm/dpkg: use local testconfig.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ pkg-clean:
 	$(RM) -r $(DESTDIR)
 
 rpm dpkg: pkg-clean source
-	utils/build-$@.sh $(SRCVERSION) $(DESTDIR)/nvml $(DESTDIR) $(CURDIR)/$@
+	utils/build-$@.sh $(SRCVERSION) $(DESTDIR)/nvml $(DESTDIR) $(CURDIR)/$@\
+			$(CURDIR)/src/test/testconfig.sh
 
 install uninstall:
 	$(MAKE) -C src $@

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,9 +37,10 @@
 SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/pkg-common.sh
 
-if [ "$#" != "4" ]
+if [ $# -lt 4 -o $# -gt 5 ]
 then
-	echo "Usage: $(basename $0) VERSION_TAG SOURCE_DIR WORKING_DIR OUT_DIR"
+	echo "Usage: $(basename $0) VERSION_TAG SOURCE_DIR WORKING_DIR"\
+					"OUT_DIR [TEST_CONFIG_FILE]"
 	exit 1
 fi
 
@@ -47,6 +48,7 @@ PACKAGE_VERSION_TAG=$1
 SOURCE=$2
 WORKING_DIR=$3
 OUT_DIR=$4
+TEST_CONFIG_FILE=$5
 
 function convert_changelog() {
 	while read line
@@ -224,7 +226,11 @@ override_dh_install:
 
 override_dh_auto_test:
 	dh_auto_test
-	cp src/test/testconfig.sh.example src/test/testconfig.sh
+	if [ -f $TEST_CONFIG_FILE ]; then
+		cp $TEST_CONFIG_FILE src/test/testconfig.sh
+	else
+	        cp src/test/testconfig.sh.example src/test/testconfig.sh
+	fi
 	make check
 EOF
 

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,15 +31,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# build-rmp.sh - Script for building rpm packages
+# build-rpm.sh - Script for building rpm packages
 #
 
 SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/pkg-common.sh
 
-if [ "$#" != "4" ]
+if [ $# -lt 4 -o $# -gt 5 ]
 then
-	echo "Usage: $(basename $0) VERSION_TAG SOURCE_DIR WORKING_DIR OUT_DIR"
+	echo "Usage: $(basename $0) VERSION_TAG SOURCE_DIR WORKING_DIR"\
+					"OUT_DIR [TEST_CONFIG_FILE]"
 	exit 1
 fi
 
@@ -47,6 +48,7 @@ PACKAGE_VERSION_TAG=$1
 SOURCE=$2
 WORKING_DIR=$3
 OUT_DIR=$4
+TEST_CONFIG_FILE=$5
 
 function convert_changelog() {
 	while read
@@ -328,7 +330,11 @@ mkdir -p %{buildroot}/usr/share/nvml
 cp utils/nvml.magic %{buildroot}/usr/share/nvml/
 
 %check
-cp src/test/testconfig.sh.example src/test/testconfig.sh
+if [ -f $TEST_CONFIG_FILE ]; then
+	cp $TEST_CONFIG_FILE src/test/testconfig.sh
+else
+	cp src/test/testconfig.sh.example src/test/testconfig.sh
+fi
 make check
 
 %clean


### PR DESCRIPTION
Use local 'src/test/testconfig.sh' (if it exists)
instead of coping 'testconfig.sh.example' as a unit tests'
config file during 'make rpm' and 'make dpkg'.