### PR TITLE
obj: fix allocation of zeroed objects

### DIFF
--- a/src/test/blk_pool/TEST7
+++ b/src/test/blk_pool/TEST7
@@ -43,11 +43,9 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-    count=$(($MIN_POOL_SIZE / 1024)) &> /dev/null
+
+create_nonzeroed_file 17 0 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST8
+++ b/src/test/blk_pool/TEST8
@@ -43,11 +43,9 @@ export UNITTEST_NUM=8
 setup
 umask 0
 
-MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-    count=$(($MIN_POOL_SIZE / 1024 - 8)) seek=8 &> /dev/null
+
+create_nonzeroed_file 17 8 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/blk_pool/out8.log.match
+++ b/src/test/blk_pool/out8.log.match
@@ -1,4 +1,4 @@
 blk_pool/TEST8: START: blk_pool
  ./blk_pool$(nW) c $(nW)/testfile 4096 0 0640
-$(nW)/testfile: file size 16785408 usable blocks 3829 mode 0640
+$(nW)/testfile: file size 17825792 usable blocks 4082 mode 0640
 blk_pool/TEST8: Done

--- a/src/test/log_pool/TEST6
+++ b/src/test/log_pool/TEST6
@@ -43,11 +43,9 @@ export UNITTEST_NUM=6
 setup
 umask 0
 
-MIN_POOL_SIZE=$((2*1024*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-    count=$(($MIN_POOL_SIZE / 1024)) &> /dev/null
+
+create_nonzeroed_file 2 0 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST7
+++ b/src/test/log_pool/TEST7
@@ -43,11 +43,9 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-MIN_POOL_SIZE=$((2*1024*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-   count=$(($MIN_POOL_SIZE / 1024 - 8)) seek=8 &> /dev/null
+
+create_nonzeroed_file 2 8 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST7
+++ b/src/test/obj_pool/TEST7
@@ -43,11 +43,9 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-    count=$(($MIN_POOL_SIZE / 1024)) &> /dev/null
+
+create_nonzeroed_file 8 0 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST8
+++ b/src/test/obj_pool/TEST8
@@ -43,11 +43,9 @@ export UNITTEST_NUM=8
 setup
 umask 0
 
-MIN_POOL_SIZE=$((16*1024*1024 + 8*1024))
 rm -f $DIR/testfile
-truncate -s $MIN_POOL_SIZE $DIR/testfile
-dd if=/dev/urandom of=$DIR/testfile bs=1K \
-    count=$(($MIN_POOL_SIZE / 1024 - 8)) seek=8 &> /dev/null
+
+create_nonzeroed_file 8 8 $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/out8.log.match
+++ b/src/test/obj_pool/out8.log.match
@@ -1,4 +1,4 @@
 obj_pool/TEST8: START: obj_pool
  ./obj_pool$(nW) c $(nW)/testfile test 0 0640
-$(nW)/testfile: file size 16785408 mode 0640
+$(nW)/testfile: file size 8388608 mode 0640
 obj_pool/TEST8: Done

--- a/src/test/obj_store/TEST0
+++ b/src/test/obj_store/TEST0
@@ -46,6 +46,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 r
 
 rm -f $DIR/testfile1

--- a/src/test/obj_store/TEST1
+++ b/src/test/obj_store/TEST1
@@ -48,6 +48,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 a
 
 rm -f $DIR/testfile1

--- a/src/test/obj_store/TEST2
+++ b/src/test/obj_store/TEST2
@@ -47,6 +47,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 f
 
 rm -f $DIR/testfile1

--- a/src/test/obj_store/TEST3
+++ b/src/test/obj_store/TEST3
@@ -47,6 +47,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 u
 
 rm -f $DIR/testfile1

--- a/src/test/obj_store/TEST4
+++ b/src/test/obj_store/TEST4
@@ -48,6 +48,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 n
 
 rm -f $DIR/testfile1

--- a/src/test/obj_store/TEST5
+++ b/src/test/obj_store/TEST5
@@ -44,6 +44,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 4 $DIR/testfile1
+
 expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 s
 
 rm -f $DIR/testfile1

--- a/src/test/obj_tx_alloc/TEST0
+++ b/src/test/obj_tx_alloc/TEST0
@@ -44,6 +44,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 8 $DIR/testfile1
+
 expect_normal_exit ./obj_tx_alloc$EXESUFFIX $DIR/testfile1
 
 rm -f $DIR/testfile1

--- a/src/test/obj_tx_alloc/TEST1
+++ b/src/test/obj_tx_alloc/TEST1
@@ -47,6 +47,9 @@ require_valgrind_pmemcheck
 setup
 
 rm -f $DIR/testfile1
+
+create_nonzeroed_file 8 8 $DIR/testfile1
+
 expect_normal_exit valgrind --tool=pmemcheck\
 	--log-file=valgrind$UNITTEST_NUM.log\
 	--mult-stores=no\

--- a/src/test/obj_tx_alloc/valgrind1.log.match
+++ b/src/test/obj_tx_alloc/valgrind1.log.match
@@ -11,5 +11,7 @@
 ==$(nW)== Number of stores not made persistent: 0
 ==$(nW)== Number of stores not made persistent: 0
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== Number of stores not made persistent: 0
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_realloc/TEST0
+++ b/src/test/obj_tx_realloc/TEST0
@@ -44,6 +44,8 @@ setup
 
 rm -f $DIR/testfile1
 
+create_nonzeroed_file 8 8 $DIR/testfile1
+
 expect_normal_exit ./obj_tx_realloc$EXESUFFIX $DIR/testfile1
 
 rm -f $DIR/testfile1

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -169,7 +169,7 @@ do_tx_zrealloc_commit(PMEMobjpool *pop)
 	size_t new_size = 2 * old_size;
 
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
+		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
 			new_size, TYPE_COMMIT_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
@@ -203,7 +203,7 @@ do_tx_zrealloc_abort(PMEMobjpool *pop)
 	size_t new_size = 2 * old_size;
 
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
+		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
 			new_size, TYPE_ABORT_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
@@ -294,8 +294,8 @@ main(int argc, char *argv[])
 		FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
-	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, 0,
+				S_IWUSR | S_IRUSR)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_realloc_no_tx(pop);

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -136,6 +136,25 @@ function create_file() {
 }
 
 #
+# create_nonzeroed_file -- create non-zeroed files of a given length in megs
+#
+# A given first kilobytes of the file is zeroed out.
+#
+# example, to create two files, each 1GB in size, with first 4K zeroed
+#	create_file_rand 1024 4 testfile1 testfile2
+#
+function create_nonzeroed_file() {
+	offset=$2
+	size=$(($1 * 1024 - $offset))
+	shift 2
+	for file in $*
+	do
+		truncate -s ${offset}K $file
+		dd if=/dev/zero bs=1K count=${size} 2>/dev/null | tr '\0' '\132' >> $file
+	done
+}
+
+#
 # create_holey_file -- create holey files of a given length in megs
 #
 # example, to create two files, each 1GB in size:


### PR DESCRIPTION
This patch includes:
- Fixed allocation and reallocation of root object
- Unit tests improvements to cover zalloc/zrealloc path
- Improved generation of non-zeroed pool files