### PR TITLE
Address Sanitizer fixes

### DIFF
--- a/src/test/obj_store/obj_store_mocks.c
+++ b/src/test/obj_store/obj_store_mocks.c
@@ -35,6 +35,7 @@
  */
 
 #include <inttypes.h>
+#include <sys/param.h>
 
 #include "unittest.h"
 #include "util.h"
@@ -105,7 +106,8 @@ FUNC_MOCK_RUN_DEFAULT {
 		pop->persist(pop, alloc, sizeof (*alloc));
 		*off = hheader->offset + sizeof (*alloc);
 		pop->persist(pop, off, sizeof (uint64_t));
-		hheader->offset += size + sizeof (*alloc);
+		hheader->offset += roundup(size, sizeof (uint64_t));
+		hheader->offset += sizeof (*alloc);
 		hheader->size -= size + sizeof (*alloc);
 		pop->persist(pop, hheader, sizeof (*hheader));
 		return 0;

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -288,11 +288,17 @@ function expect_normal_exit() {
 		rm -f $MEMCHECK_LOG_FILE
 		if echo "$*" | grep -v valgrind >/dev/null; then
 			if [ "$MEMCHECK_DONT_CHECK_LEAKS" != "1" ]; then
+				export OLD_MEMCHECK_OPTS="$MEMCHECK_OPTS"
 				export MEMCHECK_OPTS="$MEMCHECK_OPTS --leak-check=full"
 			fi
 
 			TRACE="valgrind --log-file=$MEMCHECK_LOG_FILE $MEMCHECK_OPTS $TRACE"
 		fi
+	fi
+
+	if [ "$MEMCHECK_DONT_CHECK_LEAKS" = "1" ]; then
+		export OLD_ASAN_OPTIONS="${ASAN_OPTIONS}"
+		export ASAN_OPTIONS="detect_leaks=0 ${ASAN_OPTIONS}"
 	fi
 
 	set +e
@@ -340,6 +346,14 @@ function expect_normal_exit() {
 				false
 			fi
 		fi
+
+		if [ "$MEMCHECK_DONT_CHECK_LEAKS" != "1" ]; then
+			export MEMCHECK_OPTS="$OLD_MEMCHECK_OPTS"
+		fi
+	fi
+
+	if [ "$MEMCHECK_DONT_CHECK_LEAKS" = "1" ]; then
+		export ASAN_OPTIONS="${OLD_ASAN_OPTIONS}"
 	fi
 }
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -348,7 +348,7 @@ function expect_normal_exit() {
 #
 function expect_abnormal_exit() {
 	set +e
-	eval $ECHO LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH LD_PRELOAD=$TEST_LD_PRELOAD \
+	eval $ECHO ASAN_OPTIONS="detect_leaks=0 ${ASAN_OPTIONS}" LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH LD_PRELOAD=$TEST_LD_PRELOAD \
 	$TRACE $*
 	set -e
 }


### PR DESCRIPTION
Fallout from ASan tests on newer gcc.

(These commits do not look very interesting, but note that ASan found a horrible memory corruption fixed by commit 88e71438113d15601ab2a3c4a0915543d30b5429)
