### PR TITLE
obj: add root object constructor

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -159,6 +159,9 @@ libpmemobj \- persistent memory transactional object store
 .B Root object management:
 .sp
 .BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size );
+.BI "PMEMoid pmemobj_root_construct(PMEMobjpool *" pop ", size_t " size,
+.BI "    void (*" constructor ")(PMEMobjpool *" pop ", void *" ptr ", void *" arg "),
+.BI "    void *" arg );
 .BI "size_t pmemobj_root_size(PMEMobjpool *" pop );
 .sp
 .BI "POBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
@@ -1396,6 +1399,22 @@ function shall not fail, except for the case if the requested object size
 is larger than the maximum allocation size supported for given pool,
 or if there is not enough free space in the pool to satisfy the reallocation
 of the root object.  In such case, OID_NULL is returned.
+.PP
+.PP
+.BI "PMEMoid pmemobj_root_construct(PMEMobjpool *" pop ", size_t " size,
+.BI "    void (*" constructor ")(PMEMobjpool *" pop ", void *" ptr ", void *" arg "),
+.BI "    void *" arg );
+.IP
+The
+.BR pmemobj_root_construct ()
+performs the same actions as the
+.BR pmemobj_root ()
+function, but instead of zeroing the newly allocated object a
+.I constructor
+function is called. The constructor is also called on reallocations. The
+.BR pmemobj_root_size ()
+can be used in the constructor to check whether it's the first call to the
+constructor.
 .PP
 .BI "POBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
 .IP

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -420,6 +420,13 @@ int pmemobj_type_num(PMEMoid oid);
 PMEMoid pmemobj_root(PMEMobjpool *pop, size_t size);
 
 /*
+ * Same as above, but calls the constructor function when the object is first
+ * created and on all subsequent reallocations.
+ */
+PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg);
+
+/*
  * Returns the size in bytes of the root object. Always equal to the requested
  * size.
  */

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -69,6 +69,7 @@ libpmemobj.so {
 		pmemobj_alloc_usable_size;
 		pmemobj_type_num;
 		pmemobj_root;
+		pmemobj_root_construct;
 		pmemobj_root_size;
 		pmemobj_first;
 		pmemobj_next;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1123,6 +1123,8 @@ struct carg_realloc {
 	size_t old_size;
 	size_t new_size;
 	unsigned int user_type;
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg);
+	void *arg;
 };
 
 /*
@@ -1223,6 +1225,8 @@ obj_realloc_common(PMEMobjpool *pop, struct object_store *store,
 	carg.new_size = size;
 	carg.old_size = pmemobj_alloc_usable_size(*oidp);
 	carg.user_type = type_num;
+	carg.constructor = NULL;
+	carg.arg = NULL;
 
 	struct oob_header *pobj = OOB_HEADER_FROM_OID(pop, *oidp);
 	uint16_t user_type_old = pobj->user_type;
@@ -1340,11 +1344,18 @@ constructor_zrealloc_root(PMEMobjpool *pop, void *ptr, void *arg)
 	ASSERTne(ptr, NULL);
 	ASSERTne(arg, NULL);
 
+	struct carg_realloc *carg = arg;
+
 	VALGRIND_ADD_TO_TX(OOB_HEADER_FROM_PTR(ptr),
-		((struct carg_realloc *)arg)->new_size + OBJ_OOB_SIZE);
+		carg->new_size + OBJ_OOB_SIZE);
+
 	constructor_zrealloc(pop, ptr, arg);
+
+	if (carg->constructor)
+		carg->constructor(pop, ptr, carg->arg);
+
 	VALGRIND_REMOVE_FROM_TX(OOB_HEADER_FROM_PTR(ptr),
-		((struct carg_realloc *)arg)->new_size + OBJ_OOB_SIZE);
+		carg->new_size + OBJ_OOB_SIZE);
 }
 
 /*
@@ -1557,6 +1568,8 @@ pmemobj_type_num(PMEMoid oid)
 /* arguments for constructor_alloc_root */
 struct carg_root {
 	size_t size;
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg);
+	void *arg;
 };
 
 /*
@@ -1576,7 +1589,10 @@ constructor_alloc_root(PMEMobjpool *pop, void *ptr, void *arg)
 	/* temporarily add atomic root allocation to pmemcheck transaction */
 	VALGRIND_ADD_TO_TX(ro, OBJ_OOB_SIZE + carg->size);
 
-	pop->memset_persist(pop, ptr, 0, carg->size);
+	if (carg->constructor)
+		carg->constructor(pop, ptr, carg->arg);
+	else
+		pop->memset_persist(pop, ptr, 0, carg->size);
 
 	ro->internal_type = TYPE_ALLOCATED;
 	ro->user_type = POBJ_ROOT_TYPE_NUM;
@@ -1596,7 +1612,8 @@ constructor_alloc_root(PMEMobjpool *pop, void *ptr, void *arg)
  * obj_alloc_root -- (internal) allocate root object
  */
 static int
