### PR TITLE
common: clean up libraries internal data after main

### DIFF
--- a/src/libpmem/libpmem.c
+++ b/src/libpmem/libpmem.c
@@ -59,6 +59,18 @@ libpmem_init(void)
 }
 
 /*
+ * libpmem_fini -- libpmem cleanup routine
+ *
+ * Called automatically when the process terminates.
+ */
+__attribute__((destructor))
+static void
+libpmem_fini(void)
+{
+	out_fini();
+}
+
+/*
  * pmem_check_version -- see if library meets application version requirements
  */
 const char *

--- a/src/libpmemblk/libpmemblk.c
+++ b/src/libpmemblk/libpmemblk.c
@@ -60,6 +60,18 @@ libpmemblk_init(void)
 }
 
 /*
+ * libpmemblk_fini -- libpmemblk cleanup routine
+ *
+ * Called automatically when the process terminates.
+ */
+__attribute__((destructor))
+static void
+libpmemblk_fini(void)
+{
+	out_fini();
+}
+
+/*
  * pmemblk_check_version -- see if lib meets application version requirements
  */
 const char *

--- a/src/libpmemlog/libpmemlog.c
+++ b/src/libpmemlog/libpmemlog.c
@@ -60,6 +60,18 @@ libpmemlog_init(void)
 }
 
 /*
+ * libpmemlog_fini -- libpmemlog cleanup routine
+ *
+ * Called automatically when the process terminates.
+ */
+__attribute__((destructor))
+static void
+libpmemlog_fini(void)
+{
+	out_fini();
+}
+
+/*
  * pmemlog_check_version -- see if lib meets application version requirements
  */
 const char *

--- a/src/libpmemobj/libpmemobj.c
+++ b/src/libpmemobj/libpmemobj.c
@@ -65,6 +65,19 @@ libpmemobj_init(void)
 }
 
 /*
+ * libpmemobj_fini -- libpmemobj cleanup routine
+ *
+ * Called automatically when the process terminates.
+ */
+__attribute__((destructor))
+static void
+libpmemobj_fini(void)
+{
+	obj_fini();
+	out_fini();
+}
+
+/*
  * pmemobj_check_version -- see if lib meets application version requirements
  */
 const char *

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -75,6 +75,17 @@ obj_init(void)
 }
 
 /*
+ * obj_fini -- cleanup of obj
+ *
+ * Called by destructor.
+ */
+void
+obj_fini(void)
+{
+	cuckoo_delete(pools);
+}
+
+/*
  * drain_empty -- (internal) empty function for drain on non-pmem memory
  */
 static void

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -197,3 +197,4 @@ oob_list_last(PMEMobjpool *pop, struct list_head *head)
 }
 
 void obj_init(void);
+void obj_fini(void);

--- a/src/libvmem/vmem.c
+++ b/src/libvmem/vmem.c
@@ -131,6 +131,18 @@ vmem_construct(void)
 }
 
 /*
+ * vmem_fini -- libvmem cleanup routine
+ *
+ * Called automatically when the process terminates.
+ */
+__attribute__((destructor))
+static void
+vmem_fini(void)
+{
+	out_fini();
+}
+
+/*
  * vmem_create -- create a memory pool in a temp file
  */
 VMEM *

--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -668,4 +668,5 @@ libvmmalloc_fini(void)
 	je_vmem_pool_malloc_stats_print(
 		(pool_t *)((uintptr_t)Vmp + Header_size),
 		print_jemalloc_stats, NULL, "gba");
+	out_fini();
 }


### PR DESCRIPTION
Plugs memory leaks found by valgrind/memcheck.