### PR TITLE
test: fix read of uninitialized value in util_poolset

### DIFF
--- a/src/test/util_poolset/out2.log.match
+++ b/src/test/util_poolset/out2.log.match
@@ -1,6 +1,6 @@
 util_poolset/TEST2: START: util_poolset
  ./util_poolset$(nW) o 32768 8192 $(nW)/testset1 $(nW)/testset2 $(nW)/testset3 $(nW)/testset4 $(nW)/testset5 $(nW)/testset6 $(nW)/testset7 $(nW)/testset8 $(nW)/testset9 $(nW)/testset10 $(nW)/testset11 $(nW)/testset12
-$(nW)/testset1: opened: hdrsize 8192 nreps 1 poolsize 57344 rdonly 0 zeroed 0
+$(nW)/testset1: opened: hdrsize 8192 nreps 1 poolsize 57344 rdonly 0
   replica[0]: nparts 2 repsize 57344 is_pmem 0
     part[0] path $(nW)/testfile11 filesize 32768 size 57344
     part[1] path $(nW)/testfile12 filesize 32768 size 24576

--- a/src/test/util_poolset/util_poolset.c
+++ b/src/test/util_poolset/util_poolset.c
@@ -74,9 +74,9 @@ static void
 poolset_info(const char *fname, struct pool_set *set, size_t hdrsize, int o)
 {
 	if (o)
-		OUT("%s: opened: hdrsize %zu nreps %d poolsize %zu rdonly %d "
-			"zeroed %d", fname, hdrsize, set->nreplicas,
-			set->poolsize, set->rdonly, set->zeroed);
+		OUT("%s: opened: hdrsize %zu nreps %d poolsize %zu rdonly %d",
+			fname, hdrsize, set->nreplicas, set->poolsize,
+			set->rdonly);
 	else
 		OUT("%s: created: hdrsize %zu nreps %d poolsize %zu zeroed %d",
 			fname, hdrsize, set->nreplicas, set->poolsize,


### PR DESCRIPTION
set->zeroed can be used only in "create" path. In "open" path it's left uninitialized.