### PR TITLE
blk,log: add realloc and strdup to pmem*_set_funcs 

### DIFF
--- a/doc/libpmemblk.3
+++ b/doc/libpmemblk.3
@@ -69,7 +69,9 @@ libpmemblk \- persistent memory resident array of blocks
 .sp
 .BI "void pmemblk_set_funcs("
 .BI "    void *(*" malloc_func ")(size_t " size ),
-.BI "    void (*" free_func ")(void *" ptr ));
+.BI "    void (*" free_func ")(void *" ptr ),
+.BI "    void *(*" realloc_func ")(void *" ptr ", size_t " size ),
+.BI "    char *(*" strdup_func ")(const char *" s ));
 .BI "int pmemblk_check(const char *" path ", size_t " bsize );
 .sp
 .B Error handling:
@@ -476,7 +478,11 @@ commonly used than the previous sections.
 .br
 .BI "    void *(*" malloc_func ")(size_t " size ),
 .br
-.BI "    void (*" free_func ")(void *" ptr ));
+.BI "    void (*" free_func ")(void *" ptr ),
+.br
+.BI "    void *(*" realloc_func ")(void *" ptr ", size_t " size ),
+.br
+.BI "    char *(*" strdup_func ")(const char *" s ));
 .IP
 The
 .BR pmemblk_set_funcs ()

--- a/doc/libpmemlog.3
+++ b/doc/libpmemlog.3
@@ -72,7 +72,9 @@ libpmemlog \- persistent memory resident log file
 .sp
 .BI "void pmemlog_set_funcs("
 .BI "    void *(*" malloc_func ")(size_t " size ),
-.BI "    void (*" free_func ")(void *" ptr ));
+.BI "    void (*" free_func ")(void *" ptr ),
+.BI "    void *(*" realloc_func ")(void *" ptr ", size_t " size ),
+.BI "    char *(*" strdup_func ")(const char *" s ));
 .BI "int pmemlog_check(const char *" path );
 .sp
 .B Error handling:
@@ -484,7 +486,11 @@ commonly used than the previous sections.
 .br
 .BI "    void *(*" malloc_func ")(size_t " size ),
 .br
-.BI "    void (*" free_func ")(void *" ptr ));
+.BI "    void (*" free_func ")(void *" ptr ),
+.br
+.BI "    void *(*" realloc_func ")(void *" ptr ", size_t " size ),
+.br
+.BI "    char *(*" strdup_func ")(const char *" s ));
 .IP
 The
 .BR pmemlog_set_funcs ()

--- a/src/include/libpmemblk.h
+++ b/src/include/libpmemblk.h
@@ -90,7 +90,9 @@ int pmemblk_set_error(PMEMblkpool *pbp, off_t blockno);
  */
 void pmemblk_set_funcs(
 		void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr));
+		void (*free_func)(void *ptr),
+		void *(*realloc_func)(void *ptr, size_t size),
+		char *(*strdup_func)(const char *s));
 
 const char *pmemblk_errormsg(void);
 

--- a/src/include/libpmemlog.h
+++ b/src/include/libpmemlog.h
@@ -93,7 +93,9 @@ void pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
  */
 void pmemlog_set_funcs(
 		void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr));
+		void (*free_func)(void *ptr),
+		void *(*realloc_func)(void *ptr, size_t size),
+		char *(*strdup_func)(const char *s));
 
 const char *pmemlog_errormsg(void);
 

--- a/src/libpmemblk/libpmemblk.c
+++ b/src/libpmemblk/libpmemblk.c
@@ -102,11 +102,13 @@ pmemblk_check_version(unsigned major_required, unsigned minor_required)
 void
 pmemblk_set_funcs(
 		void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr))
