### PR TITLE
obj: invalidate cache pool in all threads on close

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -299,9 +299,11 @@ TOID_DECLARE(t, POBJ_ROOT_TYPE_NUM);
 
 PMEMobjpool *pmemobj_pool(PMEMoid oid);
 
+extern int _pobj_cache_invalidate;
 extern __thread struct _pobj_pcache {
 	PMEMobjpool *pop;
 	uint64_t uuid_lo;
+	int invalidate;
 } _pobj_cached_pool;
 
 /*
@@ -313,7 +315,10 @@ pmemobj_direct(PMEMoid oid)
 	if (oid.off == 0 || oid.pool_uuid_lo == 0)
 		return NULL;
 
-	if (_pobj_cached_pool.uuid_lo != oid.pool_uuid_lo) {
+	if (_pobj_cache_invalidate != _pobj_cached_pool.invalidate ||
+		_pobj_cached_pool.uuid_lo != oid.pool_uuid_lo) {
+		_pobj_cached_pool.invalidate = _pobj_cache_invalidate;
+
 		if ((_pobj_cached_pool.pop = pmemobj_pool(oid)) == NULL) {
 			_pobj_cached_pool.uuid_lo = 0;
 			return NULL;

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -96,6 +96,7 @@ libpmemobj.so {
 		pmemobj_flush;
 		pmemobj_drain;
 		_pobj_cached_pool;
+		_pobj_cache_invalidate;
 		_pobj_debug_notice;
 	local:
 		*;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -60,6 +60,7 @@
 #include "valgrind_internal.h"
 
 static struct cuckoo *pools;
+int _pobj_cache_invalidate;
 __thread struct _pobj_pcache _pobj_cached_pool;
 
 /*
@@ -511,6 +512,8 @@ pmemobj_close(PMEMobjpool *pop)
 {
 	LOG(3, "pop %p", pop);
 
+	_pobj_cache_invalidate++;
+
 	if (cuckoo_remove(pools, pop->uuid_lo) != pop) {
 		ERR("!cuckoo_remove");
 	}
@@ -589,7 +592,6 @@ pmemobj_pool(PMEMoid oid)
 {
 	return cuckoo_get(pools, oid.pool_uuid_lo);
 }
-
 
 /* arguments for constructor_alloc_bytype */
 struct carg_bytype {

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -252,6 +252,7 @@ FUNC_MOCK(pmemobj_close, void, PMEMobjpool *pop)
 	munmap(Pop, Pop->size);
 FUNC_MOCK_END
 
+int _pobj_cache_invalidate;
 __thread struct _pobj_pcache _pobj_cached_pool;
 
 FUNC_MOCK_RET_ALWAYS(pmemobj_pool, PMEMobjpool *, Pop);

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -1,5 +1,6 @@
 scope/TEST4:
 $(*)debug/libpmemobj.so:
+_pobj_cache_invalidate
 _pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc
@@ -63,6 +64,7 @@ pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)nondebug/libpmemobj.so:
+_pobj_cache_invalidate
 _pobj_cached_pool
 _pobj_debug_notice
 pmemobj_alloc


### PR DESCRIPTION
Currently when using pmemobj_close only the thread that executed the
function had its cache invalidated which led to invalid direct ptrs
being returned in multithreaded applications.