### PR TITLE
obj: remove pool ptr from locks

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -65,31 +65,28 @@ libpmemobj \- persistent memory transactional object store
 .sp
 .B Locking:
 .sp
-.BI "void pmemobj_mutex_zero(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
-.BI "int pmemobj_mutex_lock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
-.BI "int pmemobj_mutex_trylock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
-.BI "int pmemobj_mutex_unlock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "void pmemobj_mutex_init(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_lock(PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_trylock(PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_unlock(PMEMmutex *" mutexp );
 .sp
-.BI "void pmemobj_rwlock_zero(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
-.BI "int pmemobj_rwlock_rdlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
-.BI "int pmemobj_rwlock_wrlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
-.BI "int pmemobj_rwlock_timedrdlock(PMEMobjpool *" pop ,
-.BI "    PMEMrwlock *restrict " rwlockp ,
+.BI "void pmemobj_rwlock_init(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_rdlock(PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_wrlock(PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_timedrdlock(PMEMrwlock *restrict " rwlockp ,
 .BI "    const struct timespec *restrict " abstime );
-.BI "int pmemobj_rwlock_timedwrlock(PMEMobjpool *" pop ,
-.BI "    PMEMrwlock *restrict " rwlockp ,
+.BI "int pmemobj_rwlock_timedwrlock(PMEMrwlock *restrict " rwlockp ,
 .BI "    const struct timespec *restrict " abstime );
-.BI "int pmemobj_rwlock_tryrdlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
-.BI "int pmemobj_rwlock_trywrlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
-.BI "int pmemobj_rwlock_unlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_tryrdlock(PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_trywrlock(PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_unlock(PMEMrwlock *" rwlockp );
 .sp
-.BI "void pmemobj_cond_zero(PMEMobjpool *" pop ", PMEMcond *" condp );
-.BI "int pmemobj_cond_broadcast(PMEMobjpool *" pop ", PMEMcond *" condp );
-.BI "int pmemobj_cond_signal(PMEMobjpool *" pop ", PMEMcond *" condp );
-.BI "int pmemobj_cond_timedwait(PMEMobjpool *" pop ", PMEMcond *restrict " condp ,
+.BI "void pmemobj_cond_init(PMEMobjpool *" pop ", PMEMcond *" condp );
+.BI "int pmemobj_cond_broadcast(PMEMcond *" condp );
+.BI "int pmemobj_cond_signal(PMEMcond *" condp );
+.BI "int pmemobj_cond_timedwait(PMEMcond *restrict " condp ,
 .BI "    PMEMmutex *restrict " mutexp ", const struct timespec *restrict " abstime );
-.BI "int pmemobj_cond_wait(PMEMobjpool *" pop ", PMEMcond *" condp ,
-.BI "    PMEMmutex *restrict " mutexp );
+.BI "int pmemobj_cond_wait(MEMcond *" condp ", PMEMmutex *restrict " mutexp );
 .sp
 .B Persistent object identifier:
 .sp
@@ -723,21 +720,14 @@ or
 .I PMEMcond
 type respectively.
 .PP
-.BI "void pmemobj_mutex_zero(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "void pmemobj_mutex_init(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
 .IP
 The
-.BR pmemobj_mutex_zero ()
+.BR pmemobj_mutex_init ()
 function explicitly initializes pmem-aware mutex pointed by
-.I mutexp
-by zeroing it.
-Initialization is not necessary if the object containing the mutex has been
-allocated using one of
-.BR pmemobj_zalloc ()
-or
-.BR pmemobj_tx_zalloc ()
-functions.
+.IR mutexp .
 .PP
-.BI "int pmemobj_mutex_lock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_lock(PMEMmutex *" mutexp );
 .IP
 The
 .BR pmemobj_mutex_lock ()
@@ -746,10 +736,9 @@ function locks pmem-aware mutex pointed by
 If the mutex is already locked, the calling thread will block until the
 mutex becomes available.
 If this is the first use of the mutex since opening of the pool
-.IR pop ,
 the mutex is automatically reinitialized and then locked.
 .PP
-.BI "int pmemobj_mutex_trylock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_trylock(PMEMmutex *" mutexp );
 .IP
 The
 .BR pmemobj_mutex_trylock ()
@@ -759,10 +748,9 @@ If the mutex is already locked,
 .BR pthread_mutex_trylock ()
 will not block waiting for the mutex, but will return an error condition.
 If this is the first use of the mutex since opening of the pool
-.I pop
 the mutex is automatically reinitialized and then locked.
 .PP
