### PR TITLE
obj: rewrite allocator memory block handling

### DIFF
--- a/src/libpmemobj/bucket.h
+++ b/src/libpmemobj/bucket.h
@@ -43,12 +43,12 @@ int bucket_is_small(struct bucket *b);
 uint32_t bucket_calc_units(struct bucket *b, size_t size);
 size_t bucket_unit_size(struct bucket *b);
 size_t bucket_unit_max(struct bucket *b);
-int bucket_insert_block(struct bucket *b, uint32_t chunk_id, uint32_t zone_id,
-	uint32_t size_idx, uint16_t block_off);
-int bucket_get_rm_block_bestfit(struct bucket *b, uint32_t *chunk_id,
-	uint32_t *zone_id, uint32_t *size_idx, uint16_t *block_off);
-int bucket_get_rm_block_exact(struct bucket *b, uint32_t chunk_id,
-	uint32_t zone_id, uint32_t size_idx, uint16_t block_off);
+int bucket_insert_block(struct bucket *b, struct memory_block m);
+int bucket_get_rm_block_bestfit(struct bucket *b, struct memory_block *m);
+int bucket_get_rm_block_exact(struct bucket *b, struct memory_block m);
 int bucket_lock(struct bucket *b);
 int bucket_is_empty(struct bucket *b);
+int bucket_bitmap_nval(struct bucket *b);
+uint64_t bucket_bitmap_lastval(struct bucket *b);
+int bucket_bitmap_nallocs(struct bucket *b);
 void bucket_unlock(struct bucket *b);

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -37,7 +37,7 @@
 #define	HEAP_MAJOR 1
 #define	HEAP_MINOR 0
 
-#define	MAX_CHUNK UINT16_MAX
+#define	MAX_CHUNK (UINT16_MAX - 7) /* has to be multiple of 8 */
 #define	CHUNKSIZE (1024L * 256)	/* 256 kilobytes */
 #define	HEAP_SIGNATURE_LEN 16
 #define	HEAP_SIGNATURE "MEMORY_HEAP_HDR\0"
@@ -45,7 +45,7 @@
 #define	ZONE_MIN_SIZE (sizeof (struct zone) + CHUNKSIZE)
 #define	ZONE_MAX_SIZE (sizeof (struct zone) + MAX_CHUNK * CHUNKSIZE)
 #define	HEAP_MIN_SIZE (sizeof (struct heap_layout) + ZONE_MIN_SIZE)
-#define	REDO_LOG_SIZE	4
+#define	REDO_LOG_SIZE 4
 #define	BITS_PER_VALUE 64
 #define	MAX_BITMAP_VALUES 39 /* five cachelines - 8 bytes */
 #define	RUN_BITMAP_SIZE (BITS_PER_VALUE * MAX_BITMAP_VALUES)

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -82,6 +82,9 @@
 #define	OOB_OFFSET_OF(oid, field)\
 	((oid).off - OBJ_OOB_SIZE + offsetof(struct oob_header, field))
 
+#define	OBJ_STORE_ITEM_PADDING\
+	(_POBJ_CL_ALIGNMENT - (sizeof (struct list_head) % _POBJ_CL_ALIGNMENT))
+
 typedef void (*persist_fn)(void *, size_t);
 typedef void (*flush_fn)(void *, size_t);
 typedef void (*drain_fn)(void);
