### PR TITLE
test: add parallel execution support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ clobber:
 	$(MAKE) -C doc $@
 	$(RM) -r $(RPM_BUILDDIR) $(DPKG_BUILDDIR) rpm dpkg
 
-test check: all
+test check pcheck: all
 	$(MAKE) -C src $@
 
 cstyle:
@@ -98,7 +98,7 @@ pkg-clean:
 	$(RM) -r $(DESTDIR)
 
 rpm dpkg: pkg-clean source
-	utils/build-$@.sh $(SRCVERSION) $(DESTDIR)/nvml $(DESTDIR) $(CURDIR)/$@\
+	+utils/build-$@.sh $(SRCVERSION) $(DESTDIR)/nvml $(DESTDIR) $(CURDIR)/$@\
 			$(CURDIR)/src/test/testconfig.sh
 
 install uninstall:
@@ -106,4 +106,4 @@ install uninstall:
 	$(MAKE) -C doc $@
 
 .PHONY: all clean clobber test check cstyle install uninstall\
-	source rpm dpkg pkg-clean $(SUBDIRS)
+	source rpm dpkg pkg-clean pcheck $(SUBDIRS)

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,11 +58,6 @@ SCOPE_SRC_FILES = $(foreach d, $(SCOPE_SRC_DIRS), $(wildcard $(d)/*.c))
 SCOPE_HDR_FILES = $(foreach d, $(SCOPE_HDR_DIRS), $(wildcard $(D)/*.h))
 SCOPEFILES = $(SCOPE_SRC_FILES) $(SCOPE_HDR_FILES)
 
-TEST_TYPE = check
-TEST_BUILD = all
-TEST_FS = all
-TEST_TIME = 3m
-
 all: $(ALL_TARGETS)
 install: $(INSTALL_TARGETS:=-install)
 uninstall: $(INSTALL_TARGETS:=-uninstall)
@@ -115,8 +110,8 @@ jemalloc-check: jemalloc-test
 test: all jemalloc-test
 	$(MAKE) -C test all
 
-check: test jemalloc-check
-	cd test && ./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME)
+check pcheck: test jemalloc-check
+	$(MAKE) -C test $@
 
 jemalloc jemalloc-clean jemalloc-clobber jemalloc-test jemalloc-check:
 	$(MAKE) -C jemalloc -f Makefile.nvml $@
@@ -143,5 +138,5 @@ clean:
 
 .NOTPARALLEL: libvmem libvmmalloc
 
-.PHONY: all install uninstall clean clobber cstyle test check\
+.PHONY: all install uninstall clean clobber cstyle test check pcheck\
 	jemalloc jemalloc-clean jemalloc-test jemalloc-check cscope $(ALL_TARGETS)

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -156,6 +156,13 @@ clean   : TARGET = clean
 clobber : TARGET = clobber
 test    : TARGET = test
 cstyle  : TARGET = cstyle
+check   : TARGET = check
+pcheck  : TARGET = pcheck
+
+TEST_TYPE = check
+TEST_BUILD = all
+TEST_FS = all
+TEST_TIME = 3m
 
 all test cstyle: $(TEST)
 
@@ -168,4 +175,11 @@ $(TEST): unittest
 unittest:
 	$(MAKE) -C $@ $(TARGET)
 
-.PHONY: all clean clobber test cstyle unittest $(TEST)
+check:
+	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME)
+	@echo "No failures."
+
+pcheck: $(TEST)
+	@echo "No failures."
+
+.PHONY: all check clean clobber cstyle pcheck test unittest $(TEST)

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -73,6 +73,11 @@ STATIC_DEBUG_LIBS += $(LIBS_DIR)/debug/libvmem.a
 STATIC_NONDEBUG_LIBS += $(LIBS_DIR)/nondebug/libvmem.a
 endif
 
+TEST_TYPE = check
+TEST_BUILD = all
+TEST_FS = all
+TEST_TIME = 3m
+
 #
 # This is a helper function to be combined with usage of macros available
 # in the unittest framework. It scans the code for functions that should be
@@ -133,6 +138,17 @@ ifneq ($(TARGET),)
 	../../../utils/cstyle -pP *.[ch]
 endif
 
-.PHONY: all clean clobber cstyle
+TST=$(shell basename `pwd`)
+TSTCHECKS=$(shell ls -1 TEST* | sort -V)
+
+$(TSTCHECKS):
+	@cd .. && ./RUNTESTS ${TST} -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -s $@
+
+check: all
+	@cd .. && ./RUNTESTS ${TST} -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME)
+
+pcheck: all $(TSTCHECKS)
+
+.PHONY: all check clean clobber cstyle pcheck $(TSTCHECKS)
 
 -include .deps/*.P

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -43,13 +43,14 @@ usage()
 	[ "$1" ] && echo Error: $1
 	cat <<EOF
 Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
-	    [ -o timeout ] [tests...]
+	    [ -o timeout ] [-s test-file ] [tests...]
     build-types: debug, nondebug, static-debug, static-nondebug, all (default)
      test-types: check (default), short, long
        fs-types: local, pmem, non-pmem, all (default)
         timeout: floating point number with an optional suffix: 's' for seconds
 		 (the default), 'm' for minutes, 'h' for hours or 'd' for days.
 		 Default value is 3 minutes.
+      test-file: all (default), TEST0, TEST1, ...
 EOF
 	exit 1
 }
@@ -77,6 +78,8 @@ runtest() {
 	[ "$fss" = all ] && fss="local pmem non-pmem"
 	builds=$buildtype
 	[ "$builds" = all ] && builds="debug nondebug static-debug static-nondebug"
+	runscripts=$testfile
+	[ "$runscripts" = all ] && runscripts=`ls -1 TEST* | sort -V`
 
 	# for each fs-type being tested...
 	for fs in $fss
@@ -101,7 +104,7 @@ runtest() {
 		do
 			[ "$verbose" ] && echo RUNTESTS: Testing build-type: $build...
 			# for each TEST script found...
-			for runscript in `ls -1 TEST* | sort -V`
+			for runscript in $runscripts
 			do
 				if [ "$dryrun" ]
 				then
@@ -121,9 +124,7 @@ runtest() {
 				[ $retval = 124 -o $retval = 137 ] && errmsg='timed out'
 
 				[ $retval != 0 ] && {
-					echo RUNTESTS: stopping:
-					echo "    $1/$runscript $errmsg"
-					echo "    TEST=$testtype FS=$fs BUILD=$build"
+					echo "RUNTESTS: stopping: $1/$runscript $errmsg, TEST=$testtype FS=$fs BUILD=$build"
 					exit 1
 				}
 			done
@@ -155,11 +156,12 @@ testconfig="./testconfig.sh"
 killopt="-k 10s"
 time='3m'
 use_timeout="ok"
+testfile=all
 
 #
 # command-line argument processing...
 #
-args=`getopt nvb:t:f:o: $*`
+args=`getopt nvb:t:f:o:s: $*`
 [ $? != 0 ] && usage
 set -- $args
 for arg
@@ -215,6 +217,10 @@ do
 		time="$2"
 		shift 2
 		;;
+	-s)
+		testfile="$2"
+		shift 2
+		;;
 	--)
 		shift
 		break
@@ -231,8 +237,6 @@ done
 	echo "    fs-type: $fstype"
 	echo Tests: $*
 }
-
-echo RUNTESTS: test-type: $testtype
 
 # check if timeout supports "-k" option
 timeout -k 1s 1s true &>/dev/null
@@ -261,5 +265,4 @@ fi
 [ "$local_skip" ] && echo "SKIPPED fs-type \"local\" runs: testconfig.sh doesn't set LOCAL_FS_DIR"
 [ "$pmem_skip" ] && echo "SKIPPED fs-type \"pmem\" runs: testconfig.sh doesn't set PMEM_FS_DIR"
 [ "$non_pmem_skip" ] && echo "SKIPPED fs-type \"non-pmem\" runs: testconfig.sh doesn't set NON_PMEM_FS_DIR"
-[ "$dryrun" ] || echo RUNTESTS: No failures.
 exit 0

--- a/src/test/pmemalloc/Makefile
+++ b/src/test/pmemalloc/Makefile
@@ -37,7 +37,14 @@ TARGET = pmemalloc
 
 OBJS = pmemalloc.o
 
-LIBPMEM=y
-LIBPMEMOBJ=y
+LIBS += -lpmemobj -lpmem
+LDFLAGS += -L../../nondebug/
+CFLAGS += -I../../libpmemobj
 
-include ../Makefile.inc
+include ../../tools/Makefile.inc
+
+check:
+
+pcheck:
+
+.PHONY: check pcheck

--- a/src/test/pmemspoil/Makefile
+++ b/src/test/pmemspoil/Makefile
@@ -49,3 +49,9 @@ CFLAGS += -I../../libpmemblk
 CFLAGS += -I../../libpmemobj
 
 include ../../tools/Makefile.inc
+
+check:
+
+pcheck:
+
+.PHONY: check pcheck

--- a/src/test/pmemwrite/Makefile
+++ b/src/test/pmemwrite/Makefile
@@ -49,3 +49,9 @@ CFLAGS += -I../../libpmemblk
 CFLAGS += -I../../libpmemobj
 
 include ../../tools/Makefile.inc
+
+check:
+
+pcheck:
+
+.PHONY: check pcheck

--- a/src/test/scope/Makefile
+++ b/src/test/scope/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, Intel Corporation
+# Copyright (c) 2014-2015, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,4 +44,8 @@ clobber: clean
 
 cstyle:
 
-.PHONY: all clean clobber cstyle
+check:
+
+pcheck:
+
+.PHONY: all check clean clobber cstyle pcheck

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -61,6 +61,10 @@ clobber: clean
 	$(RM) $(TARGET)
 	$(RM) -r .deps
 
-.PHONY: all test clean clobber cstyle
+check:
+
+pcheck:
+
+.PHONY: all test check clean clobber cstyle pcheck
 
 -include .deps/*.P

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -231,7 +231,7 @@ override_dh_auto_test:
 	else\
 	        cp src/test/testconfig.sh.example src/test/testconfig.sh;\
 	fi
-	make check
+	make -s pcheck
 EOF
 
 chmod +x debian/rules

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -335,7 +335,7 @@ if [ -f $TEST_CONFIG_FILE ]; then
 else
 	cp src/test/testconfig.sh.example src/test/testconfig.sh
 fi
-make check
+make -s pcheck
 
 %clean
 make clobber


### PR DESCRIPTION
Add "pcheck" target for each test directory and call "pcheck" target recursively from main Makefile.

Note: make pcheck enters each test directory. make -s disables printing enter/leave directory messages.
