### PR TITLE
doc: obj manpage clarification

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -609,10 +609,10 @@ may be stored on different pmem-aware filesystem.
 .PP
 To improve reliability and eliminate the single point of failure, all the
 changes of the data stored in the persistent memory pool
-could be also automatically written to a local or remote pool replicas,
+could be also automatically written to local pool replicas,
 thereby providing a backup for a persistent memory pool by producing a
 .IR "mirrored pool set" .
-In practice, the pool replicas may be considered the binary copies of
+In practice, the pool replicas may be considered binary copies of
 the "master" pool set.
 .PP
 Creation of all the parts of the pool set and the associated replica sets


### PR DESCRIPTION
Remove the manpage "support" for remote replication.