### PR TITLE
test: split tests by type

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -43,60 +43,130 @@ TEST_DEPS = \
        pmemalloc\
        obj_list
 
-TEST = blk_nblock\
+BLK_TESTS = \
+       blk_nblock\
        blk_non_zero\
        blk_pool\
        blk_pool_lock\
        blk_recovery\
        blk_rw\
-       blk_rw_mt\
-       checksum\
+       blk_rw_mt
+
+LOG_TESTS = \
        log_basic\
        log_pool\
        log_pool_lock\
        log_recovery\
-       log_walker\
+       log_walker
+
+# long tests first
+OBJ_TESTS = \
+       obj_basic_integration\
+       obj_many_size_allocs\
+       obj_realloc\
+       obj_sync\
+       \
+       obj_bucket\
+       obj_check\
+       obj_ctree\
+       obj_cuckoo\
+       obj_debug\
+       obj_direct\
+       obj_heap\
+       obj_heap_state\
+       obj_lane\
+       obj_list_insert\
+       obj_list_insert_new\
+       obj_list_move\
+       obj_list_move_oob\
+       obj_list_realloc\
+       obj_list_realloc_move\
+       obj_list_recovery\
+       obj_list_remove\
+       obj_list_remove_free\
+       obj_list_valgrind\
+       obj_memcheck\
+       obj_out_of_memory\
+       obj_pmalloc_basic\
+       obj_pmalloc_mt\
+       obj_pmalloc_oom_mt\
+       obj_pool\
+       obj_pool_lock\
+       obj_recovery\
+       obj_recreate\
+       obj_redo_log\
+       obj_store\
+       obj_tx_alloc\
+       obj_tx_add_range\
+       obj_tx_add_range_direct\
+       obj_tx_flow\
+       obj_tx_free\
+       obj_tx_locks\
+       obj_tx_locks_abort\
+       obj_tx_realloc\
+       obj_tx_strdup
+
+OTHER_TESTS = \
+       arch_flags\
+       checksum\
+       magic\
+       out_err\
+       out_err_mt\
+       scope\
+       set_funcs\
+       traces\
+       traces_custom_function\
+       traces_pmem\
+       util_file_create\
+       util_file_open\
+       util_map_proc\
+       util_poolset\
+       util_poolset_parse
+
+PMEM_TESTS = \
        pmem_isa_proc\
        pmem_is_pmem\
        pmem_is_pmem_proc\
        pmem_map\
-       pmem_memmove\
        pmem_memcpy\
-       pmem_movnt_align\
+       pmem_memmove\
        pmem_memset\
-       pmem_valgr_simple\
        pmem_movnt\
-       scope\
-       traces\
-       traces_custom_function\
-       traces_pmem\
-       util_map_proc\
-       util_file_create\
-       util_file_open\
-       util_poolset\
-       util_poolset_parse\
-       set_funcs\
+       pmem_movnt_align\
+       pmem_valgr_simple
+
+PMEMPOOL_TESTS = \
+       pmempool_check\
+       pmempool_create\
+       pmempool_dump\
+       pmempool_help\
+       pmempool_info\
+       pmempool_rm
+
+VMEM_TESTS = \
        vmem_aligned_alloc\
        vmem_calloc\
        vmem_check_allocations\
        vmem_check_version\
+       vmem_check\
+       vmem_create\
+       vmem_create_error\
+       vmem_create_in_region\
        vmem_custom_alloc\
+       vmem_delete\
        vmem_malloc\
        vmem_malloc_usable_size\
        vmem_mix_allocations\
        vmem_multiple_pools\
        vmem_out_of_memory\
-       vmem_check\
-       vmem_create\
-       vmem_create_error\
-       vmem_create_in_region\
-       vmem_delete\
+       vmem_pages_purging\
        vmem_realloc\
        vmem_realloc_inplace\
        vmem_stats\
        vmem_strdup\
-       vmem_valgrind\
-       vmem_pages_purging\
+       vmem_valgrind
+
+VMMALLOC_TESTS = \
        vmmalloc_calloc\
        vmmalloc_check_allocations\
        vmmalloc_fork\
@@ -108,60 +178,17 @@ TEST = blk_nblock\
        vmmalloc_out_of_memory\
        vmmalloc_realloc\
        vmmalloc_valgrind\
