### PR TITLE
common: randomize pool mapping address

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -219,7 +219,17 @@ util_map(int fd, size_t len, int cow)
 
 	LOG(3, "fd %d len %zu cow %d", fd, len, cow);
 
+#ifndef DEBUG
+	/* try to randomize the mapping address */
+	off_t off = rand() % 16 * GIGABYTE;
+	void *addr = util_map_hint(len + off);
+	if (addr == NULL)
+		addr = util_map_hint(len);
+	else
+		addr += off;
+#else
 	void *addr = util_map_hint(len);
+#endif
 
 	if ((base = mmap(addr, len, PROT_READ|PROT_WRITE,
 			(cow) ? MAP_PRIVATE|MAP_NORESERVE : MAP_SHARED,

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -242,16 +242,16 @@ test_tx_api(PMEMobjpool *pop)
 }
 
 void
-test_open_close(PMEMobjpool *pop, const char *path)
+test_open_close(PMEMobjpool **pop, const char *path)
 {
 	PMEMoid oid;
-	pmemobj_alloc(pop, &oid, TEST_ALLOC_SIZE, 1, NULL, NULL);
+	pmemobj_alloc(*pop, &oid, TEST_ALLOC_SIZE, 1, NULL, NULL);
 
-	pmemobj_close(pop);
+	pmemobj_close(*pop);
 
 	ASSERT(pmemobj_check(path, POBJ_LAYOUT_NAME(basic)) == 1);
 
-	ASSERT((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(basic))) != NULL);
+	ASSERT((*pop = pmemobj_open(path, POBJ_LAYOUT_NAME(basic))) != NULL);
 
 	pmemobj_free(&oid);
 }
@@ -275,7 +275,7 @@ main(int argc, char *argv[])
 	test_alloc_api(pop);
 	test_list_api(pop);
 	test_tx_api(pop);
-	test_open_close(pop, path);
+	test_open_close(&pop, path);
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_store/obj_store_mocks.c
+++ b/src/test/obj_store/obj_store_mocks.c
@@ -71,7 +71,6 @@ FUNC_MOCK_RUN_DEFAULT {
 		(struct heap_header *)((uint64_t)pop + pop->heap_offset);
 	hheader->pop = (uint64_t)pop;
 	pop->heap = (struct pmalloc_heap *)hheader;
-	pop->uuid_lo = (uint64_t)pop;
 	return 0;
 }
 FUNC_MOCK_END

--- a/src/test/pmem_valgr_simple/valgrind0.log.match
+++ b/src/test/pmem_valgr_simple/valgrind0.log.match
@@ -8,7 +8,7 @@
 ==$(N)== Number of stores not made persistent: 3
 ==$(N)== Stores not made persistent properly:
 ==$(N)== [0]    at 0x$(nW): main (pmem_valgr_simple.c:64)
-==$(N)== 	Address: 0x$(N)	size: 4	state: DIRTY
+==$(N)== 	Address: 0x$(nW)	size: 4	state: DIRTY
 ==$(N)== [1]    at 0x$(nW): $(nW)memset ($(*))
 ==$(N)==    by 0x$(nW): main (pmem_valgr_simple.c:82)
 ==$(N)== 	Address: 0x$(nW)	size: 8	state: DIRTY


### PR DESCRIPTION
Recently, by accident, I discovered two bugs in our unit tests.

Basically, the problem is that in 99.999% cases, the pool file is mapped at the same address `0x10000000000`. So, closing and reopening the pool would likely return exactly the same pool handle, until... it doesn't. Then, if the program contains a bug similar to the one in *obj_basic_integration.c*, it would most likely crash. The pool data corruption is also possible.

For early detection of such issues, I'm proposing a very simple randomization of the pool mapping address. The only question is whether we want this feature to be enabled by default for all the builds, for debug/nondebug only, or configurable via some compilation flag, like `EXTRA_CFLAGS=-DUSE_ASLR` ;-).
In this patch, the randomization is enabled for nondebug builds only, as developers like the round address `0x10000000000` of the pool, which makes debugging easier.
