### PR TITLE
ut: change tests to abort on assert

### DIFF
--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -418,16 +418,7 @@ ut_fatal(const char *file, int line, const char *func,
 
 	va_end(ap);
 
-	if (Outfp != NULL)
-		fclose(Outfp);
-
-	if (Errfp != NULL)
-		fclose(Errfp);
-
-	if (Tracefp != NULL)
-		fclose(Tracefp);
-
-	exit(1);
+	abort();
 }
 
 /*


### PR DESCRIPTION
Right now, asserts closes all the global log files and calls exit(1)
once done. This has two major drawbacks: debuggers don't catch ASSERTs
and the macros themselves are not threadsafe, making it difficult to
write multithreaded tests.