### PR TITLE
ut: exit from ut_sighandler

### DIFF
--- a/src/test/unittest/ut_backtrace.c
+++ b/src/test/unittest/ut_backtrace.c
@@ -156,6 +156,7 @@ ut_sighandler(int sig)
 	ERR("Signal %d, backtrace:", sig);
 	ut_dump_backtrace();
 	ERR("\n");
+	exit(128 + sig);
 }
 
 /*


### PR DESCRIPTION
Otherwise we loop forever between signal handler and crashing code.
I'm not sure how I tested the original patch...