### PR TITLE
obj: fix aborts using old cache values

### DIFF
--- a/src/test/obj_tx_add_range_direct/valgrind1.log.match
+++ b/src/test/obj_tx_add_range_direct/valgrind1.log.match
@@ -24,5 +24,7 @@
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0
 ==$(nW)== 
+==$(nW)== Number of stores not made persistent: 0
+==$(nW)== 
 ==$(nW)== 
 ==$(nW)== Number of stores not made persistent: 0


### PR DESCRIPTION
This patch addresses an issue in which data, that was already commited
by a transaction that used only one cache set instance, could be
erroneously reverted by an abort or pool recovery.