### PR TITLE
valgrind: use __builtin_expect

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -93,7 +93,7 @@ Strdup_func Strdup = strdup;
 #if defined(USE_VG_PMEMCHECK) || defined(USE_VG_HELGRIND) ||\
 	defined(USE_VG_MEMCHECK)
 /* initialized to true if the process is running inside Valgrind */
-unsigned On_valgrind;
+unsigned _On_valgrind;
 #endif
 
 static int Mmap_no_random;
@@ -132,7 +132,7 @@ util_init(void)
 
 #if defined(USE_VG_PMEMCHECK) || defined(USE_VG_HELGRIND) ||\
 	defined(USE_VG_MEMCHECK)
-	On_valgrind = RUNNING_ON_VALGRIND;
+	_On_valgrind = RUNNING_ON_VALGRIND;
 #endif
 }
 

--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -42,7 +42,8 @@
 
 #if defined(USE_VG_PMEMCHECK) || defined(USE_VG_HELGRIND) ||\
 	defined(USE_VG_MEMCHECK)
-extern unsigned On_valgrind;
+extern unsigned _On_valgrind;
+#define	On_valgrind __builtin_expect(_On_valgrind, 0)
 #include <valgrind/valgrind.h>
 #else
 #define	On_valgrind (0)


### PR DESCRIPTION
With this change compiler can shuffle the code around to give CPU's
branch predictor better information and reduce instruction cache usage.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/549)
<!-- Reviewable:end -->
