### PR TITLE
common: support make install prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,18 @@
 # locations (/usr/lib, /usr/include, and /usr/share/man).
 # You can provide custom directory prefix for installation using
 # DESTDIR variable e.g.: "make install DESTDIR=/opt"
+# You can override the prefix within DESTDIR using prefix variable
+# e.g.: "make install prefix=/usr"
 
 export SRCVERSION = $(shell git describe 2>/dev/null || cat .version)
+
+prefix ?= /usr/local
 
 RPM_BUILDDIR=rpmbuild
 DPKG_BUILDDIR=dpkgbuild
 rpm : override DESTDIR=$(CURDIR)/$(RPM_BUILDDIR)
 dpkg: override DESTDIR=$(CURDIR)/$(DPKG_BUILDDIR)
+rpm dpkg: override prefix=/usr
 
 all:
 	$(MAKE) -C src $@

--- a/README.md
+++ b/README.md
@@ -82,7 +82,14 @@ in the standard system locations:
 	# make install
 ```
 
-To install this library into other locations, you can use
+To install this library into other locations, you can use the
+prefix variable, e.g.:
+```
+	$ make install prefix=/usr/local
+```
+This will install files to /usr/local/lib, /usr/local/include /usr/local/share/man.
+
+To prepare this library for packaging, you can use the
 DESTDIR variable, e.g.:
 ```
 	$ make install DESTDIR=/tmp

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -45,7 +45,7 @@ GZFILES_3 = $(MANPAGES_3:=.gz)
 GZFILES = $(GZFILES_1) $(GZFILES_3)
 INSTALL_SECTIONS = install-1 install-3
 UNINSTALL_SECTIONS = uninstall-1 uninstall-3
-MANPAGES_DESTDIR = $(DESTDIR)/usr/share/man/man
+MANPAGES_DESTDIR = $(DESTDIR)$(prefix)/share/man/man
 
 all: $(TXTFILES)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ CLOBBER_TARGETS = $(ALL_TARGETS) test jemalloc
 CSTYLE_TARGETS = $(ALL_TARGETS) common test
 INSTALL_TARGETS = $(TARGETS)
 
-HEADERS_DESTDIR = $(DESTDIR)/usr/include
+HEADERS_DESTDIR = $(DESTDIR)$(prefix)/include
 HEADERS_INSTALL = include/libpmem.h include/libvmem.h\
 		include/libpmemobj.h include/libpmemblk.h\
 		include/libpmemlog.h include/libvmmalloc.h

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -73,16 +73,16 @@ $(error $(arch32_error_msg))
 endif
 
 ifeq ($(shell uname -m), x86_64)
-ifneq ($(wildcard /usr/lib64),)
-LIBDIR = usr/lib64
+ifneq ($(wildcard $(prefix)/lib64),)
+LIBDIR = $(prefix)/lib64
 else
-LIBDIR = usr/lib
+LIBDIR = $(prefix)/lib
 endif
 else
-LIBDIR = usr/lib
+LIBDIR = $(prefix)/lib
 endif
 
-LIBS_DESTDIR = $(DESTDIR)/$(LIBDIR)/$(LIBS_DIR)
+LIBS_DESTDIR = $(DESTDIR)$(LIBDIR)/$(LIBS_DIR)
 
 ifeq ($(DEBUG),1)
 CFLAGS += -O0 -ggdb -DDEBUG

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -45,7 +45,7 @@ CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
 LDFLAGS += -Wl,-z,relro -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS) -L../../nondebug
-TOOLSDIR=/usr/bin
+TOOLSDIR=$(prefix)/bin
 TARGET_DIR=$(DESTDIR)$(TOOLSDIR)
 BASH_COMP_FILES ?=
 BASH_COMP_DIR =$(DESTDIR)/etc/bash_completion.d/


### PR DESCRIPTION
Add support for the prefix variable when running make install.

Example:

Command                               Installation directory

make install                          #/usr/local/include/libpmemlog.h
make install prefix=/usr              #/usr/include/libpmemlog.h
make install DESTDIR=/tmp             #/tmp/usr/local/include/libpmemlog.h
make install DESTDIR=/tmp prefix=/usr #/tmp/usr/include/libpmemlog.h

Signed-off-by: Daniel Verkamp <daniel.verkamp@intel.com>