### PR TITLE
obj: block too large allocation requests

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -968,7 +968,10 @@ In practice, such a handle is a unique Object IDentifier (OID) of a global
 scope, which means that two objects from different pools may not have the
 same OID.  The special
 .I OID_NULL
-macro defines a NULL-like handle that does not represent any object.
+macro defines a NULL-like handle that does not represent any object. The size
+of a single object is limited by a
+.IR PMEMOBJ_MAX_ALLOC_SIZE .
+Thus an allocation with requested size greater than this value will fail.
 .PP
 An OID cannot be considered as a direct pointer to an object.  Each time the
 program attempts to read or write object data, it must obtain the current

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -80,6 +80,7 @@ const char *pmemobj_check_version(
 		unsigned minor_required);
 
 #define	PMEMOBJ_MIN_POOL ((size_t)(1024 * 1024 * 8)) /* 8 MB */
+#define	PMEMOBJ_MAX_ALLOC_SIZE ((size_t)0x3FFDFFFC0)
 #define	PMEMOBJ_MAX_LAYOUT ((size_t)1024)
 #define	PMEMOBJ_NUM_OID_TYPES ((unsigned)1024)
 
@@ -947,11 +948,11 @@ TOID_TYPE_NUM(t)); _pobj_ret; })
 TOID_TYPE_NUM(t)); _pobj_ret; })
 
 #define	TX_REALLOC(o, size) (\
-{ typeof((o)) _pobj_ret = (typeof((o)))pmemobj_tx_realloc((size),\
+{ typeof((o)) _pobj_ret = (typeof((o)))pmemobj_tx_realloc((o).oid, (size),\
 TOID_TYPE_NUM_OF(o)); _pobj_ret; })
 
 #define	TX_ZREALLOC(o, size) (\
-{ typeof((o)) _pobj_ret = (typeof((o)))pmemobj_tx_zrealloc((size),\
+{ typeof((o)) _pobj_ret = (typeof((o)))pmemobj_tx_zrealloc((o).oid, (size),\
 TOID_TYPE_NUM_OF(o)); _pobj_ret; })
 
 #define	TX_STRDUP(s, type_num)\

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -39,6 +39,7 @@
 
 #define	MAX_CHUNK (UINT16_MAX - 7) /* has to be multiple of 8 */
 #define	CHUNKSIZE (1024L * 256)	/* 256 kilobytes */
+#define	MAX_MEMORY_BLOCK_SIZE (MAX_CHUNK * CHUNKSIZE)
 #define	HEAP_SIGNATURE_LEN 16
 #define	HEAP_SIGNATURE "MEMORY_HEAP_HDR\0"
 #define	ZONE_HEADER_MAGIC 0xC3F0A2D2

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -648,6 +648,12 @@ obj_alloc_construct(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
 		return -1;
 	}
 
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
+		return -1;
+	}
+
 	struct list_head *lhead = &pop->store->bytype[type_num].head;
 	struct carg_bytype carg;
 
@@ -774,6 +780,12 @@ obj_realloc_common(PMEMobjpool *pop, struct object_store *store,
 
 		return obj_alloc_construct(pop, oidp, size, type_num,
 						constr_alloc, &carg);
+	}
+
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
+		return -1;
 	}
 
 	/* if size is 0 just free */
@@ -1194,6 +1206,12 @@ pmemobj_root(PMEMobjpool *pop, size_t size)
 {
 	LOG(3, "pop %p size %zu", pop, size);
 
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
+		return OID_NULL;
+	}
+
 	PMEMoid root;
 
 	pmemobj_mutex_lock(pop, &pop->rootlock);
@@ -1304,6 +1322,12 @@ pmemobj_list_insert_new(PMEMobjpool *pop, size_t pe_offset, void *head,
 		ERR("!pmemobj_list_insert_new");
 		LOG(2, "type_num has to be in range [0, %i]",
 		    PMEMOBJ_NUM_OID_TYPES - 1);
+		return OID_NULL;
+	}
+
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
 		return OID_NULL;
 	}
 

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -791,6 +791,12 @@ tx_alloc_common(size_t size, unsigned int type_num,
 		return OID_NULL;
 	}
 
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
+		return OID_NULL;
+	}
+
 	if (type_num >= PMEMOBJ_NUM_OID_TYPES) {
 		ERR("invalid type_num %d", type_num);
 		errno = EINVAL;
@@ -833,6 +839,12 @@ tx_alloc_copy_common(size_t size, unsigned int type_num, const void *ptr,
 	void *arg))
 {
 	LOG(3, NULL);
+
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
+		return OID_NULL;
+	}
 
 	if (type_num >= PMEMOBJ_NUM_OID_TYPES) {
 		ERR("invalid type_num %d", type_num);
@@ -882,6 +894,12 @@ tx_realloc_common(PMEMoid oid, size_t size, unsigned int type_num,
 	if (tx.stage != TX_STAGE_WORK) {
 		ERR("invalid tx stage");
 		errno = EINVAL;
+		return OID_NULL;
+	}
+
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		errno = ENOMEM;
 		return OID_NULL;
 	}
 

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -177,6 +177,16 @@ test_mock_pool_allocs()
 	FREE(addr);
 }
 
+void
+test_spec_compliance()
+{
+	uint64_t max_alloc = MAX_MEMORY_BLOCK_SIZE -
+		sizeof (struct allocation_header) -
+		sizeof (struct oob_header);
+
+	ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -184,6 +194,8 @@ main(int argc, char *argv[])
 
 	for (int i = 0; i < TEST_RUNS; ++i)
 		test_mock_pool_allocs();
+
+	test_spec_compliance();
 
 	DONE(NULL);
 }


### PR DESCRIPTION
The allocator shouldn't attempt to satisfy requests
that are sure to fail, i.e. larger than ~16GB.

Ref: pmem/issues#84
Ref: pmem/issues#86
Ref: pmem/issues#97
Ref: pmem/issues#98