### PR TITLE
obj: fix description of POBJ_LIST_PREV/NEXT macros

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -2186,25 +2186,15 @@ is empty.  Otherwise, 0 is returned.
 .IP
 The macro
 .B POBJ_LIST_NEXT
-returns the element from the list referenced by
-.I head
-next to the element
+returns the element next to the element
 .IR elm .
-If
-.I elm
-is the last element on the list, OID_NULL is returned.
 .PP
 .BI "POBJ_LIST_PREV(TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .IP
 The macro
 .B POBJ_LIST_PREV
-returns the element from the list referenced by
-.I head
-preceding the element
+returns the element preceding the element
 .IR elm .
-If
-.I elm
-is the first element on the list, OID_NULL is returned.
 .PP
 .BI "POBJ_LIST_FOREACH(TOID " var ", POBJ_LIST_HEAD *" head ,
 .br

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -276,9 +276,12 @@ test_list_api(PMEMobjpool *pop)
 	ASSERTeq(pmemobj_type_num(root.oid), POBJ_ROOT_TYPE_NUM);
 	ASSERTeq(TOID_TYPE_NUM_OF(root), POBJ_ROOT_TYPE_NUM);
 
+	TOID(struct dummy_node) first;
 	TOID(struct dummy_node) iter;
+
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("dummy_node %d", D_RO(iter)->value);
+		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+					D_RO(iter)->value);
 		nodes_count++;
 	}
 
@@ -304,6 +307,7 @@ test_list_api(PMEMobjpool *pop)
 	POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->dummies, plist,
 			sizeof (struct dummy_node), dummy_node_constructor,
 			&test_val);
+	test_val++;
 	POBJ_LIST_INSERT_NEW_TAIL(pop, &D_RW(root)->dummies, plist,
 			sizeof (struct dummy_node), dummy_node_constructor,
 			&test_val);
@@ -316,10 +320,21 @@ test_list_api(PMEMobjpool *pop)
 	nodes_count = 0;
 
 	POBJ_LIST_FOREACH(iter, &D_RO(root)->dummies, plist) {
-		OUT("dummy_node %d", D_RO(iter)->value);
+		OUT("POBJ_LIST_FOREACH: dummy_node %d", D_RO(iter)->value);
 		nodes_count++;
 	}
 
+	ASSERTeq(nodes_count, 3);
+
+	/* now do the same, but w/o using FOREACH macro */
+	nodes_count = 0;
+	first = POBJ_LIST_FIRST(&D_RO(root)->dummies);
+	iter = first;
+	do {
+		OUT("POBJ_LIST_NEXT: dummy_node %d", D_RO(iter)->value);
+		nodes_count++;
+		iter = POBJ_LIST_NEXT(iter, plist);
+	} while (!TOID_EQUALS(iter, first));
 	ASSERTeq(nodes_count, 3);
 
 	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, &D_RW(root)->dummies,
@@ -344,16 +359,30 @@ test_list_api(PMEMobjpool *pop)
 
 	nodes_count = 0;
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("reverse dummy_node %d", D_RO(iter)->value);
+		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+					D_RO(iter)->value);
 		nodes_count++;
 	}
 	ASSERTeq(nodes_count, 2);
 
+	/* now do the same, but w/o using FOREACH macro */
+	nodes_count = 0;
+	first = POBJ_LIST_FIRST(&D_RO(root)->dummies);
+	iter = first;
+	do {
+		OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
+		nodes_count++;
+		iter = POBJ_LIST_PREV(iter, plist);
+	} while (!TOID_EQUALS(iter, first));
+	ASSERTeq(nodes_count, 2);
+
+	test_val++;
 	POBJ_LIST_INSERT_NEW_AFTER(pop, &D_RW(root)->dummies,
 		POBJ_LIST_FIRST(&D_RO(root)->dummies), plist,
 		sizeof (struct dummy_node), dummy_node_constructor,
 		&test_val);
 
+	test_val++;
 	POBJ_LIST_INSERT_NEW_BEFORE(pop, &D_RW(root)->dummies,
 		POBJ_LIST_LAST(&D_RO(root)->dummies, plist), plist,
 		sizeof (struct dummy_node), dummy_node_constructor,
@@ -361,9 +390,21 @@ test_list_api(PMEMobjpool *pop)
 
 	nodes_count = 0;
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("reverse dummy_node %d", D_RO(iter)->value);
+		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+					D_RO(iter)->value);
 		nodes_count++;
 	}
+	ASSERTeq(nodes_count, 4);
+
+	/* now do the same, but w/o using FOREACH macro */
+	nodes_count = 0;
+	first = POBJ_LIST_LAST(&D_RO(root)->dummies, plist);
+	iter = first;
+	do {
+		OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
+		nodes_count++;
+		iter = POBJ_LIST_PREV(iter, plist);
+	} while (!TOID_EQUALS(iter, first));
 	ASSERTeq(nodes_count, 4);
 }
 

