### PR TITLE
obj: fix order of sections initialization

### DIFF
--- a/src/libpmemobj/lane.h
+++ b/src/libpmemobj/lane.h
@@ -67,19 +67,21 @@ struct lane {
 typedef int (*section_layout_op)(PMEMobjpool *pop,
 	struct lane_section_layout *layout);
 typedef int (*section_op)(struct lane_section *section);
+typedef int (*section_global_op)(PMEMobjpool *pop);
 
 struct section_operations {
 	section_op construct;
 	section_op destruct;
 	section_layout_op check;
 	section_layout_op recover;
+	section_global_op boot;
 };
 
 extern struct section_operations *section_ops[MAX_LANE_SECTION];
 
 int lane_boot(PMEMobjpool *pop);
 int lane_cleanup(PMEMobjpool *pop);
-int lane_recover(PMEMobjpool *pop);
+int lane_recover_and_section_boot(PMEMobjpool *pop);
 int lane_check(PMEMobjpool *pop);
 
 int lane_hold(PMEMobjpool *pop, struct lane_section **section,

--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -1963,11 +1963,22 @@ lane_list_destruct(struct lane_section *section)
 	return 0;
 }
 
+/*
+ * lane_list_init -- initalizes list section
+ */
+static int
+lane_list_boot(PMEMobjpool *pop)
+{
+	/* nop */
+	return 0;
+}
+
 struct section_operations list_ops = {
 	.construct = lane_list_construct,
 	.destruct = lane_list_destruct,
 	.recover = lane_list_recovery,
-	.check = lane_list_check
+	.check = lane_list_check,
+	.boot = lane_list_boot
 };
 
 SECTION_PARM(LANE_SECTION_LIST, &list_ops);

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -285,9 +285,8 @@ pmemobj_boot(PMEMobjpool *pop)
 		return errno;
 	}
 
-	if ((errno = heap_boot(pop)) != 0) {
-		lane_cleanup(pop);
-		ERR("!heap_boot");
+	if ((errno = lane_recover_and_section_boot(pop)) != 0) {
+		ERR("!lane_recover_and_section_boot");
 		return errno;
 	}
 
@@ -592,21 +591,6 @@ err:
 }
 
 /*
- * pmemobj_recover -- (internal) perform a transactional memory pool recovery
- */
-static int
-pmemobj_recover(PMEMobjpool *pop)
-{
-	LOG(3, "pop %p", pop);
-
-	if ((errno = lane_recover(pop)) != 0) {
-		ERR("!lane_recover");
-		return -1;
-	}
-	return 0;
-}
-
-/*
  * pmemobj_check_basic -- (internal) basic pool consistency check
  *
  * Used to check if all the replicas are consistent prior to pool recovery.
@@ -729,13 +713,6 @@ pmemobj_open_common(const char *path, const char *layout, int cow, int boot)
 	if (pmemobj_runtime_init(pop, 0, boot) != 0) {
 		ERR("pool initialization failed");
 		goto err;
-	}
-
-	if (boot) {
-		if (pmemobj_recover(pop) != 0) {
-			ERR("pool recovery failed");
-			goto err;
-		}
 	}
 
 	LOG(3, "pop %p", pop);

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -473,11 +473,21 @@ lane_allocator_check(PMEMobjpool *pop, struct lane_section_layout *section)
 	return ret;
 }
 
+/*
+ * lane_allocator_init -- initalizes allocator section
+ */
+static int
+lane_allocator_boot(PMEMobjpool *pop)
+{
+	return heap_boot(pop);
+}
+
 struct section_operations allocator_ops = {
 	.construct = lane_allocator_construct,
 	.destruct = lane_allocator_destruct,
 	.recover = lane_allocator_recovery,
-	.check = lane_allocator_check
+	.check = lane_allocator_check,
+	.boot = lane_allocator_boot
 };
 
 SECTION_PARM(LANE_SECTION_ALLOCATOR, &allocator_ops);

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1589,11 +1589,22 @@ lane_transaction_check(PMEMobjpool *pop,
 	return 0;
 }
 
