### PR TITLE
obj: fix race condition during small allocations

### DIFF
--- a/src/libpmemobj/bucket.c
+++ b/src/libpmemobj/bucket.c
@@ -272,7 +272,7 @@ bucket_is_empty(struct bucket *b)
 int
 bucket_lock(struct bucket *b)
 {
-	return bucket_is_small(b) ? 0 : pthread_mutex_lock(&b->lock);
+	return pthread_mutex_lock(&b->lock);
 }
 
 /*
@@ -281,9 +281,6 @@ bucket_lock(struct bucket *b)
 void
 bucket_unlock(struct bucket *b)
 {
-	if (bucket_is_small(b))
-		return;
-
 	if ((errno = pthread_mutex_unlock(&b->lock)) != 0)
 		ERR("!pthread_mutex_unlock");
 }

--- a/src/test/obj_bucket/obj_bucket.c
+++ b/src/test/obj_bucket/obj_bucket.c
@@ -68,14 +68,6 @@ FUNC_MOCK(pthread_mutex_init, int,
 	}
 } FUNC_MOCK_END
 
-FUNC_MOCK(pthread_mutex_lock, int, pthread_mutex_t *mutex)
-{
-	FUNC_MOCK_RUN_RET_DEFAULT_REAL(pthread_mutex_lock, mutex)
-	FUNC_MOCK_RUN(0) {
-		return -1;
-	}
-} FUNC_MOCK_END
-
 FUNC_MOCK(ctree_new, struct ctree *, void)
 {
 	FUNC_MOCK_RUN_RET_DEFAULT(MOCK_CRIT)


### PR DESCRIPTION
When multiple threads currently try to allocate from a single bucket
that has only one memory block available, an OOM error may occur.
This patch forces the threads to lock before determining whether the
bucket can satisfy the allocation request or not.