### PR TITLE
common: fix double path separators in makefiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@
 #
 # src/Makefile -- Makefile for NVML
 #
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 include $(TOP)/src/common.inc
 
 TARGETS = libpmem libvmem libpmemblk libpmemlog libpmemobj libvmmalloc tools

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -31,7 +31,7 @@
 # src/Makefile.inc -- common Makefile rules for NVM library
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 include $(TOP)/src/common.inc
 
 INCLUDE = ../include

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -33,14 +33,13 @@
 #
 # src/benchmarks/Makefile -- build all benchmarks
 #
-OBJCOPY=objcopy
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
+include $(TOP)/src/common.inc
 
 vpath %.c ../examples/libpmemobj/tree_map
 vpath %.c ../examples/libpmemobj/map
 vpath %.c ../examples/libpmemobj/hashmap
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/../..
-include $(TOP)/src/common.inc
 
 vpath %.c ../libpmemobj
 vpath %.c ../common

--- a/src/common.inc
+++ b/src/common.inc
@@ -31,7 +31,7 @@
 # src/Makefile.inc -- common Makefile rules for NVM library
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 
 LN = ln
 OBJCOPY = objcopy

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -32,7 +32,7 @@
 # src/common/Makefile -- Makefile for common
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/../..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
 include $(TOP)/src/common.inc
 
 cstyle:

--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -33,7 +33,7 @@
 #
 # examples/Makefile.inc -- build the NVM Library examples
 #
-TOP_SRC := $(dir $(lastword $(MAKEFILE_LIST)))/..
+TOP_SRC := $(dir $(lastword $(MAKEFILE_LIST)))..
 TOP := $(TOP_SRC)/..
 
 include $(TOP)/src/common.inc

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -37,7 +37,7 @@
 # for each unit test overrides the defaults as necessary.
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/../..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
 
 include $(TOP)/src/common.inc
 

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -34,7 +34,7 @@
 # src/test/unittest/Makefile -- build unittest support library
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/../../..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../../..
 include $(TOP)/src/common.inc
 
 TARGET = libut.a

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -31,7 +31,7 @@
 # src/tools/Makefile.inc -- Makefile include for all tools
 #
 
-TOP := $(dir $(lastword $(MAKEFILE_LIST)))/../..
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
 include $(TOP)/src/common.inc
 
 INCS += -I.


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/532)
<!-- Reviewable:end -->