+/*
+ * lane_transaction_init -- initalizes transaction section
+ */
+static int
+lane_transaction_boot(PMEMobjpool *pop)
+{
+	/* nop */
+	return 0;
+}
+
 struct section_operations transaction_ops = {
 	.construct = lane_transaction_construct,
 	.destruct = lane_transaction_destruct,
 	.recover = lane_transaction_recovery,
-	.check = lane_transaction_check
+	.check = lane_transaction_check,
+	.boot = lane_transaction_boot
 };
 
 SECTION_PARM(LANE_SECTION_TRANSACTION, &transaction_ops);

--- a/src/test/obj_lane/out0.log.match
+++ b/src/test/obj_lane/out0.log.match
@@ -31,64 +31,39 @@ lane_noop_destruct
 lane_noop_destruct
 lane_noop_destruct
 lane_noop_construct
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_recovery
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
-lane_noop_check
+lane_noop_recovery 0x18d8
+lane_noop_recovery 0x15d8
+lane_noop_recovery 0x12d8
+lane_noop_recovery 0xfd8
+lane_noop_recovery 0xcd8
+lane_noop_init
+lane_noop_recovery 0x17d8
+lane_noop_recovery 0x14d8
+lane_noop_recovery 0x11d8
+lane_noop_recovery 0xed8
+lane_noop_recovery 0xbd8
+lane_noop_init
+lane_noop_recovery 0x16d8
+lane_noop_recovery 0x13d8
+lane_noop_recovery 0x10d8
+lane_noop_recovery 0xdd8
+lane_noop_recovery 0xad8
+lane_noop_init
+lane_noop_check 0x18d8
+lane_noop_check 0x15d8
+lane_noop_check 0x12d8
+lane_noop_check 0xfd8
+lane_noop_check 0xcd8
+lane_noop_check 0x17d8
+lane_noop_check 0x14d8
+lane_noop_check 0x11d8
+lane_noop_check 0xed8
+lane_noop_check 0xbd8
+lane_noop_check 0x16d8
+lane_noop_check 0x13d8
+lane_noop_check 0x10d8
+lane_noop_check 0xdd8
+lane_noop_check 0xad8
+lane_noop_recovery 0x18d8
+lane_noop_check 0x18d8
 obj_lane/TEST0: Done

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -264,9 +264,7 @@ FUNC_MOCK_RUN_DEFAULT {
 		Pop->persist(Pop, Heap_offset, sizeof (*Heap_offset));
 	}
 
-
 	Pop->persist(Pop, Pop, HEAP_OFFSET);
-
 	return Pop;
 }
 FUNC_MOCK_END
@@ -313,6 +311,13 @@ FUNC_MOCK_END
  * Always returns success.
  */
 FUNC_MOCK_RET_ALWAYS(lane_release, int, 0);
+
+/*
+ * heap_boot -- heap_boot mock
+ *
+ * Always returns success.
+ */
+FUNC_MOCK_RET_ALWAYS(heap_boot, int, 0);
 
 /*
  * pmemobj_alloc -- pmemobj_alloc mock
@@ -486,9 +491,9 @@ FUNC_MOCK_RET_ALWAYS(pmemobj_mutex_lock, int, 0);
 FUNC_MOCK_RET_ALWAYS(pmemobj_mutex_unlock, int, 0);
 
 /*
- * lane_recover -- lane_recover mock
+ * lane_recover_and_section_boot -- lane_recover_and_section_boot mock
  */
-FUNC_MOCK(lane_recover, int, PMEMobjpool *pop)
+FUNC_MOCK(lane_recover_and_section_boot, int, PMEMobjpool *pop)
 	FUNC_MOCK_RUN_DEFAULT {
 		return section_ops[LANE_SECTION_LIST]->recover(Pop,
 				Lane_section.layout);
@@ -1180,7 +1185,7 @@ main(int argc, char *argv[])
 			do_realloc_move(pop, argv[i]);
 			break;
 		case 'V':
-			lane_recover(pop);
+			lane_recover_and_section_boot(pop);
 			break;
 		case 'F':
 			do_fail(pop, argv[i]);


### PR DESCRIPTION
This patch adds a lane mechanism to call initialization function
after the corresponding lane sections were recovered. This fixes
an issue in which allocator volatile and persistent states were
mismatched after redo log recovery.