### PR TITLE
Adding pmem_unmap() function

### DIFF
--- a/doc/libpmem.3
+++ b/doc/libpmem.3
@@ -52,6 +52,7 @@ libpmem \- persistent memory support library
 .BI "void pmem_persist(void *" addr ", size_t " len );
 .BI "int pmem_msync(void *" addr ", size_t " len );
 .BI "void *pmem_map(int " fd );
+.BI "int pmem_unmap(void *" addr ", size_t " len );
 .sp
 .B Partial flushing operations:
 .sp
@@ -278,7 +279,27 @@ returns a pointer to mapped area.  On error, NULL is returned, and
 errno is set appropriately.  To delete mappings created with
 .BR pmem_map (),
 use
-.BR munmap (2).
+.BR pmem_unmap ().
+.PP
+.BI "int pmem_unmap(void *" addr ", size_t " len );
+.IP
+The
+.BR pmem_unmap ()
+function deletes all the mappings for the specified address range, and
+causes further references to addresses within the range to generate
+invalid memory references. It will use the address specified by the
+parameter
+.IR addr ,
+where
+.I addr
+must be a previously mapped region.
+.BR pmem_unmap ()
+will delete the mappings using the
+.BR munmap (2),
+On success,
+.BR pmem_unmap ()
+returns zero.  On error, -1 is returned, and
+errno is set appropriately.
 .SH PARTIAL FLUSHING OPERATIONS
 .PP
 The functions in this section provide access to the stages
@@ -766,6 +787,13 @@ main(int argc, char *argv[])
         pmem_persist(pmemaddr, PMEM_LEN);
     else
         pmem_msync(pmemaddr, PMEM_LEN);
+
+    /*
+     * Delete the mappings. The region is also
+     * automatically unmapped when the process is
+     * terminated.
+     */
+    pmem_unmap(pmemaddr, PMEM_LEN);
 }
 .fi
 .PP

--- a/src/examples/libpmem/full_copy.c
+++ b/src/examples/libpmem/full_copy.c
@@ -154,6 +154,7 @@ main(int argc, char *argv[])
 		do_copy_to_non_pmem(pmemaddr, srcfd, stbuf.st_size);
 
 	close(srcfd);
+	pmem_unmap(pmemaddr, stbuf.st_size);
 
 	exit(0);
 }

--- a/src/examples/libpmem/manpage.c
+++ b/src/examples/libpmem/manpage.c
@@ -84,4 +84,11 @@ main(int argc, char *argv[])
 		pmem_persist(pmemaddr, PMEM_LEN);
 	else
 		pmem_msync(pmemaddr, PMEM_LEN);
+
+	/*
+	 * Delete the mappings. The region is also
+	 * automatically unmapped when the process is
+	 * terminated.
+	 */
+	pmem_unmap(pmemaddr, PMEM_LEN);
 }

--- a/src/examples/libpmem/simple_copy.c
+++ b/src/examples/libpmem/simple_copy.c
@@ -96,6 +96,7 @@ main(int argc, char *argv[])
 
 	/* read up to BUF_LEN from srcfd */
 	if ((cc = read(srcfd, buf, BUF_LEN)) < 0) {
+		pmem_unmap(pmemaddr, BUF_LEN);
 		perror("read");
 		exit(1);
 	}
@@ -109,6 +110,7 @@ main(int argc, char *argv[])
 	}
 
 	close(srcfd);
+	pmem_unmap(pmemaddr, BUF_LEN);
 
 	exit(0);
 }

--- a/src/include/libpmem.h
+++ b/src/include/libpmem.h
@@ -50,6 +50,7 @@ extern "C" {
 #include <sys/types.h>
 
 void *pmem_map(int fd);
+int pmem_unmap(void *addr, size_t len);
 int pmem_is_pmem(void *addr, size_t len);
 void pmem_persist(void *addr, size_t len);
 int pmem_msync(void *addr, size_t len);

--- a/src/libpmem/libpmem.map
+++ b/src/libpmem/libpmem.map
@@ -35,6 +35,7 @@
 libpmem.so {
 	global:
 		pmem_map;
+		pmem_unmap;
 		pmem_is_pmem;
 		pmem_persist;
 		pmem_msync;

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -632,6 +632,19 @@ pmem_map(int fd)
 }
 
 /*
+ * pmem_unmap -- unmap the specified region
+ */
+int
+pmem_unmap(void *addr, size_t len)
+{
+	int ret;
+	LOG(3, "addr %p len %zu", addr, len);
+	ret = util_unmap(addr, len);
+	VALGRIND_REMOVE_PMEM_MAPPING(addr, len);
+	return ret;
+}
+
+/*
  * memmove_nodrain_normal -- (internal) memmove to pmem without hw drain
  */
 static void *

--- a/src/test/pmem_valgr_simple/pmem_valgr_simple.c
+++ b/src/test/pmem_valgr_simple/pmem_valgr_simple.c
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 	/* shows strange behavior of memset in some cases */
 	memset(dest + dest_off, 0, bytes);
 
-	munmap(dest, (size_t)stbuf.st_size);
+	pmem_unmap(dest, stbuf.st_size);
 
 	CLOSE(fd);
 

--- a/src/test/scope/out1.log.match
+++ b/src/test/scope/out1.log.match
@@ -15,6 +15,7 @@ pmem_memset_nodrain
 pmem_memset_persist
 pmem_msync
 pmem_persist
+pmem_unmap
 $(*)nondebug/libpmem.so:
 pmem_check_version
 pmem_drain
@@ -31,6 +32,7 @@ pmem_memset_nodrain
 pmem_memset_persist
 pmem_msync
 pmem_persist
+pmem_unmap
 $(*)debug/libpmem.a:
 pmem_check_version
 pmem_drain
@@ -47,6 +49,7 @@ pmem_memset_nodrain
 pmem_memset_persist
 pmem_msync
 pmem_persist
+pmem_unmap
 $(*)nondebug/libpmem.a:
 pmem_check_version
 pmem_drain
@@ -63,3 +66,4 @@ pmem_memset_nodrain
 pmem_memset_persist
 pmem_msync
 pmem_persist
+pmem_unmap


### PR DESCRIPTION
## Adding pmem_unmap() function

Adding the `pmem_unmap()` function call. The reason behind this addition is that it will help to make 
code portable and consistent. The first reason is that libpmem has a function called `pmem_map()` but not `pmem_unmap()`, so the user is required to use `munmap(2)` to delete the mappings. If the library is ported to another platform, let's say Windows, the calls for mapping and unmapping may be different, so the user may still continue using `pmem_map()` but not `munmap()`, however, if we have the `pmem_unmap()` function present, the user can continue using `pmem_map()` and `pmem_unmap()` without having to change his code to change from `munmap(2)` to its Windows counterpart. I think that it is reasonable to add this function and it will help with portability and consistency.

Changes in this commit:

1. The libpmem examples were changed to add a explicit call for `pmem_unmap()`;
2. The manpage were updated with the function call, I also added a small explanation
   regarding the fact that the mappings are also deleted upon process termination;
3. I added the source/header for the function `pmem_unmap()`;

I tested the examples, but it will be nice if someone could test the same code on a platform with hardware drain support.