-       vmmalloc_valloc\
-       pmempool_check\
-       pmempool_info\
-       pmempool_dump\
-       pmempool_create\
-       pmempool_rm\
-       pmempool_help\
-       magic\
-       arch_flags\
-       obj_redo_log\
-       obj_basic_integration\
-       obj_pmalloc_basic\
-       obj_pool\
-       obj_pool_lock\
-       obj_lane\
-       obj_sync\
-       obj_direct\
-       obj_cuckoo\
-       obj_list_insert\
-       obj_list_insert_new\
-       obj_list_remove\
-       obj_list_remove_free\
-       obj_list_move\
-       obj_list_move_oob\
-       obj_list_realloc\
-       obj_list_realloc_move\
-       obj_list_valgrind\
-       obj_list_recovery\
-       obj_tx_flow\
-       obj_tx_alloc\
-       obj_tx_free\
-       obj_tx_add_range\
-       obj_tx_add_range_direct\
-       obj_tx_strdup\
-       obj_tx_realloc\
-       obj_tx_locks\
-       obj_tx_locks_abort\
-       obj_ctree\
-       obj_bucket\
-       obj_heap\
-       obj_store\
-       obj_debug\
-       obj_recovery\
-       obj_recreate\
-       obj_memcheck\
-       out_err\
-       out_err_mt\
-       obj_pmalloc_mt\
-       obj_many_size_allocs\
-       obj_heap_state\
-       obj_check\
-       obj_out_of_memory\
-       obj_pmalloc_oom_mt\
-       obj_realloc
+       vmmalloc_valloc
+
+TESTS = \
+       $(OBJ_TESTS)\
+       $(BLK_TESTS)\
+       $(LOG_TESTS)\
+       $(OTHER_TESTS)\
+       $(PMEM_TESTS)\
+       $(PMEMPOOL_TESTS)\
+       $(VMEM_TESTS)\
+       $(VMMALLOC_TESTS)
 
 all     : TARGET = all
 clean   : TARGET = clean
@@ -177,14 +204,14 @@ TEST_FS = all
 TEST_TIME = 3m
 MEMCHECK = auto
 
-all test cstyle: $(TEST)
+all test cstyle: $(TESTS)
 
-clean clobber: $(TEST)
+clean clobber: $(TESTS)
 
 $(TEST_DEPS):
 	$(MAKE) -C $@ $(TARGET)
 
-$(TEST): $(TEST_DEPS)
+$(TESTS): $(TEST_DEPS)
 	$(MAKE) -C $@ $(TARGET)
 
 memcheck-summary:
@@ -200,7 +227,41 @@ check: test
 	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK)
 	@echo "No failures."
 
-pcheck: $(TEST)
+pcheck: $(TESTS)
 	@echo "No failures."
 
-.PHONY: all check clean clobber cstyle pcheck test unittest $(TEST) $(TEST_DEPS)
+pcheck_blk: TARGET = pcheck
+pcheck_blk: $(BLK_TESTS)
+	@echo "No failures."
+
+pcheck_log: TARGET = pcheck
+pcheck_log: $(LOG_TESTS)
+	@echo "No failures."
+
+pcheck_obj: TARGET = pcheck
+pcheck_obj: $(OBJ_TESTS)
+	@echo "No failures."
+
+pcheck_other: TARGET = pcheck
+pcheck_other: $(OTHER_TESTS)
+	@echo "No failures."
+
+pcheck_pmem: TARGET = pcheck
+pcheck_pmem: $(PMEM_TESTS)
+	@echo "No failures."
+
+pcheck_pmempool: TARGET = pcheck
+pcheck_pmempool: $(PMEMPOOL_TESTS)
+	@echo "No failures."
+
+pcheck_vmem: TARGET = pcheck
+pcheck_vmem: $(VMEM_TESTS)
+	@echo "No failures."
+
+pcheck_vmmalloc: TARGET = pcheck
+pcheck_vmmalloc: $(VMMALLOC_TESTS)
+	@echo "No failures."
+
+.PHONY: all check clean clobber cstyle pcheck pcheck_blk pcheck_log pcheck_obj\
+        pcheck_other pcheck_pmem pcheck_pmempool pcheck_vmem pcheck_vmmalloc\
+        test unittest $(TESTS) $(TEST_DEPS)


### PR DESCRIPTION
New 'make' targets:
- pcheck_blk
- pcheck_log
- pcheck_obj
- pcheck_other
- pcheck_pmem
- pcheck_pmempool
- pcheck_vmem
- pcheck_vmmalloc

Obj tests are the most time consuming and most important - run them
first. It speeds up pcheck by 20% on my machine.