+		void (*free_func)(void *ptr),
+		void *(*realloc_func)(void *ptr, size_t size),
+		char *(*strdup_func)(const char *s))
 {
 	LOG(3, NULL);
 
-	util_set_alloc_funcs(malloc_func, free_func, NULL, NULL);
+	util_set_alloc_funcs(malloc_func, free_func, realloc_func, strdup_func);
 }
 
 /*

--- a/src/libpmemlog/libpmemlog.c
+++ b/src/libpmemlog/libpmemlog.c
@@ -102,11 +102,13 @@ pmemlog_check_version(unsigned major_required, unsigned minor_required)
 void
 pmemlog_set_funcs(
 		void *(*malloc_func)(size_t size),
-		void (*free_func)(void *ptr))
+		void (*free_func)(void *ptr),
+		void *(*realloc_func)(void *ptr, size_t size),
+		char *(*strdup_func)(const char *s))
 {
 	LOG(3, NULL);
 
-	util_set_alloc_funcs(malloc_func, free_func, NULL, NULL);
+	util_set_alloc_funcs(malloc_func, free_func, realloc_func, strdup_func);
 }
 
 /*

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -75,6 +75,7 @@ TEST = blk_nblock\
        util_file_open\
        util_poolset\
        util_poolset_parse\
+       set_funcs\
        vmem_aligned_alloc\
        vmem_calloc\
        vmem_check_allocations\

--- a/src/test/set_funcs/.gitignore
+++ b/src/test/set_funcs/.gitignore
@@ -1,0 +1,1 @@
+set_funcs

--- a/src/test/set_funcs/Makefile
+++ b/src/test/set_funcs/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/set_funcs/Makefile -- build set_funcs unit test
+#
+TARGET = set_funcs
+OBJS = set_funcs.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+LIBPMEMBLK=y
+LIBPMEMLOG=y
+LIBVMEM=y
+
+include ../Makefile.inc

--- a/src/test/set_funcs/TEST0
+++ b/src/test/set_funcs/TEST0
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/set_funcs/TEST0 -- unit test for pmem*_set_funcs
+#
+export UNITTEST_NAME=set_funcs/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+expect_normal_exit ./set_funcs$EXESUFFIX $DIR/testfile $DIR
+
+pass

--- a/src/test/set_funcs/set_funcs.c
+++ b/src/test/set_funcs/set_funcs.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * set_funcs.c -- unit test for pmem*_set_funcs()
+ */
+#include "unittest.h"
+
+#define	OBJ 0
+#define	BLK 1
+#define	LOG 2
+#define	VMEM_ 3
+
+static struct counters {
+	int mallocs;
+	int frees;
+	int reallocs;
+	int strdups;
+} cnt[4];
+
+static void *
+obj_malloc(size_t size)
+{
+	cnt[OBJ].mallocs++;
+	return malloc(size);
+}
+
+static void
+obj_free(void *ptr)
+{
+	if (ptr)
+		cnt[OBJ].frees++;
+	free(ptr);
+}
+
+static void *
+obj_realloc(void *ptr, size_t size)
+{
+	cnt[OBJ].reallocs++;
+	return realloc(ptr, size);
+}
+
+static char *
+obj_strdup(const char *s)
+{
+	cnt[OBJ].strdups++;
+	return strdup(s);
+}
+
+
+static void *
+blk_malloc(size_t size)
+{
+	cnt[BLK].mallocs++;
+	return malloc(size);
+}
+
+static void
+blk_free(void *ptr)
+{
+	if (ptr)
+		cnt[BLK].frees++;
+	free(ptr);
+}
+
+static void *
+log_malloc(size_t size)
+{
+	cnt[LOG].mallocs++;
+	return malloc(size);
+}
+
+static void
+log_free(void *ptr)
+{
+	if (ptr)
+		cnt[LOG].frees++;
+	free(ptr);
+}
+
+static void *
+_vmem_malloc(size_t size)
+{
+	cnt[VMEM_].mallocs++;
+	return malloc(size);
+}
+
+static void
+_vmem_free(void *ptr)
+{
+	if (ptr)
+		cnt[VMEM_].frees++;
+	free(ptr);
+}
+
+static void *
+_vmem_realloc(void *ptr, size_t size)
+{
+	cnt[VMEM_].reallocs++;
+	return realloc(ptr, size);
+}
+
+static char *
+_vmem_strdup(const char *s)
+{
+	cnt[VMEM_].strdups++;
+	return strdup(s);
+}
+
+static void
+test_obj(const char *path)
+{
+	memset(cnt, 0, sizeof (cnt));
+
+	PMEMobjpool *pop =
+			pmemobj_create(path, NULL, PMEMOBJ_MIN_POOL, 0600);
+
+	PMEMoid oid;
+
+	if (pmemobj_alloc(pop, &oid, 10, 0, NULL, NULL))
+		FATAL("!alloc");
+
+	if (pmemobj_realloc(pop, &oid, 100, 0))
+		FATAL("!realloc");
+
+	pmemobj_free(&oid);
+
+	pmemobj_close(pop);
+
+	OUT("obj_mallocs: %d", cnt[OBJ].mallocs);
+	OUT("obj_frees: %d", cnt[OBJ].frees);
+	OUT("obj_reallocs: %d", cnt[OBJ].reallocs);
+	OUT("obj_strdups: %d", cnt[OBJ].strdups);
+
+	if (cnt[OBJ].mallocs == 0 || cnt[OBJ].frees == 0)
+		FATAL("OBJ mallocs: %d, frees: %d", cnt[OBJ].mallocs,
+				cnt[OBJ].frees);
+	for (int i = 0; i < 4; ++i) {
+		if (i == OBJ)
+			continue;
+		if (cnt[i].mallocs || cnt[i].frees)
+			FATAL("OBJ allocation used %d functions", i);
+	}
+	if (cnt[OBJ].mallocs + cnt[OBJ].strdups != cnt[OBJ].frees)
+		FATAL("OBJ memory leak");
+
+	unlink(path);
+}
+
+static void
+test_blk(const char *path)
+{
+	memset(cnt, 0, sizeof (cnt));
+
+	PMEMblkpool *blk = pmemblk_create(path, 512, PMEMBLK_MIN_POOL, 0600);
+
+	pmemblk_close(blk);
+
+
+	OUT("blk_mallocs: %d", cnt[BLK].mallocs);
+	OUT("blk_frees: %d", cnt[BLK].frees);
+
+	if (cnt[BLK].mallocs == 0 || cnt[BLK].frees == 0)
+		FATAL("BLK mallocs: %d, frees: %d", cnt[BLK].mallocs,
+				cnt[BLK].frees);
+	for (int i = 0; i < 4; ++i) {
+		if (i == BLK)
+			continue;
+		if (cnt[i].mallocs || cnt[i].frees)
+			FATAL("BLK allocation used %d functions", i);
+	}
+	if (cnt[BLK].mallocs + cnt[BLK].strdups != cnt[BLK].frees)
+		FATAL("BLK memory leak");
+
+	unlink(path);
+}
+
+static void
+test_log(const char *path)
+{
+	memset(cnt, 0, sizeof (cnt));
+
+	PMEMlogpool *log = pmemlog_create(path, PMEMLOG_MIN_POOL, 0600);
+
+	pmemlog_close(log);
+
+
+	OUT("log_mallocs: %d", cnt[LOG].mallocs);
+	OUT("log_frees: %d", cnt[LOG].frees);
+
+	if (cnt[LOG].mallocs == 0 || cnt[LOG].frees == 0)
+		FATAL("LOG mallocs: %d, frees: %d", cnt[LOG].mallocs,
+				cnt[LOG].frees);
+	for (int i = 0; i < 4; ++i) {
+		if (i == LOG)
+			continue;
+		if (cnt[i].mallocs || cnt[i].frees)
+			FATAL("LOG allocation used %d functions", i);
+	}
+	if (cnt[LOG].mallocs + cnt[LOG].strdups != cnt[LOG].frees)
+		FATAL("LOG memory leak");
+
+	unlink(path);
+}
+
+static void
+test_vmem(const char *dir)
+{
+	memset(cnt, 0, sizeof (cnt));
+
+	VMEM *v = vmem_create(dir, VMEM_MIN_POOL);
+
+	vmem_delete(v);
+
+
+	OUT("vmem_mallocs: %d", cnt[VMEM_].mallocs);
+	OUT("vmem_frees: %d", cnt[VMEM_].frees);
+	OUT("vmem_reallocs: %d", cnt[VMEM_].reallocs);
+	OUT("vmem_strdups: %d", cnt[VMEM_].strdups);
+
+	if (cnt[VMEM_].mallocs == 0 || cnt[VMEM_].frees == 0)
+		FATAL("VMEM mallocs: %d, frees: %d", cnt[VMEM_].mallocs,
+				cnt[VMEM_].frees);
+	for (int i = 0; i < 4; ++i) {
+		if (i == VMEM_)
+			continue;
+		if (cnt[i].mallocs || cnt[i].frees)
+			FATAL("VMEM allocation used %d functions", i);
+	}
+	if (cnt[VMEM_].mallocs + cnt[VMEM_].strdups != cnt[VMEM_].frees)
+		FATAL("VMEM memory leak");
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "set_funcs");
+
+	if (argc < 3)
+		FATAL("usage: %s file dir", argv[0]);
+
+	pmemobj_set_funcs(obj_malloc, obj_free, obj_realloc, obj_strdup);
+	pmemblk_set_funcs(blk_malloc, blk_free);
+	pmemlog_set_funcs(log_malloc, log_free);
+	vmem_set_funcs(_vmem_malloc, _vmem_free, _vmem_realloc, _vmem_strdup,
+			NULL);
+
+	test_obj(argv[1]);
+	test_blk(argv[1]);
+	test_log(argv[1]);
+	test_vmem(argv[2]);
+
+	DONE(NULL);
+}

