### PR TITLE
pmempool: fix parsing optional arguments

### DIFF
--- a/doc/pmempool-create.1
+++ b/doc/pmempool-create.1
@@ -154,15 +154,13 @@ Please refer to
 .BR libpmemblk (3)
 for details.
 .PP
-.B -w, --write-layout [<blockno>]
+.B -w, --write-layout
 .RS 8
 Force writing
 .B BTT
 layout by performing
 .I write operation
-to
-.B <blockno>
-block. Default is 0.
+to block number zero.
 .RE
 .SS "Options for PMEMOBJ:"
 .LP

--- a/doc/pmempool-info.1
+++ b/doc/pmempool-info.1
@@ -168,7 +168,7 @@ section for details).
 .B -r, --range
 <range>
 .RS 8
-Range of blocks/data chunks/objects. See
+Range of blocks/data chunks/objects/zone headers/chunk headers/lanes. See
 .B RANGE
 section for details about range format.
 .RE
@@ -289,7 +289,11 @@ one of the following options may be used.
 .B -l, --lanes [<range>]
 .RS 8
 Print information about lanes. If range is not specified all lanes are
-displayed. See
+displayed. The range can be specified using
+.B -r
+option right after the
+.B -l
+option. See
 .B RANGE
 section for details about range format.
 .RE
@@ -373,7 +377,7 @@ Print information about
 heap. By default only a heap header is displayed.
 .RE
 .PP
-.B -Z, --zones [<range>]
+.B -Z, --zones
 .RS 8
 If the
 .B -H, --heap
@@ -387,7 +391,11 @@ of zones. This option requires
 .B -H, --heap
 or
 .B -s, --stats
-options. See
+options. The range can be specified using
+.B -r
+option right after the
+.B -Z
+option. See
 .B RANGE
 section for details about range format.
 .RE
@@ -411,7 +419,11 @@ within a zone. This option requires
 .B -H, --heap
 or
 .B -s, --stats
-options. See
+options. The range can be specified using
+.B -r
+option right after the
+.B -C
+option. See
 .B RANGE
 section for details about range format.
 .RE

--- a/src/test/pmempool_create/TEST1
+++ b/src/test/pmempool_create/TEST1
@@ -50,11 +50,4 @@ check_file $POOL
 check_signature PMEMBLK $POOL
 check_arena $POOL
 
-# PMEMBLK with layout using block number 10
-rm -rf $POOL
-expect_normal_exit $PMEMPOOL$EXESUFFIX create -w10 blk 512 $POOL
-check_file $POOL
-check_signature PMEMBLK $POOL
-check_arena $POOL
-
 pass

--- a/src/test/pmempool_info/TEST13
+++ b/src/test/pmempool_info/TEST13
@@ -50,7 +50,7 @@ rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool" obj $POOL
 expect_normal_exit $PMEMALLOC$EXESUFFIX -o $((1*1024*1024)) -t 1 $POOL
 expect_normal_exit $PMEMALLOC$EXESUFFIX -o 16 -t 2 $POOL
-expect_normal_exit $PMEMPOOL$EXESUFFIX info -O -E -a -A -H -Z -C0 -s $POOL >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info -O -E -a -A -H -Z -Cr0 -s $POOL >> $LOG
 
 rm -f $POOL
 

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -125,7 +125,7 @@ static const struct option long_options[] = {
 	{"max-size",	no_argument,		0,	'M' | OPT_ALL},
 	{"inherit",	required_argument,	0,	'i' | OPT_ALL},
 	{"mode",	required_argument,	0,	'm' | OPT_ALL},
-	{"write-layout", optional_argument,	0,	'w' | OPT_BLK},
+	{"write-layout", no_argument,		0,	'w' | OPT_BLK},
 	{"layout",	required_argument,	0,	'l' | OPT_OBJ},
 	{0,		0,			0,	 0 },
 };
@@ -284,7 +284,7 @@ pmempool_create_parse_args(struct pmempool_create *pcp, char *appname,
 		int argc, char *argv[], struct options *opts)
 {
 	int opt, ret;
-	while ((opt = util_options_getopt(argc, argv, "vhi:s:Mm:l:w::",
+	while ((opt = util_options_getopt(argc, argv, "vhi:s:Mm:l:w",
 			opts)) != -1) {
 		switch (opt) {
 		case 'v':
@@ -315,15 +315,7 @@ pmempool_create_parse_args(struct pmempool_create *pcp, char *appname,
 			pcp->inherit_fname = optarg;
 			break;
 		case 'w':
-			if (optarg) {
-				if (optarg[0] == '-') {
-					outv_err("value must be >= 0 -- 'w'");
-					return -1;
-				}
-				pcp->blk_layout = atoll(optarg);
-			} else {
-				pcp->blk_layout = 0;
-			}
+			pcp->blk_layout = 0;
 			break;
 		case 'l':
 			pcp->layout = optarg;


### PR DESCRIPTION
- do not use optional arguments
- the ranges for pmempool info can be specified using -r range
  for -Z, -C and -l options

Ref: pmem/issues#96