### PR TITLE
obj: fix coverity warning on D_RW macro

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -342,7 +342,7 @@ pmemobj_direct(PMEMoid oid)
 }
 
 #define	DIRECT_RW(o) (\
-{typeof((o)) _o; _o.oid = _o.oid;\
+{typeof((o)) _o; _o._type = NULL; (void)_o;\
 (typeof(*(o)._type) *)pmemobj_direct((o).oid); })
 #define	DIRECT_RO(o) ((const typeof(*(o)._type) *)pmemobj_direct((o).oid))
 


### PR DESCRIPTION
Assignment operation "_o.oid = _o.oid" has no effect.

This assignment was intentionaly wrote to have no effect but to
get compile time error when using D_RW macro on const TOID(struct ..)
variable. This patch avoids the warning.