### PR TITLE
common: fix check_whitespace script

### DIFF
--- a/utils/check_whitespace
+++ b/utils/check_whitespace
@@ -100,7 +100,9 @@ find(sub {
 		if ($full eq './.git' ||
 		    $full eq './src/jemalloc' ||
 		    $full eq './src/debug' ||
-		    $full eq './src/nondebug') {
+		    $full eq './src/nondebug' ||
+		    $full eq './rpmbuild' ||
+		    $full eq './dpkgbuild') {
 			$File::Find::prune = 1;
 			return;
 		}


### PR DESCRIPTION
Ignore rpmbuild and dpkgbuild directories in in check_whitespace
script.