### PR TITLE
examples: redirect pminvaders output to /dev/null

### DIFF
--- a/src/test/ex_libpmemobj/Makefile
+++ b/src/test/ex_libpmemobj/Makefile
@@ -63,3 +63,5 @@ endif
 
 all: $(EXAMPLES)
 	$(MAKE) -C $(EX_LIBPMEMOBJ)
+
+pcheck: export NOTTY=1

--- a/src/test/ex_libpmemobj/TEST15
+++ b/src/test/ex_libpmemobj/TEST15
@@ -63,6 +63,13 @@ echo -n ooo >> $INPUT
 dd if=/dev/zero bs=1k count=4 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
 echo -n q >> $INPUT
 
-expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 < $INPUT
+if [ -t 1 -a -z "$NOTTY" ]
+then
+	out="/dev/stdout"
+else
+	out="/dev/null"
+fi
+
+expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 >$out < $INPUT
 
 pass


### PR DESCRIPTION
... but only if running in parallel mode (pcheck) or stdout is not
terminal.