### PR TITLE
common: use tmpfs for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y uuid-dev valgrind libunwind7-dev autoconf
   - cp src/test/testconfig.sh.example src/test/testconfig.sh
+  - sudo mount -t tmpfs none /tmp -osize=4G
 script: make cstyle && make -j2 USE_LIBUNWIND=1 && make -j2 test USE_LIBUNWIND=1 && make check && make DESTDIR=/tmp source
 env:
   - EXTRA_CFLAGS=-DUSE_VALGRIND


### PR DESCRIPTION
Use tmpfs to workaround the kernel oops in msync on travis.

Ref: pmem/issues#33

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/553)
<!-- Reviewable:end -->