--- a/src/test/obj_basic_integration/out0.log.match
+++ b/src/test/obj_basic_integration/out0.log.match
@@ -10,13 +10,22 @@ free
 realloc: 0 => 1, size: 64
 realloc: 1 => 1, size: 64
 free
-dummy_node 0
-dummy_node 5
-dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 0
+POBJ_LIST_FOREACH: dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 6
+POBJ_LIST_NEXT: dummy_node 0
+POBJ_LIST_NEXT: dummy_node 5
+POBJ_LIST_NEXT: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 8
+POBJ_LIST_FOREACH_REVERSE: dummy_node 7
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_PREV: dummy_node 8
+POBJ_LIST_PREV: dummy_node 7
+POBJ_LIST_PREV: dummy_node 5
 obj_basic_integration/TEST0: Done

--- a/src/test/obj_basic_integration/out1.log.match
+++ b/src/test/obj_basic_integration/out1.log.match
@@ -10,13 +10,22 @@ free
 realloc: 0 => 1, size: 64
 realloc: 1 => 1, size: 64
 free
-dummy_node 0
-dummy_node 5
-dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 0
+POBJ_LIST_FOREACH: dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 6
+POBJ_LIST_NEXT: dummy_node 0
+POBJ_LIST_NEXT: dummy_node 5
+POBJ_LIST_NEXT: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 8
+POBJ_LIST_FOREACH_REVERSE: dummy_node 7
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_PREV: dummy_node 8
+POBJ_LIST_PREV: dummy_node 7
+POBJ_LIST_PREV: dummy_node 5
 obj_basic_integration/TEST1: Done

--- a/src/test/obj_basic_integration/out2.log.match
+++ b/src/test/obj_basic_integration/out2.log.match
@@ -10,13 +10,22 @@ free
 realloc: 0 => 1, size: 64
 realloc: 1 => 1, size: 64
 free
-dummy_node 0
-dummy_node 5
-dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 0
+POBJ_LIST_FOREACH: dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 6
+POBJ_LIST_NEXT: dummy_node 0
+POBJ_LIST_NEXT: dummy_node 5
+POBJ_LIST_NEXT: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 8
+POBJ_LIST_FOREACH_REVERSE: dummy_node 7
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_PREV: dummy_node 8
+POBJ_LIST_PREV: dummy_node 7
+POBJ_LIST_PREV: dummy_node 5
 obj_basic_integration/TEST2: Done

--- a/src/test/obj_basic_integration/out3.log.match
+++ b/src/test/obj_basic_integration/out3.log.match
@@ -10,13 +10,22 @@ free
 realloc: 0 => 1, size: 64
 realloc: 1 => 1, size: 64
 free
-dummy_node 0
-dummy_node 5
-dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 0
+POBJ_LIST_FOREACH: dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 6
+POBJ_LIST_NEXT: dummy_node 0
+POBJ_LIST_NEXT: dummy_node 5
+POBJ_LIST_NEXT: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 8
+POBJ_LIST_FOREACH_REVERSE: dummy_node 7
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_PREV: dummy_node 8
+POBJ_LIST_PREV: dummy_node 7
+POBJ_LIST_PREV: dummy_node 5
 obj_basic_integration/TEST3: Done

--- a/src/test/obj_basic_integration/out4.log.match
+++ b/src/test/obj_basic_integration/out4.log.match
@@ -10,13 +10,22 @@ free
 realloc: 0 => 1, size: 64
 realloc: 1 => 1, size: 64
 free
-dummy_node 0
-dummy_node 5
-dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
-reverse dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 0
+POBJ_LIST_FOREACH: dummy_node 5
+POBJ_LIST_FOREACH: dummy_node 6
+POBJ_LIST_NEXT: dummy_node 0
+POBJ_LIST_NEXT: dummy_node 5
+POBJ_LIST_NEXT: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 6
+POBJ_LIST_FOREACH_REVERSE: dummy_node 8
+POBJ_LIST_FOREACH_REVERSE: dummy_node 7
+POBJ_LIST_FOREACH_REVERSE: dummy_node 5
+POBJ_LIST_PREV: dummy_node 6
+POBJ_LIST_PREV: dummy_node 8
+POBJ_LIST_PREV: dummy_node 7
+POBJ_LIST_PREV: dummy_node 5
 obj_basic_integration/TEST4: Done


### PR DESCRIPTION
- Update macro descriptions in man page.
- Add unit tests for POBJ_LIST_PREV/NEXT macros.

Ref: pmem/issues#104