### PR TITLE
obj: add pmemcheck transactions support

### DIFF
--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -148,28 +148,95 @@ extern int On_valgrind;
 		VALGRIND_PMC_STOP_REORDER_FAULT;\
 } while (0)
 
+#define	VALGRIND_START_TX do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_START_TX;\
+} while (0)
+
+#define	VALGRIND_START_TX_N(txn) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_START_TX_N(txn);\
+} while (0)
+
+#define	VALGRIND_END_TX do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_END_TX;\
+} while (0)
+
+#define	VALGRIND_END_TX_N(txn) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_END_TX_N(txn);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_TX(addr, len) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_ADD_TO_TX(addr, len);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_TX_N(txn, addr, len) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_ADD_TO_TX_N(txn, addr, len);\
+} while (0)
+
+#define	VALGRIND_REMOVE_FROM_TX(addr, len) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_REMOVE_FROM_TX(addr, len);\
+} while (0)
+
+#define	VALGRIND_REMOVE_FROM_TX_N(txn, addr, len) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_REMOVE_FROM_TX_N(txn, addr, len);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE(addr, len) do {\
+	if (On_valgrind)\
+		VALGRIND_PMC_ADD_TO_GLOBAL_TX_IGNORE(addr, len);\
+} while (0)
+
 #else
 
-#define	VALGRIND_REGISTER_PMEM_MAPPING(addr, len) do {} while (0)
+#define	VALGRIND_REGISTER_PMEM_MAPPING(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
-#define	VALGRIND_REGISTER_PMEM_FILE(desc, base_addr, size, offset)\
-	do {} while (0)
+#define	VALGRIND_REGISTER_PMEM_FILE(desc, base_addr, size, offset) do {\
+	(void) (desc);\
+	(void) (base_addr);\
+	(void) (size);\
+	(void) (offset);\
+} while (0)
 
-#define	VALGRIND_REMOVE_PMEM_MAPPING(addr, len) do {} while (0)
+#define	VALGRIND_REMOVE_PMEM_MAPPING(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
-#define	VALGRIND_CHECK_IS_PMEM_MAPPING(addr, len) do {} while (0)
+#define	VALGRIND_CHECK_IS_PMEM_MAPPING(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
 #define	VALGRIND_PRINT_PMEM_MAPPINGS do {} while (0)
 
-#define	VALGRIND_DO_FLUSH(addr, len) do {} while (0)
+#define	VALGRIND_DO_FLUSH(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
 #define	VALGRIND_DO_FENCE do {} while (0)
 
 #define	VALGRIND_DO_COMMIT do {} while (0)
 
-#define	VALGRIND_DO_PERSIST(addr, len) do {} while (0)
+#define	VALGRIND_DO_PERSIST(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
-#define	VALGRIND_SET_CLEAN(addr, len) do {} while (0)
+#define	VALGRIND_SET_CLEAN(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
 #define	VALGRIND_WRITE_STATS do {} while (0)
 
@@ -177,9 +244,15 @@ extern int On_valgrind;
 
 #define	VALGRIND_NO_LOG_STORES do {} while (0)
 
-#define	VALGRIND_ADD_LOG_REGION(addr, len) do {} while (0)
+#define	VALGRIND_ADD_LOG_REGION(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
-#define	VALGRIND_REMOVE_LOG_REGION(addr, len) do {} while (0)
+#define	VALGRIND_REMOVE_LOG_REGION(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
 #define	VALGRIND_FULL_REORDER do {} while (0)
 
@@ -188,5 +261,42 @@ extern int On_valgrind;
 #define	VALGRIND_ONLY_FAULT do {} while (0)
 
 #define	VALGRIND_STOP_REORDER_FAULT do {} while (0)
+
+#define	VALGRIND_START_TX do {} while (0)
+
+#define	VALGRIND_START_TX_N(txn) do {} while (0)
+
+#define	VALGRIND_END_TX do {} while (0)
+
+#define	VALGRIND_END_TX_N(txn) do {\
+	(void) (txn);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_TX(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_TX_N(txn, addr, len) do {\
+	(void) (txn);\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
+
+#define	VALGRIND_REMOVE_FROM_TX(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
+
+#define	VALGRIND_REMOVE_FROM_TX_N(txn, addr, len) do {\
+	(void) (txn);\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
+
+#define	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE(addr, len) do {\
+	(void) (addr);\
+	(void) (len);\
+} while (0)
 
 #endif

--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -52,6 +52,7 @@
 #include "redo.h"
 #include "list.h"
 #include "obj.h"
+#include "valgrind_internal.h"
 
 static __thread int lane_idx = -1;
 static int next_lane_idx = 0;
@@ -175,6 +176,9 @@ lane_boot(PMEMobjpool *pop)
 		goto error_lanes_malloc;
 	}
 
