### PR TITLE
obj: fix libpmemobj linker map file

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -780,7 +780,7 @@ void pmemobj_tx_end();
 /*
  * Performs the actions associated with current stage of the transaction,
  * and makes the transition to the next stage. Current stage must always
- * be obtained by calling pmemobj_tx_get_stage.
+ * be obtained by calling pmemobj_tx_stage.
  *
  * If successful, function returns zero. Otherwise, an error number is returned.
  */

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -64,7 +64,7 @@ libpmemobj.so {
 		pmemobj_zalloc;
 		pmemobj_realloc;
 		pmemobj_zrealloc;
-		pmemobj_strndup;
+		pmemobj_strdup;
 		pmemobj_free;
 		pmemobj_alloc_usable_size;
 		pmemobj_type_num;

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -44,6 +44,7 @@ pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
 pmemobj_rwlock_zero
 pmemobj_set_funcs
+pmemobj_strdup
 pmemobj_tx_abort
 pmemobj_tx_add_range
 pmemobj_tx_add_range_direct
@@ -106,6 +107,7 @@ pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
 pmemobj_rwlock_zero
 pmemobj_set_funcs
+pmemobj_strdup
 pmemobj_tx_abort
 pmemobj_tx_add_range
 pmemobj_tx_add_range_direct
@@ -168,6 +170,7 @@ pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
 pmemobj_rwlock_zero
 pmemobj_set_funcs
+pmemobj_strdup
 pmemobj_tx_abort
 pmemobj_tx_add_range
 pmemobj_tx_add_range_direct
@@ -230,6 +233,7 @@ pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
 pmemobj_rwlock_zero
 pmemobj_set_funcs
+pmemobj_strdup
 pmemobj_tx_abort
 pmemobj_tx_add_range
 pmemobj_tx_add_range_direct


### PR DESCRIPTION
- change strndup to strdup in linker map file
- fix comment in libpmemobj header

Ref: pmem/issues#89