### PR TITLE
test: remove asserts from vmmalloc_init test

### DIFF
--- a/src/test/vmmalloc_init/vmmalloc_init.c
+++ b/src/test/vmmalloc_init/vmmalloc_init.c
@@ -50,12 +50,6 @@ main(int argc, char *argv[])
 
 	START(argc, argv, "vmmalloc_init");
 
-	/* check if malloc hooks are pointing to libvmmalloc */
-	ASSERTeq((void *)__malloc_hook, (void *)malloc);
-	ASSERTeq((void *)__free_hook, (void *)free);
-	ASSERTeq((void *)__realloc_hook, (void *)realloc);
-	ASSERTeq((void *)__memalign_hook, (void *)memalign);
-
 	if (argc > 2)
 		FATAL("usage: %s [d|l]", argv[0]);
 


### PR DESCRIPTION
When library is compiled with default flags, malloc and __malloc_hook
do not point to the actual malloc function, but to the proper PLT entry.
And since this is the same PLT entry (both should point to malloc from
libvmmalloc), the pointers do match.
However, when library is compiled with -Bsymbolic-functions flag (which
is automatically added when building packages on some Linux distros),
__malloc_hook no longer points to PLT, but directly to libvmmalloc's
implementation of malloc.  So, even though the same function is
referenced in both cases, the pointers are different resulting
in assertion failure.