--- a/src/test/set_funcs/set_funcs.c
+++ b/src/test/set_funcs/set_funcs.c
@@ -93,6 +93,20 @@ blk_free(void *ptr)
 }
 
 static void *
+blk_realloc(void *ptr, size_t size)
+{
+	cnt[BLK].reallocs++;
+	return realloc(ptr, size);
+}
+
+static char *
+blk_strdup(const char *s)
+{
+	cnt[BLK].strdups++;
+	return strdup(s);
+}
+
+static void *
 log_malloc(size_t size)
 {
 	cnt[LOG].mallocs++;
@@ -105,6 +119,20 @@ log_free(void *ptr)
 	if (ptr)
 		cnt[LOG].frees++;
 	free(ptr);
+}
+
+static void *
+log_realloc(void *ptr, size_t size)
+{
+	cnt[LOG].reallocs++;
+	return realloc(ptr, size);
+}
+
+static char *
+log_strdup(const char *s)
+{
+	cnt[LOG].strdups++;
+	return strdup(s);
 }
 
 static void *
@@ -188,6 +216,8 @@ test_blk(const char *path)
 
 	OUT("blk_mallocs: %d", cnt[BLK].mallocs);
 	OUT("blk_frees: %d", cnt[BLK].frees);
+	OUT("blk_reallocs: %d", cnt[BLK].reallocs);
+	OUT("blk_strdups: %d", cnt[BLK].strdups);
 
 	if (cnt[BLK].mallocs == 0 || cnt[BLK].frees == 0)
 		FATAL("BLK mallocs: %d, frees: %d", cnt[BLK].mallocs,
@@ -216,6 +246,8 @@ test_log(const char *path)
 
 	OUT("log_mallocs: %d", cnt[LOG].mallocs);
 	OUT("log_frees: %d", cnt[LOG].frees);
+	OUT("log_reallocs: %d", cnt[LOG].reallocs);
+	OUT("log_strdups: %d", cnt[LOG].strdups);
 
 	if (cnt[LOG].mallocs == 0 || cnt[LOG].frees == 0)
 		FATAL("LOG mallocs: %d, frees: %d", cnt[LOG].mallocs,
@@ -269,8 +301,8 @@ main(int argc, char *argv[])
 		FATAL("usage: %s file dir", argv[0]);
 
 	pmemobj_set_funcs(obj_malloc, obj_free, obj_realloc, obj_strdup);
-	pmemblk_set_funcs(blk_malloc, blk_free);
-	pmemlog_set_funcs(log_malloc, log_free);
+	pmemblk_set_funcs(blk_malloc, blk_free, blk_realloc, blk_strdup);
+	pmemlog_set_funcs(log_malloc, log_free, log_realloc, log_strdup);
 	vmem_set_funcs(_vmem_malloc, _vmem_free, _vmem_realloc, _vmem_strdup,
 			NULL);
 


### PR DESCRIPTION
src/common/set.c uses Realloc and Strdup, so we need a way to replace them in all libraries.