-.BI "int pmemobj_mutex_unlock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
+.BI "int pmemobj_mutex_unlock(PMEMmutex *" mutexp );
 .IP
 The
 .BR pmemobj_mutex_unlock ()
@@ -772,22 +760,15 @@ Undefined behavior follows if a thread tries to unlock a mutex that has
 not been locked by it, or if a thread tries to release a mutex that is already
 unlocked or not initialized.
 .PP
-.BI "void pmemobj_rwlock_zero(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "void pmemobj_rwlock_init(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
 .IP
 The
-.BR pmemobj_rwlock_zero ()
+.BR pmemobj_rwlock_init ()
 function is used to explicitly initialize pmem-aware read/write lock pointed
 by
-.I rwlockp
-by zeroing it.
-Initialization is not necessary if the object containing the lock has been
-allocated using one of
-.BR pmemobj_zalloc ()
-or
-.BR pmemobj_tx_zalloc ()
-functions.
+.IR rwlockp .
 .PP
-.BI "int pmemobj_rwlock_rdlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_rdlock(PMEMrwlock *" rwlockp );
 .IP
 The
 .BR pmemobj_rwlock_rdlock ()
@@ -798,12 +779,9 @@ threads are presently blocked on the lock.  If the read lock cannot be
 immediately acquired, the calling thread blocks until it can acquire the
 lock.
 If this is the first use of the lock since opening of the pool
-.IR pop ,
 the lock is automatically reinitialized and then acquired.
 .PP
-.BI "int pmemobj_rwlock_timedrdlock(PMEMobjpool *" pop ,
-.br
-.BI "    PMEMrwlock *restrict " rwlockp ,
+.BI "int pmemobj_rwlock_timedrdlock(PMEMrwlock *restrict " rwlockp ,
 .br
 .BI "    const struct timespec *restrict "abstime );
 .IP
@@ -820,7 +798,7 @@ must be called once for each lock obtained.
 The results of acquiring a read lock while the calling thread holds a
 write lock are undefined.
 .PP
-.BI "int pmemobj_rwlock_wrlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_wrlock(PMEMrwlock *" rwlockp );
 .IP
 The
 .BR pmemobj_rwlock_wrlock ()
@@ -830,9 +808,7 @@ If this is the first use of the lock since opening of the pool
 .IR pop ,
 the lock is automatically reinitialized and then acquired.
 .PP
-.BI "int pmemobj_rwlock_timedwrlock(PMEMobjpool *" pop ,
-.br
-.BI "    PMEMrwlock *restrict " rwlockp ,
+.BI "int pmemobj_rwlock_timedwrlock(PMEMrwlock *restrict " rwlockp ,
 .br
 .BI "    const struct timespec *restrict " abstime );
 .IP
@@ -842,7 +818,7 @@ performs the same action, but will not wait beyond
 .I abstime
 to obtain the lock before returning.
 .PP
-.BI "int pmemobj_rwlock_tryrdlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_tryrdlock(PMEMrwlock *" rwlockp );
 .IP
 The
 .BR pmemobj_rwlock_tryrdlock ()
@@ -853,7 +829,7 @@ but does not block if the lock cannot be immediately obtained.
 The results are undefined if the calling thread already holds the lock at
 the time the call is made.
 .PP
-.BI "int pmemobj_rwlock_trywrlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_trywrlock(PMEMrwlock *" rwlockp );
 .IP
 The
 .BR pmemobj_rwlock_trywrlock ()
@@ -864,7 +840,7 @@ but does not block if the lock cannot be immediately obtained.
 The results are undefined if the calling thread already holds the lock at
 the time the call is made.
 .PP
-.BI "int pmemobj_rwlock_unlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
+.BI "int pmemobj_rwlock_unlock(PMEMrwlock *" rwlockp );
 .IP
 The
 .BR pmemobj_rwlock_unlock ()
@@ -875,21 +851,15 @@ function is used to release the read/write lock previously obtained by
 or
 .BR pmemobj_rwlock_trywrlock ().
 .PP
-.BI "void pmemobj_cond_zero(PMEMobjpool *" pop ", PMEMcond *" condp );
+.BI "void pmemobj_cond_init(PMEMobjpool *" pop ", PMEMcond *" condp );
 .IP
 The
-.BR pmemobj_cond_zero ()
-function explicitly initializes pmem-aware condition variable by zeroing it.
-Initialization is not necessary if the object containing the condition
-variable has been allocated using one of
-.BR pmemobj_zalloc ()
-or
-.BR pmemobj_tx_zalloc ()
-functions.
+.BR pmemobj_cond_init ()
+function explicitly initializes pmem-aware condition variable.
 .PP
