### PR TITLE
travis: enable libunwind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ compiler:
 before_install:
   - sudo add-apt-repository -y ppa:tmsz-kapela/valgrind-pmem
   - sudo apt-get update -qq
-  - sudo apt-get install -y uuid-dev valgrind
+  - sudo apt-get install -y uuid-dev valgrind libunwind7-dev
   - cp src/test/testconfig.sh.example src/test/testconfig.sh
-script: make cstyle && make -j2 && make -j2 test && make check
+script: make cstyle && make -j2 USE_LIBUNWIND=1 && make -j2 test USE_LIBUNWIND=1 && make check
 env:
   - EXTRA_CFLAGS=-DUSE_VALGRIND
   - EXTRA_CFLAGS=

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -41,6 +41,11 @@ LIBS_DIR=../..
 
 UT = ../unittest/libut.a
 LIBS = $(UT)
+
+ifneq ($(USE_LIBUNWIND),)
+LIBS += -ldl $(shell pkg-config --libs libunwind || echo -lunwind)
+endif
+
 LIBS += -L$(LIBS_DIR)/debug
 LIBS += -luuid -pthread
 
@@ -102,10 +107,6 @@ CFLAGS += -Wunused-macros
 CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)
 LDFLAGS = -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)
-
-ifneq ($(USE_LIBUNWIND),)
-LDFLAGS += -ldl $(shell pkg-config --libs libunwind)
-endif
 
 #
 # By default debug and non-debug static versions are built.


### PR DESCRIPTION
Libunwind on Travis' systems is very old and does not provide pkg-config
files, so we have to provide a fallback. Additionally we have to move
-lunwind to after libut.a is linked.