### PR TITLE
common, ut: detect useless ASSERT(1)

### DIFF
--- a/src/common/out.h
+++ b/src/common/out.h
@@ -105,27 +105,66 @@ out_fatal_abort(const char *file, int line, const char *func,
 #define	FATAL(...)\
 	OUT_FATAL_ABORT(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
-/* assert a condition is true */
-#define	ASSERT(cnd)\
+/* assert a condition is true at runtime */
+#define	ASSERT_rt(cnd)\
 	((void)((cnd) || (OUT_FATAL(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s", #cnd), 0)))
 
-/* assertion with extra info printed if assertion fails */
-#define	ASSERTinfo(cnd, info)\
+/* assertion with extra info printed if assertion fails at runtime */
+#define	ASSERTinfo_rt(cnd, info)\
 	((void)((cnd) || (OUT_FATAL(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (%s = %s)", #cnd, #info, info), 0)))
 
-/* assert two integer values are equal */
-#define	ASSERTeq(lhs, rhs)\
+/* assert two integer values are equal at runtime */
+#define	ASSERTeq_rt(lhs, rhs)\
 	((void)(((lhs) == (rhs)) || (OUT_FATAL(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) == %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
 
-/* assert two integer values are not equal */
-#define	ASSERTne(lhs, rhs)\
+/* assert two integer values are not equal at runtime */
+#define	ASSERTne_rt(lhs, rhs)\
 	((void)(((lhs) != (rhs)) || (OUT_FATAL(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) != %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
+
+/* assert a condition is true */
+#define	ASSERT(cnd)\
+	do {\
+		/*\
+		 * Detect useless asserts on always true expression. Please use\
+		 * COMPILE_ERROR_ON(!cnd) or ASSERT_rt(cnd) in such cases.\
+		 */\
+		if (__builtin_constant_p(cnd))\
+			COMPILE_ERROR_ON(cnd);\
+		ASSERT_rt(cnd);\
+	} while (0)
+
+/* assertion with extra info printed if assertion fails */
+#define	ASSERTinfo(cnd, info)\
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(cnd))\
+			COMPILE_ERROR_ON(cnd);\
+		ASSERTinfo_rt(cnd);\
+	} while (0)
+
+/* assert two integer values are equal */
+#define	ASSERTeq(lhs, rhs)\
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
+			COMPILE_ERROR_ON((lhs) == (rhs));\
+		ASSERTeq_rt(lhs, rhs);\
+	} while (0)
+
+/* assert two integer values are not equal */
+#define	ASSERTne(lhs, rhs)\
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
+			COMPILE_ERROR_ON((lhs) != (rhs));\
+		ASSERTne_rt(lhs, rhs);\
+	} while (0)
 
 #define	ERR(...)\
 	out_err(__FILE__, __LINE__, __func__, __VA_ARGS__)

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -971,7 +971,7 @@ chunk_get_chunk_hdr_value(struct chunk_header hdr, uint16_t type,
 	uint32_t size_idx)
 {
 	uint64_t val;
-	ASSERT(sizeof (struct chunk_header) == sizeof (uint64_t));
+	COMPILE_ERROR_ON(sizeof (struct chunk_header) != sizeof (uint64_t));
 
 	hdr.type = type;
 	hdr.size_idx = size_idx;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1290,7 +1290,7 @@ pmemobj_tx_process()
 		tx.stage = TX_STAGE_NONE;
 		break;
 	case MAX_TX_STAGE:
-		ASSERT(1);
+		ASSERT(0);
 	}
 
 	return 0;

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -273,7 +273,7 @@ test_list_api(PMEMobjpool *pop)
 	int nodes_count = 0;
 
 	ASSERTeq(pmemobj_type_num(root.oid), POBJ_ROOT_TYPE_NUM);
-	ASSERTeq(TOID_TYPE_NUM_OF(root), POBJ_ROOT_TYPE_NUM);
+	UT_COMPILE_ERROR_ON(TOID_TYPE_NUM_OF(root) != POBJ_ROOT_TYPE_NUM);
 
 	TOID(struct dummy_node) first;
 	TOID(struct dummy_node) iter;

--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -249,9 +249,11 @@ test_lane_hold_release()
 static void
 test_lane_sizes(void)
 {
-	ASSERT(sizeof (struct lane_tx_layout) <= LANE_SECTION_LEN);
-	ASSERT(sizeof (struct allocator_lane_section) <= LANE_SECTION_LEN);
-	ASSERT(sizeof (struct lane_list_section) <= LANE_SECTION_LEN);
+	UT_COMPILE_ERROR_ON(sizeof (struct lane_tx_layout) > LANE_SECTION_LEN);
+	UT_COMPILE_ERROR_ON(sizeof (struct allocator_lane_section) >
+				LANE_SECTION_LEN);
+	UT_COMPILE_ERROR_ON(sizeof (struct lane_list_section) >
+				LANE_SECTION_LEN);
 }
 
 int

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -1154,7 +1154,7 @@ main(int argc, char *argv[])
 
 	const char *path = argv[1];
 
-	ASSERTeq(OOB_OFF, 48);
+	UT_COMPILE_ERROR_ON(OOB_OFF != 48);
 	PMEMobjpool *pop = pmemobj_open(path, NULL);
 	ASSERTne(pop, NULL);
 

--- a/src/test/out_err/out_err.c
+++ b/src/test/out_err/out_err.c
@@ -45,6 +45,10 @@
 #include "unittest.h"
 #undef ERR
 #undef FATAL
+#undef ASSERT_rt
+#undef ASSERTinfo_rt
+#undef ASSERTeq_rt
+#undef ASSERTne_rt
 #undef ASSERT
 #undef ASSERTinfo
 #undef ASSERTeq

--- a/src/test/traces/traces.c
+++ b/src/test/traces/traces.c
@@ -45,6 +45,10 @@
 #include "out.h"
 #undef ERR
 #undef FATAL
+#undef ASSERT_rt
+#undef ASSERTinfo_rt
+#undef ASSERTeq_rt
+#undef ASSERTne_rt
 #undef ASSERT
 #undef ASSERTinfo
 #undef ASSERTeq

--- a/src/test/traces_custom_function/traces_custom_function.c
+++ b/src/test/traces_custom_function/traces_custom_function.c
@@ -49,6 +49,10 @@
 #include "out.h"
 #undef ERR
 #undef FATAL
+#undef ASSERT_rt
+#undef ASSERTinfo_rt
+#undef ASSERTeq_rt
+#undef ASSERTne_rt
 #undef ASSERT
 #undef ASSERTinfo
 #undef ASSERTeq

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -155,31 +155,72 @@ void ut_err(const char *file, int line, const char *func,
     ut_err(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 
+#define	UT_COMPILE_ERROR_ON(cond) ((void)sizeof (char[(cond) ? -1 : 1]))
+
 /*
  * assertions...
  */
 
-/* assert a condition is true */
-#define	ASSERT(cnd)\
+/* assert a condition is true at runtime */
+#define	ASSERT_rt(cnd)\
 	((void)((cnd) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s", #cnd), 0)))
 
-/* assertion with extra info printed if assertion fails */
-#define	ASSERTinfo(cnd, info) \
+/* assertion with extra info printed if assertion fails at runtime */
+#define	ASSERTinfo_rt(cnd, info) \
 	((void)((cnd) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (%s = %s)", #cnd, #info, info), 0)))
 
-/* assert two integer values are equal */
-#define	ASSERTeq(lhs, rhs)\
+/* assert two integer values are equal at runtime */
+#define	ASSERTeq_rt(lhs, rhs)\
 	((void)(((lhs) == (rhs)) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) == %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
 
-/* assert two integer values are not equal */
-#define	ASSERTne(lhs, rhs)\
+/* assert two integer values are not equal at runtime */
+#define	ASSERTne_rt(lhs, rhs)\
 	((void)(((lhs) != (rhs)) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) != %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
+
+/* assert a condition is true */
+#define	ASSERT(cnd)\
+	do {\
+		/*\
+		 * Detect useless asserts on always true expression. Please use\
+		 * UT_COMPILE_ERROR_ON(!cnd) or ASSERT_rt(cnd) in such cases.\
+		 */\
+		if (__builtin_constant_p(cnd))\
+			UT_COMPILE_ERROR_ON(cnd);\
+		ASSERT_rt(cnd);\
+	} while (0)
+
+/* assertion with extra info printed if assertion fails */
+#define	ASSERTinfo(cnd, info) \
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(cnd))\
+			UT_COMPILE_ERROR_ON(cnd);\
+		ASSERTinfo_rt(cnd, info);\
+	} while (0)
+
+/* assert two integer values are equal */
+#define	ASSERTeq(lhs, rhs)\
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
+			UT_COMPILE_ERROR_ON((lhs) == (rhs));\
+		ASSERTeq_rt(lhs, rhs);\
+	} while (0)
+
+/* assert two integer values are not equal */
+#define	ASSERTne(lhs, rhs)\
+	do {\
+		/* See comment in ASSERT. */\
+		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
+			UT_COMPILE_ERROR_ON((lhs) != (rhs));\
+		ASSERTne_rt(lhs, rhs);\
+	} while (0)
 
 /* assert pointer is fits range of [start, start + size) */
 #define	ASSERTrange(ptr, start, size)\


### PR DESCRIPTION
Noticed in libpmemobj/tx.c.

After this change ASSERT* fails to build when the expression is
possible to evaluate at compile time and it's always true.

(See nice table in the commit description)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/567)
<!-- Reviewable:end -->