-.BI "int pmemobj_cond_broadcast(PMEMobjpool *" pop ", PMEMcond *" condp );
+.BI "int pmemobj_cond_broadcast(PMEMcond *" condp );
 .sp
-.BI "int pmemobj_cond_signal(PMEMobjpool *" pop ", PMEMcond *" condp );
+.BI "int pmemobj_cond_signal(PMEMcond *" condp );
 .IP
 The difference between
 .BR pmemobj_cond_broadcast ()
@@ -905,13 +875,13 @@ in which threads are unblocked.  The same mutex used for waiting must be held
 while calling either function.  Although neither function strictly enforces
 this requirement, undefined behavior may follow if the mutex is not held.
 .PP
-.BI "int pmemobj_cond_timedwait(PMEMobjpool *" pop ", PMEMcond *restrict " condp ,
+.BI "int pmemobj_cond_timedwait(PMEMcond *restrict " condp ,
 .br
 .BI "    PMEMmutex *restrict " mutexp ,
 .br
 .BI "    const struct timespec *restrict " abstime );
 .sp
-.BI "int pmemobj_cond_wait(PMEMobjpool *" pop ", PMEMcond *" condp ,
+.BI "int pmemobj_cond_wait(PMEMcond *" condp ,
 .br
 .BI "    PMEMmutex *restrict " mutexp );
 .IP

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
@@ -267,7 +267,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 	bp = POBJ_ROOT(pop, struct base);
 
 	/* acquire a read lock */
-	if (pmemobj_rwlock_rdlock(pop, &D_RW(bp)->rwlock) != 0)
+	if (pmemobj_rwlock_rdlock(&D_RW(bp)->rwlock) != 0)
 		return;
 
 	TOID(struct log) next;
@@ -279,7 +279,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 		next = D_RO(next)->hdr.next;
 	}
 
-	pmemobj_rwlock_unlock(pop, &D_RW(bp)->rwlock);
+	pmemobj_rwlock_unlock(&D_RW(bp)->rwlock);
 }
 
 /*

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
@@ -112,6 +112,7 @@ pmemlog_map(PMEMobjpool *pop, size_t fsize)
 		D_RW(bp)->log = TX_ALLOC(struct log, pool_size);
 		D_RW(D_RW(bp)->log)->hdr.data_size =
 				pool_size - sizeof (struct log_hdr);
+		pmemobj_rwlock_init(pop, &D_RW(bp)->rwlock);
 	} TX_ONABORT {
 		retval = -1;
 	} TX_END
@@ -303,7 +304,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 
 	/* acquire a rdlock here */
 	int err;
-	if ((err = pmemobj_rwlock_rdlock(pop, &D_RW(bp)->rwlock)) != 0) {
+	if ((err = pmemobj_rwlock_rdlock(&D_RW(bp)->rwlock)) != 0) {
 		errno = err;
 		return;
 	}
@@ -322,7 +323,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 		read_ptr += read_size;
 	}
 
