### PR TITLE
test: dump stacktraces on fatal signals

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -103,6 +103,10 @@ CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)
 LDFLAGS = -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)
 
+ifneq ($(USE_LIBUNWIND),)
+LDFLAGS += -ldl $(shell pkg-config --libs libunwind)
+endif
+
 #
 # By default debug and non-debug static versions are built.
 # It can be changed by setting BUILD_STATIC_DEBUG

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -34,7 +34,7 @@
 # src/test/unittest/Makefile -- build unittest support library
 #
 TARGET = libut.a
-OBJS = ut.o ut_alloc.o ut_file.o ut_pthread.o ut_signal.o
+OBJS = ut.o ut_alloc.o ut_file.o ut_pthread.o ut_signal.o ut_backtrace.o
 CFLAGS = -I../../include
 CFLAGS += -std=gnu99
 CFLAGS += -ggdb
@@ -48,6 +48,10 @@ CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)
 
 CSTYLE = ../../../utils/cstyle
+
+ifneq ($(USE_LIBUNWIND),)
+CFLAGS += $(shell pkg-config --cflags libunwind) -DUSE_LIBUNWIND
+endif
 
 all test: $(TARGET)
 

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -531,4 +531,8 @@ int ut_pthread_join(const char *file, int line, const char *func,
 
 extern unsigned long Ut_pagesize;
 
+void ut_dump_backtrace(void);
+void ut_sighandler(int);
+void ut_register_sighandlers(void);
+
 #endif	/* unittest.h */

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -320,6 +320,9 @@ ut_start(const char *file, int line, const char *func,
 
 	va_start(ap, fmt);
 
+	if (getenv("UNITTEST_NO_SIGHANDLERS") == NULL)
+		ut_register_sighandlers();
+
 	if (getenv("UNITTEST_QUIET") != NULL)
 		Quiet++;
 

--- a/src/test/unittest/ut_backtrace.c
+++ b/src/test/unittest/ut_backtrace.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2015, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * ut_backtrace.c -- backtrace reporting routines
+ */
+
+#ifndef	_GNU_SOURCE
+#define	_GNU_SOURCE
+#endif
+
+#include "unittest.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+
+#ifdef	USE_LIBUNWIND
+
+#define	UNW_LOCAL_ONLY
+#include <libunwind.h>
+#include <dlfcn.h>
+
+#define	PROCNAMELEN 256
+/*
+ * ut_dump_backtrace -- dump stacktrace to error log using libunwind
+ */
+void
+ut_dump_backtrace(void)
+{
+	unw_context_t context;
+	unw_proc_info_t pip;
+
+	pip.unwind_info = NULL;
+	int ret = unw_getcontext(&context);
+	if (ret) {
+		ERR("unw_getcontext: %s [%d]", unw_strerror(ret), ret);
+		return;
+	}
+
+	unw_cursor_t cursor;
+	ret = unw_init_local(&cursor, &context);
+	if (ret) {
+		ERR("unw_init_local: %s [%d]", unw_strerror(ret), ret);
+		return;
+	}
+
+	ret = unw_step(&cursor);
+
+	char procname[PROCNAMELEN];
+	unsigned i = 0;
+
+	while (ret > 0) {
+		ret = unw_get_proc_info(&cursor, &pip);
+		if (ret) {
+			ERR("unw_get_proc_info: %s [%d]", unw_strerror(ret),
+					ret);
+			break;
+		}
+
+		unw_word_t off;
+		ret = unw_get_proc_name(&cursor, procname, PROCNAMELEN, &off);
+		if (ret && ret != -UNW_ENOMEM) {
+			if (ret != -UNW_EUNSPEC) {
+				ERR("unw_get_proc_name: %s [%d]",
+					unw_strerror(ret), ret);
+			}
+
+			strcpy(procname, "?");
+		}
+
+		void *ptr = (void *)(pip.start_ip + off);
+		Dl_info dlinfo;
+		const char *fname = "?";
+
+		if (dladdr(ptr, &dlinfo) && dlinfo.dli_fname &&
+				*dlinfo.dli_fname)
+			fname = dlinfo.dli_fname;
+
+		ERR("%u: %s (%s%s+0x%lx) [%p]", i++, fname, procname,
+				ret == -UNW_ENOMEM ? "..." : "", off, ptr);
+
+		ret = unw_step(&cursor);
+		if (ret < 0)
+			ERR("unw_step: %s [%d]", unw_strerror(ret), ret);
+	}
+}
+#else /* USE_LIBUNWIND */
+
+#include <execinfo.h>
+
+#define	SIZE 100
+
+/*
+ * ut_dump_backtrace -- dump stacktrace to error log using libc's backtrace
+ */
+void
+ut_dump_backtrace(void)
+{
+	int j, nptrs;
+	void *buffer[SIZE];
+	char **strings;
+
+	nptrs = backtrace(buffer, SIZE);
+
+	strings = backtrace_symbols(buffer, nptrs);
+	if (strings == NULL) {
+		ERR("!backtrace_symbols");
+		return;
+	}
+
+	for (j = 0; j < nptrs; j++)
+		ERR("%u: %s", j, strings[j]);
+
+	free(strings);
+}
+
+#endif
+
+/*
+ * ut_sighandler -- fatal signal handler
+ */
+void
+ut_sighandler(int sig)
+{
+	ERR("\n");
+	ERR("Signal %d, backtrace:", sig);
+	ut_dump_backtrace();
+	ERR("\n");
+}
+
+/*
+ * ut_register_sighandlers -- register signal handlers for various fatal signals
+ */
+void
+ut_register_sighandlers()
+{
+	signal(SIGSEGV, ut_sighandler);
+	signal(SIGABRT, ut_sighandler);
+	signal(SIGILL, ut_sighandler);
+	signal(SIGQUIT, ut_sighandler);
+	signal(SIGFPE, ut_sighandler);
+	signal(SIGBUS, ut_sighandler);
+	signal(SIGINT, ut_sighandler);
+}


### PR DESCRIPTION
Libc's implementation:
Signal 6, backtrace:
0: ./obj_many_size_allocs() [0x4041bf]
1: ./obj_many_size_allocs() [0x40426f]
2: /lib/x86_64-linux-gnu/libc.so.6(+0x35180) [0x56c3180]
3: /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x37) [0x56c3107]
4: /lib/x86_64-linux-gnu/libc.so.6(abort+0x148) [0x56c44e8]
5: ../../debug/libpmemobj.so.1(+0x236ab) [0x4e556ab]
6: ../../debug/libpmemobj.so.1(pmemobj_alloc_usable_size+0xb9) [0x4e39ef2]
7: ../../debug/libpmemobj.so.1(+0x4225) [0x4e36225]
8: ../../debug/libpmemobj.so.1(+0x4a49) [0x4e36a49]
9: ../../debug/libpmemobj.so.1(+0x60ec) [0x4e380ec]
10: ../../debug/libpmemobj.so.1(pmemobj_check+0x66) [0x4e38609]
11: ./obj_many_size_allocs() [0x401c18]
12: ./obj_many_size_allocs() [0x401de6]
13: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5) [0x56afb45]
14: ./obj_many_size_allocs() [0x4019b9]

