### PR TITLE
obj: increase largest run allocation size

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -667,9 +667,9 @@ heap_buckets_init(PMEMobjpool *pop)
 	bucket_proto[i].unit_size = CHUNKSIZE;
 
 	h->last_run_max_size = bucket_proto[i - 1].unit_size *
-				(bucket_proto[i - 1].unit_max - 1);
+				bucket_proto[i - 1].unit_max;
 
-	h->bucket_map = Malloc(sizeof (*h->bucket_map) * h->last_run_max_size);
+	h->bucket_map = Malloc(sizeof (uint8_t) * (h->last_run_max_size + 1));
 	if (h->bucket_map == NULL)
 		goto error_bucket_map_malloc;
 
@@ -681,8 +681,13 @@ heap_buckets_init(PMEMobjpool *pop)
 	}
 
 	/* XXX better way to fill the bucket map */
-	for (i = 0; i < h->last_run_max_size; ++i) {
-		for (int j = 0; j < MAX_BUCKETS - 1; ++j) {
+	for (i = 0; i <= h->last_run_max_size; ++i) {
+		/*
+		 * All sizes can be handled by the largest available run bucket,
+		 * next pick the smallest fit.
+		 */
+		h->bucket_map[i] = MAX_BUCKETS - 2;
+		for (int j = 0; j < MAX_BUCKETS - 2; ++j) {
 			/*
 			 * Skip the last unit, so that the distribution
 			 * of buckets in the map is better.

--- a/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
+++ b/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
@@ -39,7 +39,7 @@
 
 #include "unittest.h"
 
-#define	TEST_ALLOC_SIZE (98304 - 64) /* last unit size */
+#define	TEST_ALLOC_SIZE (131072 - 64) /* last unit size */
 #define	LAYOUT_NAME "oom_mt"
 
 int allocated;


### PR DESCRIPTION
This patch changes the biggest size that can be handled by runs to be
exactly CHUNKSIZE/2. Should improve fragmentation a tiny bit.
Also fixes an off-by-one error in the bucket selection logic.