### PR TITLE
pmempool: fix printing chunk headers

### DIFF
--- a/doc/pmempool-info.1
+++ b/doc/pmempool-info.1
@@ -416,7 +416,7 @@ options. See
 section for details about range format.
 .RE
 .PP
-.B -T, --chunk-type used,free,run,unknown,footer
+.B -T, --chunk-type used,free,run,footer
 .RS 8
 Print only specified type(s) of chunks. The multiple types may be specified
 separated by comma. This option requires

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -299,7 +299,7 @@ static const char *help_str =
 "  -C, --chunks [<range>]          Print zones header. If range is specified\n"
 "                                  and --object|-O option is specified prints\n"
 "                                  objects from specified zones only.\n"
-"  -T, --chunk-type used,free,run,unknown,footer\n"
+"  -T, --chunk-type used,free,run,footer\n"
 "                                  Print only specified type(s) of chunk.\n"
 "                                  [requires --chunks|-C]\n"
 "  -b, --bitmap                    Print chunk run's bitmap in graphical\n"
@@ -482,7 +482,9 @@ parse_args(char *appname, int argc, char *argv[],
 		case 'T':
 			argsp->obj.chunk_types = 0;
 			if (util_parse_chunk_types(optarg,
-						&argsp->obj.chunk_types)) {
+					&argsp->obj.chunk_types) ||
+				(argsp->obj.chunk_types &
+				(1 << CHUNK_TYPE_UNKNOWN))) {
 				outv_err("'%s' -- cannot parse chunk type(s)\n",
 						optarg);
 				return -1;
@@ -661,7 +663,7 @@ pmempool_setup_poolset(struct pmem_info *pip)
 
 	/*
 	 * Open the poolset, the values passed to util_pool_open are read
-	 * from the first poolset file, these values are then comapred with
+	 * from the first poolset file, these values are then compared with
 	 * the values from all headers of poolset files.
 	 */
 	if (util_pool_open(&pip->poolset, pip->file_name, 1, minsize,


### PR DESCRIPTION
The chunk headers between 'used' or 'free' and the footer are
not changed when merging chunks, thus displaying the 'unknown'
chunk types doesn't make sense anymore. In such case it is also
required to traverse through all chunks in the zone by jumping over
size_idx of the current chunk rather than traversing through all chunks
from the zone and filtering chunks by range and types.