-	pmemobj_rwlock_unlock(pop, &D_RW(bp)->rwlock);
+	pmemobj_rwlock_unlock(&D_RW(bp)->rwlock);
 }
 
 /*

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -114,53 +114,53 @@ const char *pmemobj_errormsg(void);
 typedef union padded_pmemmutex {
 	char padding[_POBJ_CL_ALIGNMENT];
 	struct {
-		uint64_t runid;
 		pthread_mutex_t mutex;
+		uint64_t runid;
+		uint64_t pool_uuid_lo;
 	} pmemmutex;
 } PMEMmutex;
 
 typedef union padded_pmemrwlock {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_ALIGNMENT * 2];
 	struct {
-		uint64_t runid;
 		pthread_rwlock_t rwlock;
+		uint64_t runid;
+		uint64_t pool_uuid_lo;
 	} pmemrwlock;
 } PMEMrwlock;
 
 typedef union padded_pmemcond {
 	char padding[_POBJ_CL_ALIGNMENT];
 	struct {
-		uint64_t runid;
 		pthread_cond_t cond;
+		uint64_t runid;
+		uint64_t pool_uuid_lo;
 	} pmemcond;
 } PMEMcond;
 
-void pmemobj_mutex_zero(PMEMobjpool *pop, PMEMmutex *mutexp);
-int pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp);
-int pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp);
-int pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp);
+void pmemobj_mutex_init(PMEMobjpool *pop, PMEMmutex *mutexp);
+int pmemobj_mutex_lock(PMEMmutex *mutexp);
+int pmemobj_mutex_trylock(PMEMmutex *mutexp);
+int pmemobj_mutex_unlock(PMEMmutex *mutexp);
 
-void pmemobj_rwlock_zero(PMEMobjpool *pop, PMEMrwlock *rwlockp);
-int pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
-int pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
-int pmemobj_rwlock_timedrdlock(PMEMobjpool *pop,
-	PMEMrwlock *__restrict rwlockp,
+void pmemobj_rwlock_init(PMEMobjpool *pop, PMEMrwlock *rwlockp);
+int pmemobj_rwlock_rdlock(PMEMrwlock *rwlockp);
+int pmemobj_rwlock_wrlock(PMEMrwlock *rwlockp);
+int pmemobj_rwlock_timedrdlock(PMEMrwlock *__restrict rwlockp,
 	const struct timespec *__restrict abs_timeout);
-int pmemobj_rwlock_timedwrlock(PMEMobjpool *pop,
-	PMEMrwlock *__restrict rwlockp,
+int pmemobj_rwlock_timedwrlock(PMEMrwlock *__restrict rwlockp,
 	const struct timespec *__restrict abs_timeout);
-int pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
-int pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
-int pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp);
+int pmemobj_rwlock_tryrdlock(PMEMrwlock *rwlockp);
+int pmemobj_rwlock_trywrlock(PMEMrwlock *rwlockp);
+int pmemobj_rwlock_unlock(PMEMrwlock *rwlockp);
 
-void pmemobj_cond_zero(PMEMobjpool *pop, PMEMcond *condp);
-int pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp);
-int pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp);
-int pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *__restrict condp,
+void pmemobj_cond_init(PMEMobjpool *pop, PMEMcond *condp);
+int pmemobj_cond_broadcast(PMEMcond *condp);
+int pmemobj_cond_signal(PMEMcond *condp);
+int pmemobj_cond_timedwait(PMEMcond *__restrict condp,
 	PMEMmutex *__restrict mutexp,
 	const struct timespec *__restrict abstime);
-int pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
-	PMEMmutex *__restrict mutexp);
+int pmemobj_cond_wait(PMEMcond *condp, PMEMmutex *__restrict mutexp);
 
 /*
  * Persistent memory object
@@ -607,6 +607,9 @@ struct name {\
 	TOID(type) pe_first;\
 	PMEMmutex lock;\
 }
+
+#define	POBJ_LIST_INIT(pop, head)\
+pmemobj_mutex_init((pop), &(head)->lock)
 
 int pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, void *head,
 	PMEMoid dest, int before, PMEMoid oid);

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -41,11 +41,11 @@ libpmemobj.so {
 		pmemobj_open;
 		pmemobj_close;
 		pmemobj_check;
-		pmemobj_mutex_zero;
+		pmemobj_mutex_init;
 		pmemobj_mutex_lock;
 		pmemobj_mutex_trylock;
 		pmemobj_mutex_unlock;
-		pmemobj_rwlock_zero;
+		pmemobj_rwlock_init;
 		pmemobj_rwlock_rdlock;
 		pmemobj_rwlock_wrlock;
 		pmemobj_rwlock_timedrdlock;
@@ -53,7 +53,7 @@ libpmemobj.so {
 		pmemobj_rwlock_tryrdlock;
 		pmemobj_rwlock_trywrlock;
 		pmemobj_rwlock_unlock;
-		pmemobj_cond_zero;
+		pmemobj_cond_init;
 		pmemobj_cond_broadcast;
 		pmemobj_cond_signal;
 		pmemobj_cond_timedwait;

--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -118,7 +118,7 @@ list_mutexes_lock(PMEMobjpool *pop,
 	ASSERTne(head1, NULL);
 
 	if (!head2)
-		return pmemobj_mutex_lock(pop, &head1->lock);
+		return pmemobj_mutex_lock(&head1->lock);
 
 	PMEMmutex *lock1;
 	PMEMmutex *lock2;
@@ -131,14 +131,14 @@ list_mutexes_lock(PMEMobjpool *pop,
 	}
 
 	int ret;
-	if ((ret = pmemobj_mutex_lock(pop, lock1)))
+	if ((ret = pmemobj_mutex_lock(lock1)))
 		goto err;
-	if ((ret = pmemobj_mutex_lock(pop, lock2)))
+	if ((ret = pmemobj_mutex_lock(lock2)))
 		goto err_unlock;
 
 	return 0;
 err_unlock:
-	pmemobj_mutex_unlock(pop, lock1);
+	pmemobj_mutex_unlock(lock1);
 err:
 	return ret;
 }
@@ -153,10 +153,10 @@ list_mutexes_unlock(PMEMobjpool *pop,
 	ASSERTne(head1, NULL);
 
 	if (!head2)
-		return pmemobj_mutex_unlock(pop, &head1->lock);
+		return pmemobj_mutex_unlock(&head1->lock);
 
-	int ret1 = pmemobj_mutex_unlock(pop, &head1->lock);
-	int ret2 = pmemobj_mutex_unlock(pop, &head2->lock);
+	int ret1 = pmemobj_mutex_unlock(&head1->lock);
+	int ret2 = pmemobj_mutex_unlock(&head2->lock);
 
 	return ret2 ? ret2 : ret1;
 }
@@ -735,13 +735,13 @@ list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
 	 *
 	 * XXX performance improvement: initialize oob locks at pool opening
 	 */
