### PR TITLE
ut: disable useless local tests

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -418,6 +418,7 @@ function require_test_type() {
 # require_fs_type -- only allow script to continue for a certain fs type
 #
 function require_fs_type() {
+	req_fs_type=1
 	for type in $*
 	do
 		[ "$type" = "$FS" ] && return
@@ -643,6 +644,12 @@ function require_no_asan() {
 function setup() {
 	# make sure we have a well defined locale for string operations here
 	export LC_ALL="C"
+
+	# skip checks in local dir when test did not require any fs type
+	# (in such cases local is equal to either non-pmem or pmem)
+	if [ "$FS" = "local" -a "$req_fs_type" != "1" ]; then
+		exit 0
+	fi
 
 	if [ "$MEMCHECK" = "force-enable" ]; then
 		export RUN_MEMCHECK=1


### PR DESCRIPTION
When TEST file is not requiring any fs type, we are running it against
pmem, non-pmem and local. In such cases local tests are redundant,
because they are equal to either non-pmem or pmem tests.

This patch speeds up make check by 30% on my system.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/548)
<!-- Reviewable:end -->
