### PR TITLE
test: fix pmem_valgr_simple match file

### DIFF
--- a/src/test/pmem_valgr_simple/valgrind0.log.match
+++ b/src/test/pmem_valgr_simple/valgrind0.log.match
@@ -7,18 +7,18 @@
 ==$(N)== 
 ==$(N)== Number of stores not made persistent: 3
 ==$(N)== Stores not made persistent properly:
-==$(N)== [0]    at 0x$(nW): main (pmem_valgr_simple.c:64)
-==$(N)== 	Address: 0x$(N)	size: 4	state: DIRTY
-==$(N)== [1]    at 0x$(nW): $(nW)memset ($(*))
-==$(N)==    by 0x$(nW): main (pmem_valgr_simple.c:82)
-==$(N)== 	Address: 0x$(nW)	size: 8	state: DIRTY
-==$(N)== [2]    at 0x$(nW): main (pmem_valgr_simple.c:77)
-$(OPT)==$(N)== 	Address: 0x$(nW)	size: 2	state: FLUSHED
-$(OPT)==$(N)== 	Address: 0x$(nW)	size: 2	state: FENCED
+==$(N)== [0]    at 0x$(X): main (pmem_valgr_simple.c:64)
+==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
+==$(N)== [1]    at 0x$(X): $(nW)memset ($(*))
+==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:82)
+==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
+==$(N)== [2]    at 0x$(X): main (pmem_valgr_simple.c:77)
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FLUSHED
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FENCED
 ==$(N)== Total memory not made persistent: 14
 $(OPT)==$(N)== 
 $(OPT)==$(N)== Number of overwritten stores: 1
 $(OPT)==$(N)== Overwritten stores before they were made persistent:
-$(OPT)==$(N)== [0]    at 0x$(nW): $(nW)memset ($(*))
-$(OPT)==$(N)==    by 0x$(nW): main (pmem_valgr_simple.c:82)
-$(OPT)==$(N)== 	Address: 0x$(nW)	size: 8	state: DIRTY
+$(OPT)==$(N)== [0]    at 0x$(X): $(nW)memset ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:82)
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY


### PR DESCRIPTION
One of the lines matched hex-encoded address as decimal integer ($(N)).
Change it to $(X) and fix other address matches.