### PR TITLE
common: fix make clobber

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -170,7 +170,7 @@ clean: $(EXTRA_TARGETS_CLEAN)
 
 clobber: clean $(EXTRA_TARGETS_CLOBBER)
 	$(RM) $(LIB_AR) $(LIB_SO_SONAME) $(LIB_SO_REAL) $(LIB_SO)
-	$(RM) -d $(objdir)/.deps/*.P $(objdir)/.deps
+	$(RM) -r $(objdir)/.deps
 
 cstyle:
 	$(CSTYLE) -pP *.[ch]
@@ -178,10 +178,10 @@ cstyle:
 $(objdir)/%.o: %.c
 	@mkdir -p $(objdir)/.deps
 	$(CC) -MD -c -o $@ $(CFLAGS) $(INCS) -fPIC $<
-	@cp $(objdir)/$*.d $(objdir)/.deps/$*.P; \
+	@$(CP) $(objdir)/$*.d $(objdir)/.deps/$*.P; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	    -e '/^$$/ d' -e 's/$$/ :/' < $(objdir)/$*.d >> $(objdir)/.deps/$*.P; \
-	rm -f $(objdir)/$*.d
+	$(RM) -f $(objdir)/$*.d
 
 .PHONY: all clean clobber install uninstall cstyle
 

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -119,14 +119,14 @@ $(TARGET): $(OBJS) $(EXTRA_DEPS)
 	@cp $*.d .deps/$*.P; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	    -e '/^$$/ d' -e 's/$$/ :/' < $*.d >> .deps/$*.P; \
-	rm -f $*.d
+	$(RM) -f $*.d
 
 clean:
 	$(RM) *.o */*.o core a.out *.log testfile*
 
 clobber: clean
 	$(RM) $(TARGET) $(TARGET_STATIC_DEBUG) $(TARGET_STATIC_NONDEBUG)
-	$(RM) -d .deps/*.P .deps
+	$(RM) -r .deps
 
 cstyle:
 ifneq ($(TARGET),)

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -49,7 +49,7 @@ $(TARGET): $(OBJS)
 	@cp $*.d .deps/$*.P; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	    -e '/^$$/ d' -e 's/$$/ :/' < $*.d >> .deps/$*.P; \
-	rm -f $*.d
+	$(RM) -f $*.d
 
 clean:
 	$(RM) *.o core a.out
@@ -59,7 +59,7 @@ cstyle:
 
 clobber: clean
 	$(RM) $(TARGET)
-	$(RM) -d .deps/*.P .deps
+	$(RM) -r .deps
 
 .PHONY: all test clean clobber cstyle
 

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -51,7 +51,7 @@ clean:
 
 clobber: clean
 	$(RM) $(TARGET)
-	$(RM) -d .deps/*.P .deps
+	$(RM) -r .deps
 
 cstyle:
 	$(CSTYLE) -pP *.[ch]
@@ -90,7 +90,7 @@ $(TARGET): $(OBJS)
 	@cp $*.d .deps/$*.P; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
 	    -e '/^$$/ d' -e 's/$$/ :/' < $*.d >> .deps/$*.P; \
-	rm -f $*.d
+	$(RM) -f $*.d
 
 .PHONY: all clean clobber cstyle install uninstall
 


### PR DESCRIPTION
rm "-d" option is not recognized on all the systems.  Use "-r" instead.