### PR TITLE
all: always evaluate LOG & ASSERT arguments

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -161,7 +161,9 @@ out_init(const char *log_prefix, const char *log_level_var,
 	else
 		setlinebuf(Out_fp);
 
+#ifdef	DEBUG
 	LOG(1, "pid %d: program: %s", getpid(), getexecname());
+#endif
 	LOG(1, "%s version %d.%d", log_prefix, major_version, minor_version);
 	LOG(1, "src version %s", nvml_src_version);
 #ifdef USE_VG_PMEMCHECK

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -343,7 +343,6 @@ read_info(struct btt *bttp, struct btt_info *infop)
 	return 1;
 }
 
-#ifdef DEBUG
 /*
  * map_entry_is_zero -- (internal) checks if map_entry is in zero state
  */
@@ -352,7 +351,6 @@ map_entry_is_zero(uint32_t map_entry)
 {
 	return (map_entry & ~BTT_MAP_ENTRY_LBA_MASK) == BTT_MAP_ENTRY_ZERO;
 }
-#endif
 
 /*
  * map_entry_is_error -- (internal) checks if map_entry is in error state

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -47,7 +47,6 @@
 #include "heap.h"
 #include "bucket.h"
 #include "heap_layout.h"
-#include "out.h"
 #include "valgrind_internal.h"
 
 enum alloc_op_redo {

--- a/src/libpmemobj/redo.c
+++ b/src/libpmemobj/redo.c
@@ -138,7 +138,9 @@ redo_log_process(PMEMobjpool *pop, struct redo_log *redo,
 {
 	LOG(15, "redo %p nentries %zu", redo, nentries);
 
+#ifdef	DEBUG
 	ASSERTeq(redo_log_check(pop, redo, nentries), 0);
+#endif
 
 	uint64_t *val;
 	while ((redo->offset & REDO_FINISH_FLAG) == 0) {

--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -80,9 +80,7 @@
 #include "out.h"
 #include "valgrind_internal.h"
 
-#ifdef DEBUG
 #define	HUGE (2 * 1024 * 1024)
-#endif
 
 /*
  * private to this file...


### PR DESCRIPTION
Now compiler can check type compatibility in non-debug builds, sees
which variables are used and not generate warnings about unused
variables / parameters, etc. This patch is necessary for enabling
-Wunused-parameter.

When those arguments do not have any side effects they are optimized
away by the compiler.

Size comparison:
nondebug/libpmemblk.so.1.0.0   63872 ->  63848 -24b
nondebug/libpmemlog.so.1.0.0   49752 ->  49736 -16b
nondebug/libpmemobj.so.1.0.0  141240 -> 141208 -32b
nondebug/libpmem.so.1.0.0      36048 ->  36048 no diff
nondebug/libvmem.so.1.0.0     291752 -> 291752 no diff
nondebug/libvmmalloc.so.1.0.0 291584 -> 291584 no diff

New binaries - with ASSERT & LOG arg evaluation - are smaller.
This is a bit suprising, but the difference is within noise.