### PR TITLE
Fix pmemspoil return value

### DIFF
--- a/src/test/obj_check/TEST5
+++ b/src/test/obj_check/TEST5
@@ -40,11 +40,11 @@ export UNITTEST_NUM=5
 # standard unit test setup
 . ../unittest/unittest.sh
 
-
-
 setup
 
 rm -f log$UNITTEST_NUM.log
+
+SIZE=128
 
 # Transaction lane section
 
@@ -57,7 +57,7 @@ rm -f $DIR/testfile
 
 # Set invalid internal_type for allocation
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -ea $DIR/testfile
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -ea $DIR/testfile
 $PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_alloc.entry(0).oob.internal_type=0x5"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
@@ -65,7 +65,7 @@ rm -f $DIR/testfile
 
 # Set invalid user_type for allocation
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -ea $DIR/testfile
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -ea $DIR/testfile
 $PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_alloc.entry(0).oob.user_type=4096"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
@@ -73,7 +73,7 @@ rm -f $DIR/testfile
 
 # Set invalid internal_type for free
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -f -ef $DIR/testfile
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -f -ef $DIR/testfile
 $PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_free.entry(0).oob.internal_type=0x5"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
@@ -81,7 +81,7 @@ rm -f $DIR/testfile
 
 # Set invalid user_type for free
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -f -ef $DIR/testfile
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -f -ef $DIR/testfile
 $PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_free.entry(0).oob.user_type=4096"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
@@ -89,7 +89,7 @@ rm -f $DIR/testfile
 
 # Set invalid offset in tx range
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -s -es $DIR/testfile
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -s -es $DIR/testfile
 $PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_set.entry(0).tx_range.offset=0"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
@@ -97,9 +97,9 @@ rm -f $DIR/testfile
 
 # Set invalid size in tx range
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
-expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o16 -s -es $DIR/testfile
-$PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_set.entry(0).tx_range.size=$SIZE"
+INVALID_SIZE=$(stat -c%s $DIR/testfile)
+expect_abnormal_exit $PMEMALLOC$EXESUFFIX -o$SIZE -s -es $DIR/testfile
+$PMEMSPOIL $DIR/testfile "pmemobj.lane(0).tx.undo_set.entry(0).tx_range.size=$INVALID_SIZE"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile
 cat out$UNITTEST_NUM.log >> log$UNITTEST_NUM.log
 rm -f $DIR/testfile

--- a/src/test/obj_check/out5.log.match
+++ b/src/test/obj_check/out5.log.match
@@ -20,9 +20,9 @@ not consistent: tx lane: invalid user type
 obj_check/TEST5: Done
 obj_check/TEST5: START: obj_check
  ./obj_check$(nW) $(nW)testfile
-consistent
+not consistent: tx_lane: invalid offset in tx range object
 obj_check/TEST5: Done
 obj_check/TEST5: START: obj_check
  ./obj_check$(nW) $(nW)testfile
-consistent
+not consistent: tx_lane: invalid offset in tx range object
 obj_check/TEST5: Done

--- a/src/test/pmemspoil/spoil.c
+++ b/src/test/pmemspoil/spoil.c
@@ -1305,7 +1305,6 @@ pmemspoil_process_pmemobj(struct pmemspoil *psp,
 	struct heap_layout *hlayout = (void *)pop + pop->heap_offset;
 	struct lane_layout *lanes = (void *)pop + pop->lanes_offset;
 	struct object_store *obj_store = (void *)pop + pop->obj_store_offset;
-	int ret = 0;
 
 	PROCESS_BEGIN(psp, pfp) {
 		struct checksum_args checksum_args = {
@@ -1332,7 +1331,7 @@ pmemspoil_process_pmemobj(struct pmemspoil *psp,
 		PROCESS(obj_store, obj_store, 1);
 	} PROCESS_END
 
-	return ret;
+	return PROCESS_RET;
 }
 
 /*
@@ -1398,8 +1397,11 @@ main(int argc, char *argv[])
 
 	out_set_prefix(psp->fname);
 
-	for (int i = 0; i < psp->argc; i++)
-		pmemspoil_process(psp, &psp->args[i]);
+	for (int i = 0; i < psp->argc; i++) {
+		ret = pmemspoil_process(psp, &psp->args[i]);
+		if (ret)
+			goto error;
+	}
 
 error:
 	if (psp != NULL) {


### PR DESCRIPTION
Fix returning error by pmemspoil and fix obj_check/TEST5 which didn't fail because of the pmemspoil issue.