### PR TITLE
test: avoid permission denied error on /dev/stdout

### DIFF
--- a/src/test/ex_libpmemobj/TEST15
+++ b/src/test/ex_libpmemobj/TEST15
@@ -65,11 +65,9 @@ echo -n q >> $INPUT
 
 if [ -t 1 -a -z "$NOTTY" ]
 then
-	out="/dev/stdout"
+	expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 < $INPUT
 else
-	out="/dev/null"
+	expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 >/dev/null < $INPUT
 fi
-
-expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 >$out < $INPUT
 
 pass


### PR DESCRIPTION
May happen when pminvaders unit test is executed via sudo.