-	if ((ret = pmemobj_mutex_lock(pop, &oob_head->lock))) {
+	if ((ret = pmemobj_mutex_lock(&oob_head->lock))) {
 		LOG(2, "pmemobj_mutex_lock failed");
 		goto err_oob_lock;
 	}
 
 	if (head) {
-		if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+		if ((ret = pmemobj_mutex_lock(&head->lock))) {
 			LOG(2, "pmemobj_mutex_lock failed");
 			goto err_lock;
 		}
@@ -820,13 +820,13 @@ list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
 	ret = 0;
 
 	if (head) {
-		out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+		out_ret = pmemobj_mutex_unlock(&head->lock);
 		ASSERTeq(out_ret, 0);
 		if (out_ret)
 			LOG(2, "pmemobj_mutex_unlock failed");
 	}
 err_lock:
-	out_ret = pmemobj_mutex_unlock(pop, &oob_head->lock);
+	out_ret = pmemobj_mutex_unlock(&oob_head->lock);
 	ASSERTeq(out_ret, 0);
 	if (out_ret)
 		LOG(2, "pmemobj_mutex_unlock failed");
@@ -869,7 +869,7 @@ list_insert(PMEMobjpool *pop,
 		return ret;
 	}
 
-	if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+	if ((ret = pmemobj_mutex_lock(&head->lock))) {
 		LOG(2, "pmemobj_mutex_lock failed");
 		goto err;
 	}
@@ -921,7 +921,7 @@ list_insert(PMEMobjpool *pop,
 	ASSERT(redo_index <= REDO_NUM_ENTRIES);
 	redo_log_process(pop, redo, REDO_NUM_ENTRIES);
 
-	out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+	out_ret = pmemobj_mutex_unlock(&head->lock);
 	ASSERTeq(out_ret, 0);
 	if (out_ret)
 		LOG(2, "pmemobj_mutex_unlock failed");
@@ -970,13 +970,13 @@ list_remove_free(PMEMobjpool *pop, struct list_head *oob_head,
 	 *
 	 * XXX performance improvement: initialize oob locks at pool opening
 	 */
-	if ((ret = pmemobj_mutex_lock(pop, &oob_head->lock))) {
+	if ((ret = pmemobj_mutex_lock(&oob_head->lock))) {
 		LOG(2, "pmemobj_mutex_lock failed");
 		goto err_oob_lock;
 	}
 
 	if (head) {
-		if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+		if ((ret = pmemobj_mutex_lock(&head->lock))) {
 			LOG(2, "pmemobj_mutex_lock failed");
 			goto err_lock;
 		}
@@ -1034,7 +1034,7 @@ list_remove_free(PMEMobjpool *pop, struct list_head *oob_head,
 	redo_log_process(pop, redo, REDO_NUM_ENTRIES);
 
 	if (head) {
-		out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+		out_ret = pmemobj_mutex_unlock(&head->lock);
 		ASSERTeq(out_ret, 0);
 		if (out_ret)
 			LOG(2, "pmemobj_mutex_unlock failed");
@@ -1053,7 +1053,7 @@ list_remove_free(PMEMobjpool *pop, struct list_head *oob_head,
 	}
 
 err_lock:
-	out_ret = pmemobj_mutex_unlock(pop, &oob_head->lock);
+	out_ret = pmemobj_mutex_unlock(&oob_head->lock);
 	ASSERTeq(out_ret, 0);
 	if (out_ret)
 		LOG(2, "pmemobj_mutex_unlock failed");
@@ -1095,7 +1095,7 @@ list_remove(PMEMobjpool *pop,
 	ASSERTne(lane_section, NULL);
 	ASSERTne(lane_section->layout, NULL);
 
-	if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+	if ((ret = pmemobj_mutex_lock(&head->lock))) {
 		LOG(2, "pmemobj_mutex_lock failed");
 		goto err;
 	}
@@ -1134,7 +1134,7 @@ list_remove(PMEMobjpool *pop,
 	ASSERT(redo_index <= REDO_NUM_ENTRIES);
 	redo_log_process(pop, redo, REDO_NUM_ENTRIES);
 
-	out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+	out_ret = pmemobj_mutex_unlock(&head->lock);
 	ASSERTeq(out_ret, 0);
 	if (out_ret)
 		LOG(2, "pmemobj_mutex_unlock failed");
@@ -1408,13 +1408,13 @@ list_realloc(PMEMobjpool *pop, struct list_head *oob_head,
 	 *
 	 * XXX performance improvement: initialize oob locks at pool opening
 	 */
-	if ((ret = pmemobj_mutex_lock(pop, &oob_head->lock))) {
+	if ((ret = pmemobj_mutex_lock(&oob_head->lock))) {
 		LOG(2, "pmemobj_mutex_lock failed");
 		goto err_oob_lock;
 	}
 
 	if (head) {
-		if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+		if ((ret = pmemobj_mutex_lock(&head->lock))) {
 			LOG(2, "pmemobj_mutex_lock failed");
 			goto err_lock;
 		}
@@ -1573,14 +1573,14 @@ list_realloc(PMEMobjpool *pop, struct list_head *oob_head,
 	ret = 0;
 err_unlock:
 	if (head) {
-		out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+		out_ret = pmemobj_mutex_unlock(&head->lock);
 		ASSERTeq(out_ret, 0);
 		if (out_ret)
 			LOG(2, "pmemobj_mutex_unlock failed");
 	}
 
 err_lock:
-	out_ret = pmemobj_mutex_unlock(pop, &oob_head->lock);
+	out_ret = pmemobj_mutex_unlock(&oob_head->lock);
 	ASSERTeq(out_ret, 0);
 	if (out_ret)
 		LOG(2, "pmemobj_mutex_unlock failed");
@@ -1653,7 +1653,7 @@ list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 	}
 
 	if (head) {
-		if ((ret = pmemobj_mutex_lock(pop, &head->lock))) {
+		if ((ret = pmemobj_mutex_lock(&head->lock))) {
 			LOG(2, "pmemobj_mutex_lock failed");
 			goto err_lock;
 		}
@@ -1828,7 +1828,7 @@ list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 	ret = 0;
 err_unlock:
 	if (head) {
-		out_ret = pmemobj_mutex_unlock(pop, &head->lock);
+		out_ret = pmemobj_mutex_unlock(&head->lock);
 		ASSERTeq(out_ret, 0);
 		if (out_ret)
 			LOG(2, "pmemobj_mutex_unlock failed");

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -117,6 +117,8 @@ typedef void *(*memset_fn)(PMEMobjpool *pop, void *dest, int c, size_t len);
 
 extern unsigned long Pagesize;
 
+extern struct cuckoo *pools;
+
 struct pmemobjpool {
 	struct pool_hdr hdr;	/* memory pool header */
 

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -278,6 +278,9 @@ test_list_api(PMEMobjpool *pop)
 	TOID(struct dummy_node) first;
 	TOID(struct dummy_node) iter;
 
+	POBJ_LIST_INIT(pop, &D_RW(root)->dummies);
+	POBJ_LIST_INIT(pop, &D_RW(root)->moved);
+
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
 		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
 					D_RO(iter)->value);
@@ -414,6 +417,8 @@ test_tx_api(PMEMobjpool *pop)
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct dummy_root)));
 
 	int *vstate = NULL; /* volatile state */
+
+	pmemobj_mutex_init(pop, &D_RW(root)->lock);
 
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		vstate = MALLOC(sizeof (*vstate));

--- a/src/test/obj_debug/obj_debug.c
+++ b/src/test/obj_debug/obj_debug.c
@@ -89,6 +89,9 @@ test_FOREACH(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead);
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead2);
+
 	POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->lhead, next,
 			sizeof (struct tobj), NULL, NULL);
 
@@ -128,6 +131,8 @@ test_lists(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead);
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead2);
 
 	COMMANDS_LISTS();
 	TX_BEGIN(pop) {

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -46,7 +46,7 @@
 #include "unittest.h"
 #include "valgrind_internal.h"
 
-#define	MOCK_POOL_SIZE PMEMOBJ_MIN_POOL
+#define	MOCK_POOL_SIZE PMEMOBJ_MIN_POOL * 2
 #define	TEST_MEGA_ALLOC_SIZE (1024 * 1024)
 #define	TEST_HUGE_ALLOC_SIZE (255 * 1024)
 #define	TEST_SMALL_ALLOC_SIZE (200)
@@ -59,7 +59,7 @@
 
 struct mock_pop {
 	PMEMobjpool p;
-	char lanes[LANE_SECTION_LEN];
+	char lanes[LANE_SECTION_LEN * 3];
 	uint64_t ptr;
 };
 
@@ -174,6 +174,7 @@ test_mock_pool_allocs()
 	mock_pop->persist = obj_persist;
 	mock_pop->flush = obj_flush;
 	mock_pop->drain = obj_drain;
+	pmemobj_mutex_init(mock_pop, &mock_pop->rootlock);
 
 	heap_init(mock_pop);
 	heap_boot(mock_pop);

--- a/src/test/obj_recovery/obj_recovery.c
+++ b/src/test/obj_recovery/obj_recovery.c
@@ -93,6 +93,7 @@ main(int argc, char *argv[])
 	void *lock = NULL;
 
 	if (argv[2][0] == 'y') {
+		pmemobj_mutex_init(pop, &D_RW(root)->lock);
 		lock_type = TX_LOCK_MUTEX;
 		lock = &D_RW(root)->lock;
 	}

--- a/src/test/obj_store/obj_store.c
+++ b/src/test/obj_store/obj_store.c
@@ -107,9 +107,12 @@ test_root_object(const char *path)
 
 	/* create root object */
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+
 	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 	ASSERT(util_is_zeroed(D_RO(root), sizeof (struct root)));
+
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead);
 
 	/* fill in root object */
 	strncpy(D_RW(root)->name, ROOT_NAME, MAX_ROOT_NAME);
@@ -343,6 +346,8 @@ test_user_lists(const char *path)
 	ASSERT(TOID_IS_NULL(root) == 0);
 	ASSERTeq(pmemobj_root_size(pop), sizeof (struct root));
 	ASSERT(util_is_zeroed(D_RW(root), sizeof (struct root)));
+
+	POBJ_LIST_INIT(pop, &D_RW(root)->lhead);
 
 	/* fill in root object */
 	strncpy(D_RW(root)->name, ROOT_NAME, MAX_ROOT_NAME);

--- a/src/test/obj_tx_locks/obj_tx_locks.c
+++ b/src/test/obj_tx_locks/obj_tx_locks.c
@@ -201,6 +201,10 @@ main(int argc, char *argv[])
 
 	test_obj.mutexes = CALLOC(NUM_LOCKS, sizeof (PMEMmutex));
 	test_obj.rwlocks = CALLOC(NUM_LOCKS, sizeof (PMEMrwlock));
+	for (int i = 0; i < NUM_LOCKS; ++i) {
+		pmemobj_mutex_init(test_obj.pop, &test_obj.mutexes[i]);
+		pmemobj_rwlock_init(test_obj.pop, &test_obj.rwlocks[i]);
+	}
 
 	if (multithread) {
 		run_mt_test(do_tx, &test_obj);

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -9,10 +9,10 @@ pmemobj_check
 pmemobj_check_version
 pmemobj_close
 pmemobj_cond_broadcast
+pmemobj_cond_init
 pmemobj_cond_signal
 pmemobj_cond_timedwait
 pmemobj_cond_wait
-pmemobj_cond_zero
 pmemobj_create
 pmemobj_drain
 pmemobj_errormsg
@@ -25,10 +25,10 @@ pmemobj_list_move
 pmemobj_list_remove
 pmemobj_memcpy_persist
 pmemobj_memset_persist
+pmemobj_mutex_init
 pmemobj_mutex_lock
 pmemobj_mutex_trylock
 pmemobj_mutex_unlock
-pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
@@ -36,6 +36,7 @@ pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
+pmemobj_rwlock_init
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
 pmemobj_rwlock_timedwrlock
@@ -43,7 +44,6 @@ pmemobj_rwlock_tryrdlock
 pmemobj_rwlock_trywrlock
 pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
-pmemobj_rwlock_zero
 pmemobj_set_funcs
 pmemobj_strdup
 pmemobj_tx_abort
@@ -73,10 +73,10 @@ pmemobj_check
 pmemobj_check_version
 pmemobj_close
 pmemobj_cond_broadcast
+pmemobj_cond_init
 pmemobj_cond_signal
 pmemobj_cond_timedwait
 pmemobj_cond_wait
-pmemobj_cond_zero
 pmemobj_create
 pmemobj_drain
 pmemobj_errormsg
@@ -89,10 +89,10 @@ pmemobj_list_move
 pmemobj_list_remove
 pmemobj_memcpy_persist
 pmemobj_memset_persist
+pmemobj_mutex_init
 pmemobj_mutex_lock
 pmemobj_mutex_trylock
 pmemobj_mutex_unlock
-pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
@@ -100,6 +100,7 @@ pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
+pmemobj_rwlock_init
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
 pmemobj_rwlock_timedwrlock
@@ -107,7 +108,6 @@ pmemobj_rwlock_tryrdlock
 pmemobj_rwlock_trywrlock
 pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
-pmemobj_rwlock_zero
 pmemobj_set_funcs
 pmemobj_strdup
 pmemobj_tx_abort
@@ -137,10 +137,10 @@ pmemobj_check
 pmemobj_check_version
 pmemobj_close
 pmemobj_cond_broadcast
+pmemobj_cond_init
 pmemobj_cond_signal
 pmemobj_cond_timedwait
 pmemobj_cond_wait
-pmemobj_cond_zero
 pmemobj_create
 pmemobj_drain
 pmemobj_errormsg
@@ -153,10 +153,10 @@ pmemobj_list_move
 pmemobj_list_remove
 pmemobj_memcpy_persist
 pmemobj_memset_persist
+pmemobj_mutex_init
 pmemobj_mutex_lock
 pmemobj_mutex_trylock
 pmemobj_mutex_unlock
-pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
@@ -164,6 +164,7 @@ pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
+pmemobj_rwlock_init
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
 pmemobj_rwlock_timedwrlock
@@ -171,7 +172,6 @@ pmemobj_rwlock_tryrdlock
 pmemobj_rwlock_trywrlock
 pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
-pmemobj_rwlock_zero
 pmemobj_set_funcs
 pmemobj_strdup
 pmemobj_tx_abort
@@ -201,10 +201,10 @@ pmemobj_check
 pmemobj_check_version
 pmemobj_close
 pmemobj_cond_broadcast
+pmemobj_cond_init
 pmemobj_cond_signal
 pmemobj_cond_timedwait
 pmemobj_cond_wait
-pmemobj_cond_zero
 pmemobj_create
 pmemobj_drain
 pmemobj_errormsg
@@ -217,10 +217,10 @@ pmemobj_list_move
 pmemobj_list_remove
 pmemobj_memcpy_persist
 pmemobj_memset_persist
+pmemobj_mutex_init
 pmemobj_mutex_lock
 pmemobj_mutex_trylock
 pmemobj_mutex_unlock
-pmemobj_mutex_zero
 pmemobj_next
 pmemobj_open
 pmemobj_persist
@@ -228,6 +228,7 @@ pmemobj_pool
 pmemobj_realloc
 pmemobj_root
 pmemobj_root_size
+pmemobj_rwlock_init
 pmemobj_rwlock_rdlock
 pmemobj_rwlock_timedrdlock
 pmemobj_rwlock_timedwrlock
@@ -235,7 +236,6 @@ pmemobj_rwlock_tryrdlock
 pmemobj_rwlock_trywrlock
 pmemobj_rwlock_unlock
 pmemobj_rwlock_wrlock
-pmemobj_rwlock_zero
 pmemobj_set_funcs
 pmemobj_strdup
 pmemobj_tx_abort

--- a/src/test/unittest/ut_backtrace.c
+++ b/src/test/unittest/ut_backtrace.c
@@ -156,6 +156,7 @@ ut_sighandler(int sig)
 	ERR("Signal %d, backtrace:", sig);
 	ut_dump_backtrace();
 	ERR("\n");
+	exit(sig);
 }
 
 /*


### PR DESCRIPTION
This patch simplifies the usage of pmem synchronization primitives,
but adds a requirement to explicitly initialize the locks.

This patch requires the root object constructor - otherwise there
would be no way to initialize locks or lists inside the root object.

This is preview only - don't merge it yet (build system issues).