-obj_alloc_root(PMEMobjpool *pop, struct object_store *store, size_t size)
+obj_alloc_root(PMEMobjpool *pop, struct object_store *store, size_t size,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg)
 {
 	LOG(3, "pop %p store %p size %zu", pop, store, size);
 
@@ -1604,6 +1621,8 @@ obj_alloc_root(PMEMobjpool *pop, struct object_store *store, size_t size)
 	struct carg_root carg;
 
 	carg.size = size;
+	carg.constructor = constructor;
+	carg.arg = arg;
 
 	return list_insert_new(pop, lhead, 0, NULL, OID_NULL, 0,
 				size, constructor_alloc_root, &carg, NULL);
@@ -1614,7 +1633,8 @@ obj_alloc_root(PMEMobjpool *pop, struct object_store *store, size_t size)
  */
 static int
 obj_realloc_root(PMEMobjpool *pop, struct object_store *store, size_t size,
-	size_t old_size)
+	size_t old_size,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg)
 {
 	LOG(3, "pop %p store %p size %zu old_size %zu",
 		pop, store, size, old_size);
@@ -1627,6 +1647,8 @@ obj_realloc_root(PMEMobjpool *pop, struct object_store *store, size_t size,
 	carg.old_size = old_size;
 	carg.new_size = size;
 	carg.user_type = POBJ_ROOT_TYPE_NUM;
+	carg.constructor = constructor;
+	carg.arg = arg;
 
 	return list_realloc(pop, lhead, 0, NULL, size,
 				constructor_zrealloc_root, &carg,
@@ -1650,12 +1672,13 @@ pmemobj_root_size(PMEMobjpool *pop)
 }
 
 /*
- * pmemobj_root -- returns root object
+ * pmemobj_root_construct -- returns root object
  */
-PMEMoid
-pmemobj_root(PMEMobjpool *pop, size_t size)
+PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg)
 {
-	LOG(3, "pop %p size %zu", pop, size);
+	LOG(3, "pop %p size %zu constructor %p args %p", pop, size, constructor,
+		arg);
 
 	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
 		ERR("requested size too large");
@@ -1668,11 +1691,12 @@ pmemobj_root(PMEMobjpool *pop, size_t size)
 	pmemobj_mutex_lock(pop, &pop->rootlock);
 	if (pop->store->root.head.pe_first.off == 0)
 		/* root object list is empty */
-		obj_alloc_root(pop, pop->store, size);
+		obj_alloc_root(pop, pop->store, size, constructor, arg);
 	else {
 		size_t old_size = pmemobj_root_size(pop);
 		if (size > old_size)
-			if (obj_realloc_root(pop, pop->store, size, old_size)) {
+			if (obj_realloc_root(pop, pop->store, size, old_size,
+				constructor, arg)) {
 				pmemobj_mutex_unlock(pop, &pop->rootlock);
 				LOG(2, "obj_realloc_root failed");
 				return OID_NULL;
@@ -1681,6 +1705,17 @@ pmemobj_root(PMEMobjpool *pop, size_t size)
 	root = pop->store->root.head.pe_first;
 	pmemobj_mutex_unlock(pop, &pop->rootlock);
 	return root;
+}
+
+/*
+ * pmemobj_root -- returns root object
+ */
+PMEMoid
+pmemobj_root(PMEMobjpool *pop, size_t size)
+{
+	LOG(3, "pop %p size %zu", pop, size);
+
+	return pmemobj_root_construct(pop, size, NULL, NULL);
 }
 
 /*

--- a/src/test/obj_store/TEST6
+++ b/src/test/obj_store/TEST6
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_store/TEST6 -- unit test for pmemobj_root_construct
+#
+export UNITTEST_NAME=obj_store/TEST6
+export UNITTEST_NUM=6
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+create_nonzeroed_file 8 4 $DIR/testfile1
+
+expect_normal_exit ./obj_store$EXESUFFIX $DIR/testfile1 c
+
+pass

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -35,6 +35,7 @@ pmemobj_persist
 pmemobj_pool
 pmemobj_realloc
 pmemobj_root
+pmemobj_root_construct
 pmemobj_root_size
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
@@ -99,6 +100,7 @@ pmemobj_persist
 pmemobj_pool
 pmemobj_realloc
 pmemobj_root
+pmemobj_root_construct
 pmemobj_root_size
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
@@ -163,6 +165,7 @@ pmemobj_persist
 pmemobj_pool
 pmemobj_realloc
 pmemobj_root
+pmemobj_root_construct
 pmemobj_root_size
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
@@ -227,6 +230,7 @@ pmemobj_persist
 pmemobj_pool
 pmemobj_realloc
 pmemobj_root
+pmemobj_root_construct
 pmemobj_root_size
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock


### PR DESCRIPTION
Right now the root object is initialized with zeroes and there's no
way around it. This patch addresses this problem by allowing the user
to specify a constructor which is called when the root object is first
created.