### PR TITLE
common: fix util_poolset tests for pmem fs

### DIFF
--- a/src/test/util_poolset/TEST0
+++ b/src/test/util_poolset/TEST0
@@ -40,6 +40,8 @@ export UNITTEST_NUM=0
 # standard unit test setup
 . ../unittest/unittest.sh
 
+require_fs_type non-pmem
+
 setup
 
 export TEST_LOG_LEVEL=4

--- a/src/test/util_poolset/TEST2
+++ b/src/test/util_poolset/TEST2
@@ -40,6 +40,8 @@ export UNITTEST_NUM=2
 # standard unit test setup
 . ../unittest/unittest.sh
 
+require_fs_type non-pmem
+
 setup
 
 export TEST_LOG_LEVEL=4


### PR DESCRIPTION
The match files for TEST0 and TEST2 are prepared for running on
non-pmem filesystem. Just add proper requirement for fs.