### PR TITLE
benchmark: silence glib unknown attributes

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -80,6 +80,14 @@ else
 CFLAGS += -ggdb
 endif
 
+GLIB_TEST_PROG="\#include <glib.h>\nint main(){return 0;}"
+GLIB_SILENCE := $(shell printf $(GLIB_TEST_PROG) |\
+	$(CC) $(CFLAGS) -x c - 2>/dev/null && echo n || echo y)
+
+ifeq ($(GLIB_SILENCE), y)
+CFLAGS += -Wno-unknown-attributes
+endif
+
 default: $(TARGET)
 
 no-glib:


### PR DESCRIPTION
The glib headers use GCC attributes which are not supported by clang -
for example the __alloc_size__.
We must test if this is an issue and turn off warning on unknown
attributes using the -Wno-unknown-attributes.