### PR TITLE
obj: fix zalloc and zrealloc

### DIFF
--- a/src/libpmemobj/list.c
+++ b/src/libpmemobj/list.c
@@ -637,15 +637,19 @@ list_realloc_replace(PMEMobjpool *pop,
 	struct list_head *head, uint64_t pe_offset,
 	size_t old_size,
 	uint64_t obj_offset, uint64_t new_obj_offset,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
+	void (*constructor)(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg), void *arg,
 	uint64_t field_offset, uint64_t field_value)
 {
 	uint64_t obj_doffset = obj_offset + OBJ_OOB_SIZE;
 	uint64_t new_obj_doffset = new_obj_offset + OBJ_OOB_SIZE;
 
+	size_t usable_size = pmalloc_usable_size(pop, new_obj_offset)
+		- OBJ_OOB_SIZE;
+
 	/* call the constructor manually */
 	void *ptr = OBJ_OFF_TO_PTR(pop, new_obj_doffset);
-	constructor(pop, ptr, arg);
+	constructor(pop, ptr, usable_size, arg);
 
 	if (field_offset) {
 		redo_index = list_set_user_field(pop,
@@ -711,7 +715,7 @@ int
 list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head, PMEMoid dest, int before,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg,	PMEMoid *oidp)
+	size_t usable_size, void *arg), void *arg, PMEMoid *oidp)
 {
 	LOG(3, NULL);
 	ASSERTne(oob_head, NULL);
@@ -1411,8 +1415,8 @@ int
 list_realloc(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, uint64_t field_offset, uint64_t field_value,
-	PMEMoid *oidp)
+	size_t usable_size, void *arg), void *arg, uint64_t field_offset,
+	uint64_t field_value, PMEMoid *oidp)
 {
 	LOG(3, NULL);
 	ASSERTne(oob_head, NULL);
@@ -1640,8 +1644,8 @@ int
 list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 	struct list_head *oob_head_new, size_t pe_offset,
 	struct list_head *head, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
-	uint64_t field_offset, uint64_t field_value,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
+	void *arg), void *arg, uint64_t field_offset, uint64_t field_value,
 	PMEMoid *oidp)
 {
 	LOG(3, NULL);

--- a/src/libpmemobj/list.h
+++ b/src/libpmemobj/list.h
@@ -63,19 +63,20 @@ struct list_head {
 int list_insert_new(PMEMobjpool *pop, struct list_head *oob_head,
 	size_t pe_offset, struct list_head *head, PMEMoid dest, int before,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, PMEMoid *oidp);
+	size_t usable_size, void *arg), void *arg, PMEMoid *oidp);
 
 int list_realloc(PMEMobjpool *pop, struct list_head *oob_head,
-	size_t pe_offset, struct list_head *head,
-	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
+	size_t pe_offset, struct list_head *head, size_t size,
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
 	void *arg), void *arg, uint64_t field_offset, uint64_t field_value,
 	PMEMoid *oidp);
 
 int list_realloc_move(PMEMobjpool *pop, struct list_head *oob_head_old,
 	struct list_head *oob_head_new, size_t pe_offset,
 	struct list_head *head, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
-	uint64_t field_offset, uint64_t field_value, PMEMoid *oidp);
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
+	void *arg), void *arg, uint64_t field_offset, uint64_t field_value,
+	PMEMoid *oidp);
 
 int list_insert(PMEMobjpool *pop,
 	size_t pe_offset, struct list_head *head, PMEMoid dest, int before,

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -138,8 +138,8 @@ get_mblock_from_alloc(PMEMobjpool *pop, struct bucket *b,
 static int
 persist_alloc(PMEMobjpool *pop, struct lane_section *lane,
 	struct memory_block m, uint64_t real_size, uint64_t *off,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg),
-	void *arg, uint64_t data_off)
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
+	void *arg), void *arg, uint64_t data_off)
 {
 	int err;
 
@@ -168,7 +168,9 @@ persist_alloc(PMEMobjpool *pop, struct lane_section *lane,
 	alloc_write_header(pop, block_data, m.chunk_id, m.zone_id, real_size);
 
 	if (constructor != NULL)
-		constructor(pop, userdatap, arg);
+		constructor(pop, userdatap,
+			real_size - sizeof (struct allocation_header) -
+			data_off, arg);
 
 	if ((err = heap_lock_if_run(pop, m)) != 0) {
 		VALGRIND_DO_MEMPOOL_FREE(pop, userdatap);
@@ -218,8 +220,8 @@ pmalloc(PMEMobjpool *pop, uint64_t *off, size_t size, uint64_t data_off)
  */
 int
 pmalloc_construct(PMEMobjpool *pop, uint64_t *off, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg),
-	void *arg, uint64_t data_off)
+	void (*constructor)(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg), void *arg, uint64_t data_off)
 {
 	int err = 0;
 
@@ -303,8 +305,8 @@ prealloc(PMEMobjpool *pop, uint64_t *off, size_t size, uint64_t data_off)
  */
 int
 prealloc_construct(PMEMobjpool *pop, uint64_t *off, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
-	uint64_t data_off)
+	void (*constructor)(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg), void *arg, uint64_t data_off)
 {
 	if (size <= pmalloc_usable_size(pop, *off))
 		return 0;
@@ -361,7 +363,9 @@ prealloc_construct(PMEMobjpool *pop, uint64_t *off, size_t size,
 		real_size  - sizeof (struct allocation_header) - data_off);
 
 	if (constructor != NULL)
-		constructor(pop, userdatap, arg);
+		constructor(pop, userdatap,
+			real_size - sizeof (struct allocation_header) -
+			data_off, arg);
 
 	struct allocator_lane_section *sec =
 		(struct allocator_lane_section *)lane->layout;

--- a/src/libpmemobj/pmalloc.h
+++ b/src/libpmemobj/pmalloc.h
@@ -42,13 +42,13 @@ int heap_check(PMEMobjpool *pop);
 
 int pmalloc(PMEMobjpool *pop, uint64_t *off, size_t size, uint64_t data_off);
 int pmalloc_construct(PMEMobjpool *pop, uint64_t *off, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
-	uint64_t data_off);
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
+	void *arg), void *arg, uint64_t data_off);
 
 int prealloc(PMEMobjpool *pop, uint64_t *off, size_t size, uint64_t data_off);
 int prealloc_construct(PMEMobjpool *pop, uint64_t *off, size_t size,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg), void *arg,
