### PR TITLE
obj: fix concurrency issue in user lists macros

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemobj.3
 .\"
-.TH libpmemobj 3 "pmemobj API version 0.4.18" "NVM Library"
+.TH libpmemobj 3 "pmemobj API version 0.4.19" "NVM Library"
 .SH NAME
 libpmemobj \- persistent memory transactional object store
 .SH SYNOPSIS
@@ -204,6 +204,8 @@ libpmemobj \- persistent memory transactional object store
 .BI "POBJ_LIST_EMPTY(POBJ_LIST_HEAD *" head )
 .BI "POBJ_LIST_NEXT(TOID " elm ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_PREV(TOID " elm ", POBJ_LIST_ENTRY " FIELD )
+.B POBJ_LIST_DEST_HEAD
+.B POBJ_LIST_DEST_TAIL
 .sp
 .BI "POBJ_LIST_FOREACH(TOID " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
 .BI "POBJ_LIST_FOREACH_REVERSE(TOID " var ", POBJ_LIST_HEAD *" head ", POBJ_LIST_ENTRY " FIELD )
@@ -1989,7 +1991,13 @@ If
 value is OID_NULL, the object is inserted at the head or at the end of the list,
 depending on the
 .I before
-flag value.
+flag value. If value is 1 the object is inserted at the head, if value is 0 the
+object is inserted at the end of the list. The relevant values are available
+through
+.B POBJ_LIST_DEST_HEAD
+and
+.B POBJ_LIST_DEST_TAIL
+defines respectively.
 The argument
 .I pe_offset
 declares an offset of the structure that connects the elements in the list.
@@ -2032,7 +2040,13 @@ If
 value is OID_NULL, the object is inserted at the head or at the end of the list,
 depending on the
 .I before
-flag value.
+flag value. If value is 1 the object is inserted at the head, if value is 0 the
+object is inserted at the end of the list. The relevant values are available
+through
+.B POBJ_LIST_DEST_HEAD
+and
+.B POBJ_LIST_DEST_TAIL
+defines respectively.
 The argument
 .I pe_offset
 declares an offset of the structure that connects the elements in the list.
@@ -2115,7 +2129,13 @@ If
 value is OID_NULL, the object is inserted at the head or at the end of the
 second list, depending on the
 .I before
-flag value.
+flag value. If value is 1 the object is inserted at the head, if value is 0 the
+object is inserted at the end of the list. The relevant values are available
+through
+.B POBJ_LIST_DEST_HEAD
+and
+.B POBJ_LIST_DEST_TAIL
+defines respectively.
 The arguments
 .I pe_old_offset
 and

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -638,6 +638,8 @@ D_RO((head)->pe_first)->field.pe_prev)
 #define	POBJ_LIST_EMPTY(head)	(TOID_IS_NULL((head)->pe_first))
 #define	POBJ_LIST_NEXT(elm, field)	(D_RO(elm)->field.pe_next)
 #define	POBJ_LIST_PREV(elm, field)	(D_RO(elm)->field.pe_prev)
+#define	POBJ_LIST_DEST_HEAD	1
+#define	POBJ_LIST_DEST_TAIL	0
 
 #define	POBJ_LIST_FOREACH(var, head, field)\
 for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_LIST_FOREACH")\
@@ -660,14 +662,14 @@ for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_LIST_FOREACH_REVERSE")\
 #define	POBJ_LIST_INSERT_HEAD(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	(head), POBJ_LIST_FIRST((head)).oid,\
-	1 /* before */, (elm).oid)
+	(head), OID_NULL,\
+	POBJ_LIST_DEST_HEAD, (elm).oid)
 
 #define	POBJ_LIST_INSERT_TAIL(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
-	(head), POBJ_LIST_LAST((head), field).oid,\
-	0 /* after */, (elm).oid)
+	(head), OID_NULL,\
+	POBJ_LIST_DEST_TAIL, (elm).oid)
 
 #define	POBJ_LIST_INSERT_AFTER(pop, head, listelm, elm, field)\
 pmemobj_list_insert((pop),\
@@ -684,15 +686,13 @@ pmemobj_list_insert((pop), \
 #define	POBJ_LIST_INSERT_NEW_HEAD(pop, head, field, size, constr, arg)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*((head)->pe_first._type)), field),\
-	(head), POBJ_LIST_FIRST((head)).oid,\
-	1 /* before */,	(size),\
+	(head), OID_NULL, POBJ_LIST_DEST_HEAD, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_INSERT_NEW_TAIL(pop, head, field, size, constr, arg)\
 pmemobj_list_insert_new((pop),\
 	offsetof(typeof (*((head)->pe_first._type)), field),\
-	(head), POBJ_LIST_LAST((head), field).oid,\
-	0 /* after */, (size),\
+	(head), OID_NULL, POBJ_LIST_DEST_TAIL, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_INSERT_NEW_AFTER(pop, head, listelm, field, size,\
@@ -724,18 +724,14 @@ pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	(head_new),\
-	POBJ_LIST_FIRST((head_new)).oid,\
-	1 /* before */, (elm).oid)
+	(head_new), OID_NULL, POBJ_LIST_DEST_HEAD, (elm).oid)
 
 #define	POBJ_LIST_MOVE_ELEMENT_TAIL(pop, head, head_new, elm, field, field_new)\
 pmemobj_list_move((pop),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
 	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
-	(head_new),\
-	POBJ_LIST_LAST((head_new), field_new).oid,\
-	0 /* after */, (elm).oid)
+	(head_new), OID_NULL, POBJ_LIST_DEST_TAIL, (elm).oid)
 
 #define	POBJ_LIST_MOVE_ELEMENT_AFTER(pop,\
 	head, head_new, listelm, elm, field, field_new)\

--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -172,10 +172,12 @@ static inline PMEMoid
 list_get_dest(PMEMobjpool *pop, struct list_head *head, PMEMoid dest,
 		uint64_t pe_offset, int before)
 {
+	ASSERT(before == POBJ_LIST_DEST_HEAD || before == POBJ_LIST_DEST_TAIL);
+
 	if (dest.off)
 		return dest;
 
-	if (head->pe_first.off == 0 || before)
+	if (head->pe_first.off == 0 || before == POBJ_LIST_DEST_HEAD)
 		return head->pe_first;
 
 	struct list_entry *first_ptr = (struct list_entry *)OBJ_OFF_TO_PTR(pop,


### PR DESCRIPTION
The POBJ_LIST_INSERT_HEAD, POBJ_LIST_INSERT_TAIL,
POBJ_LIST_INSERT_NEW_HEAD, POBJ_LIST_INSERT_NEW_TAIL,
POBJ_LIST_MOVE_ELEMENT_HEAD and POBJ_LIST_MOVE_ELEMENT_TAIL
macros were using POBJ_LIST_FIRST/POBJ_LIST_LAST macros which was not
thread safe atomic, because the lock on list head was held after
passing the first/last element to the appropriate function. This patch
changes mentioned macros to use OID_NULL as destination and depending
on the _before_ value the destination will be either head or tail of
the list. The POBJ_LIST_DEST_HEAD and POBJ_LIST_DEST_TAIL defines
constant values for appropriate destination.
This approach is thread safe atomic for mentioned macros.