Libunwind's implementation (enabled by make USE_LIBUNWIND=1):
Signal 6, backtrace:
0: ./obj_many_size_allocs (ut_sighandler+0x2c) [0x4046c6]
1: /lib/x86_64-linux-gnu/libc.so.6 (killpg+0x40) [0x5ae21bf]
2: /lib/x86_64-linux-gnu/libc.so.6 (gsignal+0x37) [0x5ae2107]
3: /lib/x86_64-linux-gnu/libc.so.6 (abort+0x148) [0x5ae34e8]
4: ../../debug/libpmemobj.so.1 (out_err+0x0) [0x52745df]
5: ../../debug/libpmemobj.so.1 (pmemobj_alloc_usable_size+0xb9) [0x5258ef2]
6: ../../debug/libpmemobj.so.1 (pmemobj_vg_register_object+0xc9) [0x5255225]
7: ../../debug/libpmemobj.so.1 (pmemobj_vg_boot+0xd5) [0x5255a49]
8: ../../debug/libpmemobj.so.1 (pmemobj_open_common+0x52e) [0x52570ec]
9: ../../debug/libpmemobj.so.1 (pmemobj_check+0x66) [0x5257609]
10: ./obj_many_size_allocs (test_allocs+0x153) [0x401e68]
11: ./obj_many_size_allocs (main+0xda) [0x402036]
12: /lib/x86_64-linux-gnu/libc.so.6 (__libc_start_main+0xf5) [0x5aceb45]
13: ./obj_many_size_allocs (_start+0x29) [0x401c09]
14: ? (?+0x29) [0x29]