### PR TITLE
libs, ut, tools: enable -Wconversion

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -50,7 +50,9 @@ CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-#CFLAGS += -Wconversion
+ifeq ($(call check_Wconversion), y)
+CFLAGS += -Wconversion
+endif
 CFLAGS += -pthread
 CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)

--- a/src/common.inc
+++ b/src/common.inc
@@ -42,3 +42,6 @@ CSTYLE = $(TOP)/utils/cstyle -pP
 
 check_flag = $(shell echo "int main(){return 0;}" |\
 	$(CC) $(CFLAGS) $(1) -x c -o /dev/null - 2>/dev/null && echo y || echo n)
+
+check_Wconversion = $(shell echo "long int random(void); char test(void); char test(void){char a = 0; char b = 'a'; char ret = random() == 1 ? a : b; return ret;}" |\
+	$(CC) -c $(CFLAGS) -Wconversion -x c -o /dev/null - 2>/dev/null && echo y || echo n)

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -50,7 +50,9 @@ CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-#CFLAGS += -Wconversion
+ifeq ($(call check_Wconversion), y)
+CFLAGS += -Wconversion
+endif
 CFLAGS += -pthread
 CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -45,7 +45,9 @@ CFLAGS += -Wunused-macros
 CFLAGS += -Wmissing-field-initializers
 CFLAGS += -Wsign-conversion
 CFLAGS += -Wsign-compare
-#CFLAGS += -Wconversion
+ifeq ($(call check_Wconversion), y)
+CFLAGS += -Wconversion
+endif
 CFLAGS += -fno-common
 CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -O2 -D_FORTIFY_SOURCE=2


### PR DESCRIPTION
All problems reported by -Wconversion are already solved. This commit only enables it *when* the compiler is smart enough. (gcc 4.6, as used by travis, is not)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/518)
<!-- Reviewable:end -->