-	uint64_t data_off);
+	void (*constructor)(PMEMobjpool *pop, void *ptr, size_t usable_size,
+	void *arg), void *arg, uint64_t data_off);
 
 size_t pmalloc_usable_size(PMEMobjpool *pop, uint64_t off);
 int pfree(PMEMobjpool *pop, uint64_t *off, uint64_t data_off);

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -80,7 +80,6 @@ struct lane_tx_runtime {
 
 struct tx_alloc_args {
 	type_num_t type_num;
-	size_t size;
 };
 
 struct tx_alloc_copy_args {
@@ -100,7 +99,7 @@ struct tx_add_range_args {
  * constructor_tx_alloc -- (internal) constructor for normal alloc
  */
 static void
-constructor_tx_alloc(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_alloc(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 
@@ -124,7 +123,7 @@ constructor_tx_alloc(PMEMobjpool *pop, void *ptr, void *arg)
 	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
 
 	/* do not report changes to the new object */
-	VALGRIND_ADD_TO_TX(ptr, args->size);
+	VALGRIND_ADD_TO_TX(ptr, usable_size);
 
 	VALGRIND_DO_MAKE_MEM_NOACCESS(pop, &oobh->data.padding,
 			sizeof (oobh->data.padding));
@@ -134,7 +133,8 @@ constructor_tx_alloc(PMEMobjpool *pop, void *ptr, void *arg)
  * constructor_tx_zalloc -- (internal) constructor for zalloc
  */
 static void
-constructor_tx_zalloc(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_zalloc(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 
@@ -158,19 +158,20 @@ constructor_tx_zalloc(PMEMobjpool *pop, void *ptr, void *arg)
 	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
 
 	/* do not report changes to the new object */
-	VALGRIND_ADD_TO_TX(ptr, args->size);
+	VALGRIND_ADD_TO_TX(ptr, usable_size);
 
 	VALGRIND_DO_MAKE_MEM_NOACCESS(pop, &oobh->data.padding,
 			sizeof (oobh->data.padding));
 
-	memset(ptr, 0, args->size);
+	memset(ptr, 0, usable_size);
 }
 
 /*
  * constructor_tx_add_range -- (internal) constructor for add_range
  */
 static void
-constructor_tx_add_range(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_add_range(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 
@@ -207,7 +208,7 @@ constructor_tx_add_range(PMEMobjpool *pop, void *ptr, void *arg)
  * constructor_tx_copy -- (internal) copy constructor
  */
 static void
-constructor_tx_copy(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_copy(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 
@@ -243,7 +244,8 @@ constructor_tx_copy(PMEMobjpool *pop, void *ptr, void *arg)
  * the non-copied area
  */
 static void
-constructor_tx_copy_zero(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_copy_zero(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 
@@ -266,15 +268,15 @@ constructor_tx_copy_zero(PMEMobjpool *pop, void *ptr, void *arg)
 	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
 
 	/* do not report changes made to the copy */
-	VALGRIND_ADD_TO_TX(ptr, args->size);
+	VALGRIND_ADD_TO_TX(ptr, usable_size);
 
 	VALGRIND_DO_MAKE_MEM_NOACCESS(pop, &oobh->data.padding,
 			sizeof (oobh->data.padding));
 
 	memcpy(ptr, args->ptr, args->copy_size);
-	if (args->size > args->copy_size) {
+	if (usable_size > args->copy_size) {
 		void *zero_ptr = (void *)((uintptr_t)ptr + args->copy_size);
-		size_t zero_size = args->size - args->copy_size;
+		size_t zero_size = usable_size - args->copy_size;
 		memset(zero_ptr, 0, zero_size);
 	}
 }
@@ -865,7 +867,8 @@ release_and_free_tx_locks(struct lane_tx_runtime *lane)
  */
 static PMEMoid
 tx_alloc_common(size_t size, type_num_t type_num,
-	void (*constructor)(PMEMobjpool *pop, void *ptr, void *arg))
+	void (*constructor)(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg))
 {
 	LOG(3, NULL);
 
@@ -893,7 +896,6 @@ tx_alloc_common(size_t size, type_num_t type_num,
 
 	struct tx_alloc_args args = {
 		.type_num = type_num,
-		.size = size,
 	};
 
 	/* allocate object to undo log */
@@ -922,7 +924,7 @@ err_oom:
 static PMEMoid
 tx_alloc_copy_common(size_t size, type_num_t type_num, const void *ptr,
 	size_t copy_size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg))
+	size_t usable_size, void *arg))
 {
 	LOG(3, NULL);
 
@@ -974,8 +976,10 @@ err_oom:
  */
 static PMEMoid
 tx_realloc_common(PMEMoid oid, size_t size, unsigned int type_num,
-	void (*constructor_alloc)(PMEMobjpool *pop, void *ptr, void *arg),
-	void (*constructor_realloc)(PMEMobjpool *pop, void *ptr, void *arg))
+	void (*constructor_alloc)(PMEMobjpool *pop, void *ptr,
+		size_t usable_size, void *arg),
+	void (*constructor_realloc)(PMEMobjpool *pop, void *ptr,
+		size_t usable_size, void *arg))
 {
 	LOG(3, NULL);
 
@@ -1313,7 +1317,8 @@ pmemobj_tx_add_large(struct lane_tx_layout *layout,
  * constructor_tx_range_cache -- (internal) cache constructor
  */
 static void
-constructor_tx_range_cache(PMEMobjpool *pop, void *ptr, void *arg)
+constructor_tx_range_cache(PMEMobjpool *pop, void *ptr,
+	size_t usable_size, void *arg)
 {
 	LOG(3, NULL);
 

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -406,7 +406,7 @@ FUNC_MOCK_END
  */
 FUNC_MOCK(pmalloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, uint64_t data_off)
+	size_t usable_size, void *arg), void *arg, uint64_t data_off)
 	FUNC_MOCK_RUN_DEFAULT {
 		size = 2 * (size - OOB_OFF) + OOB_OFF;
 		uint64_t *alloc_size = (uint64_t *)((uintptr_t)Pop +
@@ -421,7 +421,7 @@ FUNC_MOCK(pmalloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 		Pop->persist(Pop, Heap_offset, sizeof (*Heap_offset));
 
 		void *ptr = (void *)((uintptr_t)Pop + *off + data_off);
-		constructor(pop, ptr, arg);
+		constructor(pop, ptr, size, arg);
 
 		return 0;
 	}
@@ -459,12 +459,12 @@ FUNC_MOCK_END
  */
 FUNC_MOCK(prealloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, uint64_t data_off)
+	size_t usable_size, void *arg), void *arg, uint64_t data_off)
 	FUNC_MOCK_RUN_DEFAULT {
 		int ret = prealloc(pop, off, size, data_off);
 		if (!ret) {
 			void *ptr = (void *)((uintptr_t)Pop + *off + data_off);
-			constructor(pop, ptr, arg);
+			constructor(pop, ptr, size, arg);
 		}
 		return ret;
 	}
@@ -810,7 +810,7 @@ do_print_reverse(PMEMobjpool *pop, const char *arg)
  * new value
  */
 static void
-item_constructor(PMEMobjpool *pop, void *ptr, void *arg)
+item_constructor(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 {
 	int id = *(int *)arg;
 	struct item *item = (struct item *)ptr;
@@ -830,7 +830,7 @@ struct realloc_arg {
  * id and argument value
  */
 static void
-realloc_constructor(PMEMobjpool *pop, void *ptr, void *arg)
+realloc_constructor(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 {
 	struct realloc_arg *rarg = arg;
 	struct item *item = (struct item *)ptr;

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -3,7 +3,7 @@ obj_persist_count/TEST1: START: obj_persist_count
 persist	;msync	;flush	;drain	;task
 3	;9	;0	;0	;pool_create
 11	;0	;3	;0	;root_alloc
-11	;0	;3	;0	;atomic_alloc
+10	;0	;4	;1	;atomic_alloc
 8	;0	;3	;0	;atomic_free
 17	;0	;7	;0	;tx_alloc
 14	;0	;7	;0	;tx_free

--- a/src/test/obj_realloc/Makefile
+++ b/src/test/obj_realloc/Makefile
@@ -36,10 +36,12 @@
 vpath %.c ../../common
 
 TARGET = obj_realloc
-OBJS = obj_realloc.o
+OBJS = obj_realloc.o util.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
+
+out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 

--- a/src/test/obj_store/obj_store_mocks.c
+++ b/src/test/obj_store/obj_store_mocks.c
@@ -121,14 +121,14 @@ FUNC_MOCK_END
  */
 FUNC_MOCK(pmalloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, uint64_t data_off)
+	size_t real_size, void *arg), void *arg, uint64_t data_off)
 FUNC_MOCK_RUN_DEFAULT {
 	struct heap_header_mock *hheader = (struct heap_header_mock *)pop->heap;
 	if (pmalloc(pop, off, size, data_off))
 		return ENOMEM;
 	else {
 		(*constructor)(pop, (void *)(hheader->pop + *off + data_off),
-			arg);
+			size, arg);
 		return 0;
 	}
 }
@@ -149,14 +149,14 @@ FUNC_MOCK_END
  */
 FUNC_MOCK(prealloc_construct, int, PMEMobjpool *pop, uint64_t *off,
 	size_t size, void (*constructor)(PMEMobjpool *pop, void *ptr,
-	void *arg), void *arg, uint64_t data_off)
+	size_t real_size, void *arg), void *arg, uint64_t data_off)
 FUNC_MOCK_RUN_DEFAULT {
 	struct heap_header_mock *hheader = (struct heap_header_mock *)pop->heap;
 	if (prealloc(pop, off, size, data_off))
 		return ENOMEM;
 	else {
 		(*constructor)(pop, (void *)(hheader->pop + *off + data_off),
-			arg);
+			size, arg);
 		return 0;
 	}
 }


### PR DESCRIPTION
This patch makes the zalloc an zrealloc functions to
zero initialize the entire allocated area - not just the
requested area. The problem was if the zallocated object
was zreallocated, in such situation the memory above requested area and
below the usable size was not zeroed, next in zrealloc the memory above
the usable size was zeroed which resulted in non-zeroed part of emmory
after zrealloc.

Ref: pmem/issues#120
Ref: pmem/issues#121

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/550)
<!-- Reviewable:end -->
