### PR TITLE
common: remove unnecessary pmemcheck macros

### DIFF
--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -277,7 +277,6 @@ predrain_fence_sfence(void)
 	LOG(15, NULL);
 
 	_mm_sfence();	/* ensure CLWB or CLFLUSHOPT completes before PCOMMIT */
-	VALGRIND_DO_FENCE;
 }
 
 /*
@@ -314,9 +313,7 @@ drain_pcommit(void)
 
 	Func_predrain_fence();
 	_mm_pcommit();
-	VALGRIND_DO_COMMIT;
 	_mm_sfence();
-	VALGRIND_DO_FENCE;
 }
 
 /*
@@ -356,8 +353,6 @@ flush_clflush(void *addr, size_t len)
 	for (uptr = (uintptr_t)addr & ~(FLUSH_ALIGN - 1);
 		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN)
 		_mm_clflush((char *)uptr);
-
-	VALGRIND_DO_FLUSH(addr, len);
 }
 
 /*
@@ -378,8 +373,6 @@ flush_clwb(void *addr, size_t len)
 		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN) {
 		_mm_clwb((char *)uptr);
 	}
-
-	VALGRIND_DO_FLUSH(addr, len);
 }
 
 /*
@@ -400,8 +393,6 @@ flush_clflushopt(void *addr, size_t len)
 		uptr < (uintptr_t)addr + len; uptr += FLUSH_ALIGN) {
 		_mm_clflushopt((char *)uptr);
 	}
-
-	VALGRIND_DO_FLUSH(addr, len);
 }
 
 /*

--- a/src/test/pmem_valgr_simple/pmem_valgr_simple.c
+++ b/src/test/pmem_valgr_simple/pmem_valgr_simple.c
@@ -75,7 +75,7 @@ main(int argc, char *argv[])
 
 	uint16_t *tmp16dst = (void *)((uintptr_t)dest + 1024);
 	*tmp16dst = 21;
-	/* will appear as flushed in valgrind log */
+	/* will appear as flushed/fenced in valgrind log */
 	pmem_flush(tmp16dst, sizeof (*tmp16dst));
 
 	/* shows strange behavior of memset in some cases */

--- a/src/test/pmem_valgr_simple/valgrind0.log.match
+++ b/src/test/pmem_valgr_simple/valgrind0.log.match
@@ -1,4 +1,4 @@
-==$(N)== pmemcheck-$(N).$(N), a simple persistent store checker
+==$(N)== pmemcheck-$(N).$(nW), a simple persistent store checker
 ==$(N)== Copyright (c) $(N)-$(N), Intel Corporation
 ==$(N)== Using $(*)
 ==$(N)== Command: ./pmem_valgr_simple$(nW) $(nW) $(N) $(N)
@@ -13,7 +13,8 @@
 ==$(N)==    by 0x$(nW): main (pmem_valgr_simple.c:82)
 ==$(N)== 	Address: 0x$(nW)	size: 8	state: DIRTY
 ==$(N)== [2]    at 0x$(nW): main (pmem_valgr_simple.c:77)
-==$(N)== 	Address: 0x$(nW)	size: 2	state: FLUSHED
+$(OPT)==$(N)== 	Address: 0x$(nW)	size: 2	state: FLUSHED
+$(OPT)==$(N)== 	Address: 0x$(nW)	size: 2	state: FENCED
 ==$(N)== Total memory not made persistent: 14
 $(OPT)==$(N)== 
 $(OPT)==$(N)== Number of overwritten stores: 1


### PR DESCRIPTION
Since pmemcheck now automatically recognizes the new instructions, the
additional instrumentation is unnecessary.