### PR TITLE
obj: implement optimized version of pmemobj_direct

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -143,6 +143,7 @@ libpmemobj \- persistent memory transactional object store
 .BI "    unsigned int " type_num );
 .BI "void pmemobj_free(PMEMoid *" oidp );
 .BI "size_t pmemobj_alloc_usable_size(PMEMoid " oid );
+.BI "PMEMobjpool *pmemobj_pool(PMEMoid " oid );
 .BI "void *pmemobj_direct(PMEMoid " oid );
 .BI "unsigned int pmemobj_type_num(PMEMoid " oid );
 .sp
@@ -987,6 +988,15 @@ The
 function returns a pointer to an object represented by
 .IR oid .
 If OID_NULL is passed as an argument, function returns NULL.
+.PP
+.BI "PMEMobjpool *pmemobj_pool(PMEMoid " oid );
+.IP
+The
+.BR pmemobj_pool ()
+function returns a handle to the pool which contains the object represented by
+.IR oid .
+If the pool is not open or OID_NULL is passed as an argument, function
+returns NULL.
 .PP
 At the time of allocation (or reallocation), each object may be assigned
 a number representing its type.  Such a

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -59,6 +59,7 @@ libpmemobj.so {
 		pmemobj_cond_signal;
 		pmemobj_cond_timedwait;
 		pmemobj_cond_wait;
+		pmemobj_pool;
 		pmemobj_direct;
 		pmemobj_alloc;
 		pmemobj_zalloc;
@@ -95,6 +96,7 @@ libpmemobj.so {
 		pmemobj_persist;
 		pmemobj_flush;
 		pmemobj_drain;
+		_pobj_cached_pool;
 		_pobj_debug_notice;
 	local:
 		*;

--- a/src/test/obj_direct/obj_direct.c
+++ b/src/test/obj_direct/obj_direct.c
@@ -93,7 +93,6 @@ main(int argc, char *argv[])
 		ASSERTeq(pmemobj_direct(tmpoids[i]), NULL);
 
 		pmemobj_close(pops[i]);
-
 		ASSERTeq(pmemobj_direct(oids[i]), NULL);
 	}
 

--- a/src/test/scope/TEST4
+++ b/src/test/scope/TEST4
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ parse_lib() {
 	local lib_path=$1
 	echo "$lib_path:" >> out$UNITTEST_NUM.log
 	(nm -g $lib_path |\
-		perl -ne 'print if s/^[0-9a-z]+ T (\w+)/$1/' |\
+		perl -ne 'print if s/^[0-9a-z]+ [TB] (\w+)/$1/' |\
 		sort >> out$UNITTEST_NUM.log) 2>&1
 
 }

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -1,5 +1,6 @@
 scope/TEST4:
 $(*)debug/libpmemobj.so:
+_pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc
 pmemobj_alloc_usable_size
@@ -13,7 +14,6 @@ pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
 pmemobj_create_part
-pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -32,6 +32,7 @@ pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
+pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
@@ -63,6 +64,7 @@ pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)nondebug/libpmemobj.so:
+_pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc
 pmemobj_alloc_usable_size
@@ -76,7 +78,6 @@ pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
 pmemobj_create_part
-pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -95,6 +96,7 @@ pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
+pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
@@ -126,6 +128,7 @@ pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)debug/libpmemobj.a:
+_pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc
 pmemobj_alloc_usable_size
@@ -139,7 +142,6 @@ pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
 pmemobj_create_part
-pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -158,6 +160,7 @@ pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
+pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
@@ -189,6 +192,7 @@ pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)nondebug/libpmemobj.a:
+_pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc
 pmemobj_alloc_usable_size
@@ -202,7 +206,6 @@ pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
 pmemobj_create_part
-pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -221,6 +224,7 @@ pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
+pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size


### PR DESCRIPTION
Right now each D_* macro invocation used for ptr dereferencing calls
a function that then performs a lookup in a hashtable - which had a
considerable performance impact on many workloads. This patch adds
a global per-thread variable that serves as a pool ptr cache. Quick
measurements show over 2x improvement.