### PR TITLE
vmem, vmmalloc: align start of pool to 4MB

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1084,7 +1084,7 @@ util_replica_create(struct pool_set *set, unsigned repidx, int flags,
 	rep->repsize -= (rep->nparts - 1) * hdrsize;
 
 	/* determine a hint address for mmap() */
-	void *addr = util_map_hint(rep->repsize);
+	void *addr = util_map_hint(rep->repsize, 0);
 	if (addr == NULL) {
 		ERR("cannot find a contiguous region of given size");
 		return -1;
@@ -1264,7 +1264,7 @@ util_replica_open(struct pool_set *set, unsigned repidx, int flags,
 	rep->repsize -= (rep->nparts - 1) * hdrsize;
 
 	/* determine a hint address for mmap() */
-	void *addr = util_map_hint(rep->repsize);
+	void *addr = util_map_hint(rep->repsize, 0);
 	if (addr == NULL) {
 		ERR("cannot find a contiguous region of given size");
 		return -1;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -252,9 +252,9 @@ util_map_hint_unused(void *minaddr, size_t len, size_t align)
  * address.
  */
 char *
-util_map_hint(size_t len)
+util_map_hint(size_t len, size_t req_align)
 {
-	LOG(3, "len %zu", len);
+	LOG(3, "len %zu req_align %zu", len, req_align);
 
 	char *addr;
 
@@ -264,7 +264,9 @@ util_map_hint(size_t len)
 	 * twice as big as the page size.
 	 */
 	size_t align = Pagesize;
-	if (len >= 2 * GIGABYTE)
+	if (req_align)
+		align = req_align;
+	else if (len >= 2 * GIGABYTE)
 		align = GIGABYTE;
 	else if (len >= 4 * MEGABYTE)
 		align = 2 * MEGABYTE;
@@ -304,12 +306,12 @@ util_map_hint(size_t len)
  * If cow is set, the file is mapped copy-on-write.
  */
 void *
-util_map(int fd, size_t len, int cow)
+util_map(int fd, size_t len, int cow, size_t req_align)
 {
-	LOG(3, "fd %d len %zu cow %d", fd, len, cow);
+	LOG(3, "fd %d len %zu cow %d req_align %zu", fd, len, cow, req_align);
 
 	void *base;
-	void *addr = util_map_hint(len);
+	void *addr = util_map_hint(len, req_align);
 
 	if ((base = mmap(addr, len, PROT_READ|PROT_WRITE,
 			(cow) ? MAP_PRIVATE|MAP_NORESERVE : MAP_SHARED,
@@ -403,7 +405,7 @@ err:
  * size must be multiple of page size.
  */
 void *
-util_map_tmpfile(const char *dir, size_t size)
+util_map_tmpfile(const char *dir, size_t size, size_t req_align)
 {
 	int oerrno;
 	int fd = util_tmpfile(dir, size);
@@ -413,7 +415,7 @@ util_map_tmpfile(const char *dir, size_t size)
 	}
 
 	void *base;
-	if ((base = util_map(fd, size, 0)) == NULL) {
+	if ((base = util_map(fd, size, 0, req_align)) == NULL) {
 		LOG(2, "cannot mmap temporary file");
 		goto err;
 	}

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -54,11 +54,11 @@ void util_set_alloc_funcs(
 		void (*free_func)(void *ptr),
 		void *(*realloc_func)(void *ptr, size_t size),
 		char *(*strdup_func)(const char *s));
-void *util_map(int fd, size_t len, int cow);
+void *util_map(int fd, size_t len, int cow, size_t req_align);
 int util_unmap(void *addr, size_t len);
 
 int util_tmpfile(const char *dir, size_t size);
-void *util_map_tmpfile(const char *dir, size_t size);
+void *util_map_tmpfile(const char *dir, size_t size, size_t req_align);
 
 /*
  * Number of bits per type in alignment descriptor
@@ -204,7 +204,7 @@ int util_feature_check(struct pool_hdr *hdrp, uint32_t incompat,
 				uint32_t ro_compat, uint32_t compat);
 
 char *util_map_hint_unused(void *addr, size_t len, size_t align);
-char *util_map_hint(size_t len);
+char *util_map_hint(size_t len, size_t req_align);
 
 int util_poolset_parse(const char *path, int fd, struct pool_set **setp);
 void util_poolset_close(struct pool_set *set, int del);

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -630,7 +630,7 @@ pmem_map(int fd)
 	}
 
 	void *addr;
-	if ((addr = util_map(fd, (size_t)stbuf.st_size, 0)) == NULL)
+	if ((addr = util_map(fd, (size_t)stbuf.st_size, 0, 0)) == NULL)
 		return NULL;    /* util_map() set errno, called LOG */
 
 	LOG(3, "returning %p", addr);

--- a/src/libvmem/vmem.c
+++ b/src/libvmem/vmem.c
@@ -160,7 +160,7 @@ vmem_create(const char *dir, size_t size)
 	size = roundup(size, Pagesize);
 
 	void *addr;
-	if ((addr = util_map_tmpfile(dir, size)) == NULL)
+	if ((addr = util_map_tmpfile(dir, size, 4 << 20)) == NULL)
 		return NULL;
 
 	/* store opaque info at beginning of mapped area */

--- a/src/libvmem/vmem.h
+++ b/src/libvmem/vmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Intel Corporation
+ * Copyright (c) 2014,2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -366,7 +366,7 @@ libvmmalloc_create(const char *dir, size_t size)
 		return NULL;
 
 	void *addr;
-	if ((addr = util_map(Fd, size, 0)) == NULL)
+	if ((addr = util_map(Fd, size, 0, 4 << 20)) == NULL)
 		return NULL;
 
 	/* store opaque info at beginning of mapped area */

--- a/src/test/util_map_proc/util_map_proc.c
+++ b/src/test/util_map_proc/util_map_proc.c
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 
 		void *h1 =
 			util_map_hint_unused((void *)TERABYTE, len, GIGABYTE);
-		void *h2 = util_map_hint(len);
+		void *h2 = util_map_hint(len, 0);
 		if (h1 != NULL)
 			ASSERTeq((uintptr_t)h1 & (GIGABYTE - 1), 0);
 		if (h2 != NULL)

--- a/src/test/vmem_check_allocations/vmem_check_allocations.c
+++ b/src/test/vmem_check_allocations/vmem_check_allocations.c
@@ -76,6 +76,9 @@ main(int argc, char *argv[])
 			vmp = vmem_create(dir, VMEM_MIN_POOL);
 			if (vmp == NULL)
 				FATAL("!vmem_create");
+
+			/* vmem_create should align pool to 4MB */
+			ASSERTeq(((uintptr_t)vmp) & ((4 << 20) - 1), 0);
 		}
 
 		memset(allocs, 0, sizeof (allocs));


### PR DESCRIPTION
jemalloc divides passed memory between base allocator and "usable" space
in a way which depends on alignment of passed address.
It means the amount of usable space for files of the same size depends
on luck. This is quite suprising.

This patch takes the luck out and makes the division at fixed point.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/533)
<!-- Reviewable:end -->
