### PR TITLE
pmempool: fix possible NULL pointer dereference / memory leaks

### DIFF
--- a/src/tools/pmempool/info_blk.c
+++ b/src/tools/pmempool/info_blk.c
@@ -539,6 +539,7 @@ pmempool_info_blk(struct pmem_info *pip)
 
 	if (pmempool_info_read(pip, pbp, sizeof (struct pmemblk), 0)) {
 		outv_err("cannot read pmemblk header\n");
+		free(pbp);
 		return -1;
 	}
 

--- a/src/tools/pmempool/info_log.c
+++ b/src/tools/pmempool/info_log.c
@@ -174,6 +174,7 @@ pmempool_info_log(struct pmem_info *pip)
 
 	if (pmempool_info_read(pip, plp, sizeof (struct pmemlog), 0)) {
 		outv_err("cannot read pmemlog header\n");
+		free(plp);
 		return -1;
 	}
 

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -1069,7 +1069,7 @@ int
 pmempool_info_obj(struct pmem_info *pip)
 {
 	pip->obj.addr = pool_set_file_map(pip->pfile, 0);
-	if (pip->obj.addr == MAP_FAILED)
+	if (pip->obj.addr == NULL)
 		return -1;
 
 	pip->obj.size = pip->pfile->size;


### PR DESCRIPTION
Found by Klocwork.