### PR TITLE
obj: rename USE_VALGRIND to USE_VG_PMEMCHECK

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ run different types of tests.
 
 To compile this library with enabled support for the PM-aware version
 of [Valgrind](https://github.com/pmem/valgrind), supply the compiler
-with the **USE_VALGRIND** flag, for example:
+with the **USE_VG_PMEMCHECK** flag, for example:
 ```
-	$ make EXTRA_CFLAGS=-DUSE_VALGRIND
+	$ make EXTRA_CFLAGS=-DUSE_VG_PMEMCHECK
 ```
 
 

--- a/src/common/out.c
+++ b/src/common/out.c
@@ -47,6 +47,7 @@
 #include "libvmem.h"
 
 #include "out.h"
+#include "valgrind_internal.h"
 
 char nvml_src_version[] = "SRCVERSION:" SRCVERSION;
 
@@ -140,9 +141,9 @@ out_init(const char *log_prefix, const char *log_level_var,
 	LOG(1, "pid %d: program: %s", getpid(), getexecname());
 	LOG(1, "%s version %d.%d", log_prefix, major_version, minor_version);
 	LOG(1, "src version %s", nvml_src_version);
-#ifdef USE_VALGRIND
-	LOG(1, "compiled with support for Valgrind");
-#endif /* USE_VALGRIND */
+#ifdef USE_VG_PMEMCHECK
+	LOG(1, "compiled with support for Valgrind pmemcheck");
+#endif /* USE_VG_PMEMCHECK */
 }
 
 /*

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -49,10 +49,8 @@
 #include <stddef.h>
 #include <elf.h>
 #include <link.h>
-#ifdef USE_VALGRIND
-#include <valgrind/valgrind.h>
-#endif
 
+#include "valgrind_internal.h"
 #include "util.h"
 #include "out.h"
 
@@ -92,7 +90,7 @@ Free_func Free = free;
 Realloc_func Realloc = realloc;
 Strdup_func Strdup = strdup;
 
-#ifdef USE_VALGRIND
+#if defined(USE_VG_PMEMCHECK)
 /* initialized to true if the process is running inside Valgrind */
 int On_valgrind;
 #endif
@@ -109,7 +107,7 @@ util_init(void)
 	if (Pagesize == 0)
 		Pagesize = (unsigned long) sysconf(_SC_PAGESIZE);
 
-#ifdef USE_VALGRIND
+#if defined(USE_VG_PMEMCHECK)
 	On_valgrind = RUNNING_ON_VALGRIND;
 #endif
 }

--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -35,10 +35,17 @@
  */
 
 #ifdef USE_VALGRIND
+#define	USE_VG_PMEMCHECK
+#endif
+
+#if defined(USE_VG_PMEMCHECK)
+extern int On_valgrind;
+#include <valgrind/valgrind.h>
+#endif
+
+#ifdef USE_VG_PMEMCHECK
 
 #include <valgrind/pmemcheck.h>
-
-extern int On_valgrind;
 
 #define	VALGRIND_REGISTER_PMEM_MAPPING(addr, len) do {\
 	if (On_valgrind)\

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -264,7 +264,7 @@ tx_clear_undo_log(PMEMobjpool *pop, struct list_head *head)
 	while (!OBJ_LIST_EMPTY(head)) {
 		obj = head->pe_first;
 
-#ifdef USE_VALGRIND
+#ifdef USE_VG_PMEMCHECK
 		struct oob_header *oobh = OOB_HEADER_FROM_OID(pop, obj);
 		size_t size = pmalloc_usable_size(pop,
 				obj.off - OBJ_OOB_SIZE);
@@ -1398,7 +1398,7 @@ pmemobj_tx_free(PMEMoid oid)
 				&layout->undo_free, oid);
 	} else {
 		ASSERTeq(oobh->internal_type, TYPE_NONE);
-#ifdef USE_VALGRIND
+#ifdef USE_VG_PMEMCHECK
 		size_t size = pmalloc_usable_size(lane->pop,
 				oid.off - OBJ_OOB_SIZE);
 

--- a/src/test/arch_flags/log0.log.match
+++ b/src/test/arch_flags/log0.log.match
@@ -1,7 +1,7 @@
 <arch_flags>: <1> [$(nW) out_init] pid $(nW): program: $(nW)
 <arch_flags>: <1> [$(nW) out_init] arch_flags version 0.0
 <arch_flags>: <1> [$(nW) out_init] src version SRCVERSION:utversion
-$(OPT)<arch_flags>: <1> [$(nW) out_init] compiled with support for Valgrind
+$(OPT)<arch_flags>: <1> [$(nW) out_init] compiled with support for Valgrind pmemcheck
 <arch_flags>: <1> [$(nW) util_get_arch_flags] open /proc/self/exe: $(*)
 <arch_flags>: <1> [$(nW) util_get_arch_flags] read /proc/self/exe: $(*)
 <arch_flags>: <1> [$(nW) util_get_arch_flags] invalid ELF magic

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -1,7 +1,7 @@
 <trace>: <1> [../../common/out.c:$(N) out_init] pid $(N): program: $(nW)
 <trace>: <1> [../../common/out.c:$(N) out_init] trace version 1.0
 <trace>: <1> [../../common/out.c:$(N) out_init] src version SRCVERSION:utversion
-$(OPT)<trace>: <1> [../../common/out.c:$(N) out_init] compiled with support for Valgrind
+$(OPT)<trace>: <1> [../../common/out.c:$(N) out_init] compiled with support for Valgrind pmemcheck
 <trace>: <1> [out_err.c:$(N) main] ERR #1
 <trace>: <1> [out_err.c:$(N) main] ERR #2: Success
 <trace>: <1> [out_err.c:$(N) main] ERR #3: Invalid argument

--- a/src/test/traces_custom_function/out0.log.match
+++ b/src/test/traces_custom_function/out0.log.match
@@ -6,7 +6,7 @@ CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] trace_func version $(S)
 
 CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] src version SRCVERSION:utversion
 
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] compiled with support for Valgrind
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] compiled with support for Valgrind pmemcheck
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <0> [$(nW):$(N) main] Log level NONE
 

--- a/src/test/traces_custom_function/out1.log.match
+++ b/src/test/traces_custom_function/out1.log.match
@@ -6,7 +6,7 @@ CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] trace_func version $(S)
 
 CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] src version SRCVERSION:utversion
 
-$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] compiled with support for Valgrind
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init] compiled with support for Valgrind pmemcheck
 $(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) out_set_vsnprintf_func] vsnprintf 0x$(X)
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -283,9 +283,9 @@ function require_valgrind_pmemcheck() {
 	local binary=$1
 	[ -n "$binary" ] || binary=*
         strings ${binary}.static-debug 2>&1 | \
-            grep -q "compiled with support for Valgrind" && true
+            grep -q "compiled with support for Valgrind pmemcheck" && true
         if [ $? -ne 0 ]; then
-            echo "$UNITTEST_NAME: SKIP not compiled with support for Valgrind"
+            echo "$UNITTEST_NAME: SKIP not compiled with support for Valgrind pmemcheck"
             exit 0
         fi
 


### PR DESCRIPTION
... in preparation for memcheck support

USE_VALGRIND will be a shortcut for both.