### PR TITLE
ut: use EXTRA_CFLAGS consistently

### DIFF
--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -44,6 +44,8 @@ CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wpointer-arith
 CFLAGS += -pthread
 CFLAGS += -fno-common
+CFLAGS += $(EXTRA_CFLAGS)
+
 CSTYLE = ../../../utils/cstyle
 
 all test: $(TARGET)


### PR DESCRIPTION
EXTRA_CFLAGS is used everywhere. unittest helper library is the only exception.
