### PR TITLE
obj: abort transaction on allocation failure

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -795,6 +795,7 @@ tx_alloc_common(size_t size, unsigned int type_num,
 	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
 		ERR("requested size too large");
 		errno = ENOMEM;
+		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;
 	}
 
@@ -844,6 +845,7 @@ tx_alloc_copy_common(size_t size, unsigned int type_num, const void *ptr,
 	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
 		ERR("requested size too large");
 		errno = ENOMEM;
+		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;
 	}
 
@@ -901,6 +903,7 @@ tx_realloc_common(PMEMoid oid, size_t size, unsigned int type_num,
 	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
 		ERR("requested size too large");
 		errno = ENOMEM;
+		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;
 	}
 
@@ -1328,6 +1331,7 @@ pmemobj_tx_alloc(size_t size, unsigned int type_num)
 	if (size == 0) {
 		ERR("allocation with size 0");
 		errno = EINVAL;
+		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;
 	}
 
@@ -1345,6 +1349,7 @@ pmemobj_tx_zalloc(size_t size, unsigned int type_num)
 	if (size == 0) {
 		ERR("allocation with size 0");
 		errno = EINVAL;
+		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;
 	}
 
@@ -1391,6 +1396,7 @@ pmemobj_tx_strdup(const char *s, unsigned int type_num)
 	}
 
 	if (NULL == s) {
+		ERR("cannot duplicate NULL string");
 		errno = EINVAL;
 		pmemobj_tx_abort(EINVAL);
 		return OID_NULL;

--- a/src/test/obj_tx_alloc/valgrind1.log.match
+++ b/src/test/obj_tx_alloc/valgrind1.log.match
@@ -24,5 +24,13 @@
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
 ==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -114,6 +114,24 @@ do_tx_strdup_abort(PMEMobjpool *pop)
 }
 
 /*
+ * do_tx_strdup_null -- duplicate a NULL string to trigger tx abort
+ */
+static void
+do_tx_strdup_null(PMEMobjpool *pop)
+{
+	TOID(char) str;
+	TX_BEGIN(pop) {
+		TOID_ASSIGN(str, pmemobj_tx_strdup(NULL, TYPE_ABORT));
+		ASSERT(0); /* should not get to this point */
+	} TX_ONCOMMIT {
+		ASSERT(0);
+	} TX_END
+
+	TOID_ASSIGN(str, pmemobj_first(pop, TYPE_ABORT));
+	ASSERT(TOID_IS_NULL(str));
+}
+
+/*
  * do_tx_strdup_free_commit -- duplicate a string, free and commit the
  * transaction
  */
@@ -275,6 +293,7 @@ main(int argc, char *argv[])
 	do_tx_strdup_no_tx(pop);
 	do_tx_strdup_commit(pop);
 	do_tx_strdup_abort(pop);
+	do_tx_strdup_null(pop);
 	do_tx_strdup_free_commit(pop);
 	do_tx_strdup_free_abort(pop);
 	do_tx_strdup_commit_nested(pop);


### PR DESCRIPTION
Abort transaction in case of:
- allocation with size 0,
- allocation/reallocation with size larger than PMEMOBJ_MAX_ALLOC_SIZE.

Fix overwriting "errno" with 0, when no error occured.