### PR TITLE
vmmalloc: add missing __MALLOC_HOOK_VOLATILE macro

### DIFF
--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -303,6 +303,11 @@ malloc_usable_size(void *ptr)
 }
 
 #if (defined(__GLIBC__) && !defined(__UCLIBC__))
+
+#ifndef __MALLOC_HOOK_VOLATILE
+#define	__MALLOC_HOOK_VOLATILE
+#endif
+
 /*
  * Interpose malloc hooks in glibc.  Even if the application uses dlopen
  * with RTLD_DEEPBIND flag, all the references to libc's malloc(3) functions


### PR DESCRIPTION
This macro is not defined in older versions of malloc.h.