@@ -146,6 +149,7 @@ enum internal_type {
 /* single object store item */
 struct object_store_item {
 	struct list_head head;
+	uint8_t padding[OBJ_STORE_ITEM_PADDING];
 };
 
 struct object_store {

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -139,7 +139,8 @@ TEST = blk_nblock\
        obj_debug\
        obj_recovery\
        out_err\
-       out_err_mt
+       out_err_mt\
+       obj_pmalloc_mt
 
 all     : TARGET = all
 clean   : TARGET = clean

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -42,7 +42,7 @@
 #define	TEST_STR "abcdefgh"
 #define	TEST_STR_LEN 8
 #define	TEST_VALUE 5
-#define	TEST_ALLOC_SIZE 8000
+#define	TEST_ALLOC_SIZE 2048
 
 /*
  * Layout definition
@@ -226,8 +226,9 @@ test_tx_api(PMEMobjpool *pop)
 void
 test_open_close(PMEMobjpool *pop, const char *path)
 {
-	PMEMoid oid;
-	pmemobj_alloc(pop, &oid, TEST_ALLOC_SIZE, 1, NULL, NULL);
+	PMEMoid oid[TEST_ALLOC_SIZE];
+	for (int i = 0; i < TEST_ALLOC_SIZE; ++i)
+		pmemobj_alloc(pop, &oid[i], i, 0, NULL, NULL);
 
 	pmemobj_close(pop);
 
@@ -235,7 +236,8 @@ test_open_close(PMEMobjpool *pop, const char *path)
 
 	ASSERT((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(basic))) != NULL);
 
-	pmemobj_free(&oid);
+	for (int i = 0; i < TEST_ALLOC_SIZE; ++i)
+		pmemobj_free(&oid[i]);
 }
 
 int

--- a/src/test/obj_ctree/obj_ctree.c
+++ b/src/test/obj_ctree/obj_ctree.c
@@ -72,7 +72,7 @@ FUNC_MOCK(pthread_mutex_lock, int, pthread_mutex_t *mutex)
 {
 	FUNC_MOCK_RUN_RET_DEFAULT_REAL(pthread_mutex_lock, mutex)
 	FUNC_MOCK_RUN(TEST_REMOVE + 0)
-	FUNC_MOCK_RUN(TEST_INSERT + 0) {
+	FUNC_MOCK_RUN(TEST_INSERT + 1) {
 		return -1;
 	}
 } FUNC_MOCK_END

--- a/src/test/obj_pmalloc_mt/.gitignore
+++ b/src/test/obj_pmalloc_mt/.gitignore
@@ -1,0 +1,1 @@
+obj_pmalloc_mt

--- a/src/test/obj_pmalloc_mt/Makefile
+++ b/src/test/obj_pmalloc_mt/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pmalloc_mt/Makefile -- build obj_pmalloc_mt unit test
+#
+vpath %.c ../../libpmemobj
+vpath %.c ../../common
+
+TARGET = obj_pmalloc_mt
+OBJS = obj_pmalloc_mt.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
+    util.o out.o obj.o cuckoo.o list.o sync.o tx.o libpmemobj.o
+
+LIBPMEM=y
+
+out.o: CFLAGS += -DSRCVERSION=\"utversion\"
+
+include ../Makefile.inc
+
+INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_pmalloc_mt/TEST0 -- multithreaded allocator test
+#
+export UNITTEST_NAME=obj_pmalloc_mt/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_valgrind_dev_3_10
+require_fs_type pmem non-pmem
+require_test_type long
+
+setup
+
+rm -f $DIR/testfile
+
+expect_normal_exit\
+	PMEM_IS_PMEM_FORCE=1\
+	valgrind --tool=helgrind\
+	--log-file=valgrind$UNITTEST_NUM.log\
+	./obj_pmalloc_mt$EXESUFFIX\ $DIR/testfile
+
+rm -f $DIR/testfile
+
+check
+
+pass

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_pmalloc_mt.c -- multithreaded test of allocator
+ */
+#include <stdint.h>
+
+#include "libpmemobj.h"
+#include "pmalloc.h"
+#include "unittest.h"
+
+#define	THREADS 32
+#define	OPS_PER_THREAD 1000
+#define	ALLOC_SIZE 350
+#define	REALLOC_SIZE (ALLOC_SIZE * 3)
+#define	FRAGMENTATION 3
+
+struct root {
+	uint64_t offs[THREADS][OPS_PER_THREAD];
+};
+
+struct worker_args {
+	PMEMobjpool *pop;
+	struct root *r;
+	int idx;
+};
+
+void *
+alloc_worker(void *arg)
+{
+	struct worker_args *a = arg;
+
+	for (int i = 0; i < OPS_PER_THREAD; ++i) {
+		pmalloc(a->pop, &a->r->offs[a->idx][i], ALLOC_SIZE);
+		ASSERTne(a->r->offs[a->idx][i], 0);
+	}
+
+	return NULL;
+}
+
+void *
+realloc_worker(void *arg)
+{
+	struct worker_args *a = arg;
+
+	for (int i = 0; i < OPS_PER_THREAD; ++i) {
+		prealloc(a->pop, &a->r->offs[a->idx][i], REALLOC_SIZE);
+		ASSERTne(a->r->offs[a->idx][i], 0);
+	}
+
+	return NULL;
+}
+
+void *
+free_worker(void *arg)
+{
+	struct worker_args *a = arg;
+
+	for (int i = 0; i < OPS_PER_THREAD; ++i) {
+		pfree(a->pop, &a->r->offs[a->idx][i]);
+		ASSERTeq(a->r->offs[a->idx][i], 0);
+	}
+
+	return NULL;
+}
+
+void
+run_worker(void *(worker_func)(void *arg), struct worker_args args[])
+{
+	pthread_t t[THREADS];
+
+	for (int i = 0; i < THREADS; ++i)
+		pthread_create(&t[i], NULL, worker_func, &args[i]);
+
+	for (int i = 0; i < THREADS; ++i)
+		pthread_join(t[i], NULL);
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_pmalloc_mt");
+
+	if (argc != 2)
+		FATAL("usage: %s [file]", argv[0]);
+
+	PMEMobjpool *pop = pmemobj_create(argv[1], "TEST",
+		THREADS * OPS_PER_THREAD * ALLOC_SIZE * FRAGMENTATION, 0666);
+
+	if (pop == NULL)
+		FATAL("!pmemobj_create");
+
+	PMEMoid oid = pmemobj_root(pop, sizeof (struct root));
+	struct root *r = pmemobj_direct(oid);
+	ASSERTne(r, NULL);
+
+	struct worker_args args[THREADS];
+
+	for (int i = 0; i < THREADS; ++i) {
+		args[i].pop = pop;
+		args[i].r = r;
+		args[i].idx = i;
+	}
+
+	pmalloc(pop, &r->offs[0][0], 1);
+	pfree(pop, &r->offs[0][0]);
+
+	run_worker(alloc_worker, args);
+	run_worker(realloc_worker, args);
+	run_worker(free_worker, args);
+
+	DONE(NULL);
+}

--- a/src/test/obj_pmalloc_mt/valgrind0.log.match
+++ b/src/test/obj_pmalloc_mt/valgrind0.log.match
@@ -1,0 +1,11 @@
+==$(nW)== Helgrind, a thread error detector
+==$(nW)== Copyright (C) $(nW), and GNU GPL'd, by OpenWorks LLP et al.
+==$(nW)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(nW)== Command: ./obj_pmalloc_mt$(nW) $(nW)
+==$(nW)== Parent PID: $(nW)
+==$(nW)== 
+==$(nW)== 
+==$(nW)== For counts of detected and suppressed errors, rerun with: -v
+==$(nW)== Use --history-level=approx or =none to gain increased speed, at
+==$(nW)== the cost of reduced accuracy of conflicting-access information
+==$(nW)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(nW) from $(nW))


### PR DESCRIPTION
Memory block heap operations are now unified regardless of their type,
this enables a simple and efficient implementation of realloc and
simplifies other operations. This patch also addresses issues related
to persistent/volatile heap state mismatch, which, combined with small
ctree optimization, significantly improves allocation performance.