### PR TITLE
jemalloc: fix left shift which overflows

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/arena.h
+++ b/src/jemalloc/include/jemalloc/internal/arena.h
@@ -541,7 +541,7 @@ small_size2bin_compute(size_t size)
 		size_t lg_delta = (x < LG_SIZE_CLASS_GROUP + LG_QUANTUM + 1)
 		    ? LG_QUANTUM : x - LG_SIZE_CLASS_GROUP - 1;
 
-		size_t delta_inverse_mask = ZI(-1) << lg_delta;
+		size_t delta_inverse_mask = ZU(-1) << lg_delta;
 		size_t mod = ((((size-1) & delta_inverse_mask) >> lg_delta)) &
 		    ((ZU(1) << LG_SIZE_CLASS_GROUP) - 1);
 

--- a/src/jemalloc/include/jemalloc/internal/arena.h
+++ b/src/jemalloc/include/jemalloc/internal/arena.h
@@ -541,8 +541,7 @@ small_size2bin_compute(size_t size)
 		size_t lg_delta = (x < LG_SIZE_CLASS_GROUP + LG_QUANTUM + 1)
 		    ? LG_QUANTUM : x - LG_SIZE_CLASS_GROUP - 1;
 
-		size_t delta_inverse_mask = ZU(-1) << lg_delta;
-		size_t mod = ((((size-1) & delta_inverse_mask) >> lg_delta)) &
+		size_t mod = ((size - 1) >> lg_delta) &
 		    ((ZU(1) << LG_SIZE_CLASS_GROUP) - 1);
 
 		size_t bin = NTBINS + grp + mod;


### PR DESCRIPTION
This code is fishy. I'm not sure what was intended here.