+	/* add lanes to pmemcheck ignored list */
+	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE((void *)pop + pop->lanes_offset,
+		(sizeof (struct lane_layout) * pop->nlanes));
 	int i;
 	for (i = 0; i < pop->nlanes; ++i) {
 		struct lane_layout *layout = lane_get_layout(pop, i);

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -61,8 +61,11 @@
 #define	OBJ_OID_IS_NULL(oid)	((oid).off == 0)
 #define	OBJ_LIST_EMPTY(head)	OBJ_OID_IS_NULL((head)->pe_first)
 #define	OBJ_PTR_IS_VALID(pop, ptr)\
-	(OBJ_PTR_TO_OFF(pop, ptr) >= (pop)->heap_offset &&\
-	OBJ_PTR_TO_OFF(pop, ptr) < (pop)->heap_offset + (pop)->heap_size)
+	((OBJ_PTR_TO_OFF(pop, ptr) >= (pop)->heap_offset &&\
+	OBJ_PTR_TO_OFF(pop, ptr) < (pop)->heap_offset + (pop)->heap_size) ||\
+	((OBJ_PTR_TO_OFF(pop, ptr) >= (pop)->obj_store_offset &&\
+	OBJ_PTR_TO_OFF(pop, ptr) < (pop)->obj_store_offset +\
+	(pop)->obj_store_size)))
 
 #define	OBJ_OID_IS_VALID(pop, oid) (\
 	{\

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -52,6 +52,7 @@
 #include "bucket.h"
 #include "heap_layout.h"
 #include "out.h"
+#include "valgrind_internal.h"
 
 enum alloc_op_redo {
 	ALLOC_OP_REDO_PTR_OFFSET,
@@ -67,10 +68,11 @@ void
 alloc_write_header(PMEMobjpool *pop, struct allocation_header *alloc,
 	uint32_t chunk_id, uint32_t zone_id, uint64_t size)
 {
+	VALGRIND_ADD_TO_TX(alloc, sizeof (*alloc));
 	alloc->chunk_id = chunk_id;
 	alloc->size = size;
 	alloc->zone_id = zone_id;
-
+	VALGRIND_REMOVE_FROM_TX(alloc, sizeof (*alloc));
 	pop->persist(alloc, sizeof (*alloc));
 }
 
@@ -331,7 +333,6 @@ error:
 
 	return err;
 }
-
 
 /*
  * pmalloc_usable_size -- returns the number of bytes in the memory block

--- a/src/test/obj_basic_integration/TEST1
+++ b/src/test/obj_basic_integration/TEST1
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 #
 # Copyright (c) 2015, Intel Corporation
 #
@@ -30,21 +31,19 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-#
-# src/test/obj_list/Makefile -- build obj_list test
-#
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+export UNITTEST_NAME=obj_basic_integration/TEST1
+export UNITTEST_NUM=1
 
-TARGET = obj_list
-OBJS = obj_list.o list.o redo.o util.o out.o lane.o
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBPMEM=y
+require_valgrind_pmemcheck
 
-include ../Makefile.inc
-CFLAGS += -g -DDEBUG
-LDFLAGS += $(call extract_funcs, obj_list.c)
-INCS += -I../../libpmemobj/ -I../../common/
+setup
 
-obj_list.o: obj_list.c
-out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+expect_normal_exit\
+    valgrind --tool=pmemcheck\
+    --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_basic_integration$EXESUFFIX $DIR/testfile1
+
+pass

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -240,6 +240,7 @@ test_tx_api(PMEMobjpool *pop)
 	ASSERTeq(D_RW(root)->value, TEST_VALUE);
 
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
+		TX_ADD(root);
 		ASSERT(!TOID_IS_NULL(D_RW(root)->node));
 		TX_FREE(D_RW(root)->node);
 		D_RW(root)->node = TOID_NULL(struct dummy_node);

--- a/src/test/obj_basic_integration/valgrind1.log.match
+++ b/src/test/obj_basic_integration/valgrind1.log.match
@@ -1,0 +1,8 @@
+==$(nW)== pmemcheck-$(nW), a simple persistent store checker
+==$(nW)== Copyright (c) $(nW), Intel Corporation
+==$(nW)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(nW)== Command: ./obj_basic_integration$(nW) $(nW)testfile1
+==$(nW)== Parent PID: $(nW)
+==$(nW)== 
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_debug/README
+++ b/src/test/obj_debug/README
@@ -26,3 +26,5 @@ The following characters and operations can be used:
 		- pmemobj_list_remove
 	r - tests notice messages for the function:
 		- pmemobj_tx_add_common
+	a - tests notice of atomic allocation in tx:
+		- pmemobj_alloc

--- a/src/test/obj_debug/TEST3
+++ b/src/test/obj_debug/TEST3
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 #
 # Copyright (c) 2015, Intel Corporation
 #
@@ -31,20 +32,26 @@
 #
 
 #
-# src/test/obj_list/Makefile -- build obj_list test
+# src/test/obj_debug/TEST3 -- unit test for debug features
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+export UNITTEST_NAME=obj_debug/TEST3
+export UNITTEST_NUM=3
 
-TARGET = obj_list
-OBJS = obj_list.o list.o redo.o util.o out.o lane.o
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBPMEM=y
+require_build_type debug
+require_valgrind_pmemcheck
 
-include ../Makefile.inc
-CFLAGS += -g -DDEBUG
-LDFLAGS += $(call extract_funcs, obj_list.c)
-INCS += -I../../libpmemobj/ -I../../common/
+setup
 
-obj_list.o: obj_list.c
-out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+export PMEMOBJ_LOG_LEVEL=4
+expect_normal_exit valgrind --tool=pmemcheck\
+	--log-file=valgrind$UNITTEST_NUM.log\
+	./obj_debug$EXESUFFIX $DIR/testfile1 a
+
+grep "_pobj_debug_notice" ./pmemobj$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
+
+check
+
+pass

--- a/src/test/obj_debug/grep3.log.match
+++ b/src/test/obj_debug/grep3.log.match
@@ -1,0 +1,1 @@
+<libpmemobj>: <$(N)> [obj.c:$(N) _pobj_debug_notice] Notice: non-transactional API used inside a transaction (pmemobj_alloc)

--- a/src/test/obj_debug/valgrind3.log.match
+++ b/src/test/obj_debug/valgrind3.log.match
@@ -1,0 +1,54 @@
+==$(N)== pmemcheck-$(nW), a simple persistent store checker
+==$(N)== Copyright (c) 2014-2015, Intel Corporation
+==$(N)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(N)== Command: ./obj_debug$(nW) $(nW)testfile1 a
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== Number of stores not made persistent: 0
+==$(N)== 
+==$(N)== Number of stores made outside of transactions: 5
+==$(N)== Stores made outside of transactions:
+==$(N)== [0]    at 0x$(nW): constructor_alloc_bytype (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmalloc_construct (pmalloc.c:$(N))
+==$(N)==    by 0x$(nW): list_insert_new (list.c:$(N))
+==$(N)==    by 0x$(nW): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmemobj_alloc (obj.c:$(N))
+==$(N)==    by 0x$(nW): test_alloc_construct (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): main (obj_debug.c:$(N))
+==$(N)== 	Address: 0x$(nW)	size: $(N)
+==$(N)== [1]    at 0x$(nW): constructor_alloc_bytype (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmalloc_construct (pmalloc.c:$(N))
+==$(N)==    by 0x$(nW): list_insert_new (list.c:$(N))
+==$(N)==    by 0x$(nW): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmemobj_alloc (obj.c:$(N))
+==$(N)==    by 0x$(nW): test_alloc_construct (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): main (obj_debug.c:$(N))
+==$(N)== 	Address: 0x$(nW)	size: $(N)
+==$(N)== [2]    at 0x$(nW): int3_constructor (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): constructor_alloc_bytype (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmalloc_construct (pmalloc.c:$(N))
+==$(N)==    by 0x$(nW): list_insert_new (list.c:$(N))
+==$(N)==    by 0x$(nW): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmemobj_alloc (obj.c:$(N))
+==$(N)==    by 0x$(nW): test_alloc_construct (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): main (obj_debug.c:$(N))
+==$(N)== 	Address: 0x$(nW)	size: $(N)
+==$(N)== [3]    at 0x$(nW): int3_constructor (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): constructor_alloc_bytype (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmalloc_construct (pmalloc.c:$(N))
+==$(N)==    by 0x$(nW): list_insert_new (list.c:$(N))
+==$(N)==    by 0x$(nW): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmemobj_alloc (obj.c:$(N))
+==$(N)==    by 0x$(nW): test_alloc_construct (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): main (obj_debug.c:$(N))
+==$(N)== 	Address: 0x$(nW)	size: $(N)
+==$(N)== [4]    at 0x$(nW): int3_constructor (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): constructor_alloc_bytype (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmalloc_construct (pmalloc.c:$(N))
+==$(N)==    by 0x$(nW): list_insert_new (list.c:$(N))
+==$(N)==    by 0x$(nW): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(nW): pmemobj_alloc (obj.c:$(N))
+==$(N)==    by 0x$(nW): test_alloc_construct (obj_debug.c:$(N))
+==$(N)==    by 0x$(nW): main (obj_debug.c:$(N))
+==$(N)== 	Address: 0x$(nW)	size: $(N)

--- a/src/test/obj_tx_add_range/valgrind1.log.match
+++ b/src/test/obj_tx_add_range/valgrind1.log.match
@@ -5,14 +5,24 @@
 ==$(nW)== Parent PID: $(nW)
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_add_range_direct/valgrind1.log.match
+++ b/src/test/obj_tx_add_range_direct/valgrind1.log.match
@@ -5,14 +5,24 @@
 ==$(nW)== Parent PID: $(nW)
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_alloc/valgrind1.log.match
+++ b/src/test/obj_tx_alloc/valgrind1.log.match
@@ -5,13 +5,24 @@
 ==$(nW)== Parent PID: $(nW)
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_free/valgrind1.log.match
+++ b/src/test/obj_tx_free/valgrind1.log.match
@@ -5,15 +5,26 @@
 ==$(nW)== Parent PID: $(nW)
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_realloc/TEST1
+++ b/src/test/obj_tx_realloc/TEST1
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 #
 # Copyright (c) 2015, Intel Corporation
 #
@@ -31,20 +32,24 @@
 #
 
 #
-# src/test/obj_list/Makefile -- build obj_list test
+# src/test/obj_tx_realloc/TEST0 -- unit test for pmemobj_tx_realloc
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+export UNITTEST_NAME=obj_tx_realloc/TEST1
+export UNITTEST_NUM=1
 
-TARGET = obj_list
-OBJS = obj_list.o list.o redo.o util.o out.o lane.o
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBPMEM=y
+require_valgrind_pmemcheck
 
-include ../Makefile.inc
-CFLAGS += -g -DDEBUG
-LDFLAGS += $(call extract_funcs, obj_list.c)
-INCS += -I../../libpmemobj/ -I../../common/
+setup
 
-obj_list.o: obj_list.c
-out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+create_nonzeroed_file 8 8 $DIR/testfile1
+
+expect_normal_exit valgrind --tool=pmemcheck\
+    --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_tx_realloc$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_tx_realloc/out1.log.match
+++ b/src/test/obj_tx_realloc/out1.log.match
@@ -1,0 +1,3 @@
+obj_tx_realloc/TEST1: START: obj_tx_realloc
+ ./obj_tx_realloc$(nW) $(nW)testfile1
+obj_tx_realloc/TEST1: Done

--- a/src/test/obj_tx_realloc/valgrind1.log.match
+++ b/src/test/obj_tx_realloc/valgrind1.log.match
@@ -1,0 +1,8 @@
+==$(nW)== pmemcheck-$(nW), a simple persistent store checker
+==$(nW)== Copyright (c) $(nW), Intel Corporation
+==$(nW)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(nW)== Command: ./obj_tx_realloc$(nW) $(nW)testfile1
+==$(nW)== Parent PID: $(nW)
+==$(nW)== 
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_strdup/TEST1
+++ b/src/test/obj_tx_strdup/TEST1
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 #
 # Copyright (c) 2015, Intel Corporation
 #
@@ -31,20 +32,22 @@
 #
 
 #
-# src/test/obj_list/Makefile -- build obj_list test
+# src/test/obj_tx_strdup/TEST0 -- unit test for pmemobj_tx_strdup
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+export UNITTEST_NAME=obj_tx_strdup/TEST1
+export UNITTEST_NUM=1
 
-TARGET = obj_list
-OBJS = obj_list.o list.o redo.o util.o out.o lane.o
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBPMEM=y
+require_valgrind_pmemcheck
 
-include ../Makefile.inc
-CFLAGS += -g -DDEBUG
-LDFLAGS += $(call extract_funcs, obj_list.c)
-INCS += -I../../libpmemobj/ -I../../common/
+setup
 
-obj_list.o: obj_list.c
-out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+expect_normal_exit valgrind --tool=pmemcheck\
+    --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_tx_strdup$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_tx_strdup/out1.log.match
+++ b/src/test/obj_tx_strdup/out1.log.match
@@ -1,0 +1,3 @@
+obj_tx_strdup/TEST1: START: obj_tx_strdup
+ ./obj_tx_strdup$(nW) $(nW)testfile1
+obj_tx_strdup/TEST1: Done

--- a/src/test/obj_tx_strdup/valgrind1.log.match
+++ b/src/test/obj_tx_strdup/valgrind1.log.match
@@ -1,0 +1,8 @@
+==$(nW)== pmemcheck-$(nW), a simple persistent store checker
+==$(nW)== Copyright (c) $(nW), Intel Corporation
+==$(nW)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(nW)== Command: ./obj_tx_strdup$(nW) $(nW)testfile1
+==$(nW)== Parent PID: $(nW)
+==$(nW)== 
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0


### PR DESCRIPTION
Modify library source so that it includes transaction macros from
pmemcheck. Add some tests using transactions.