### PR TITLE
test: fix obj_sync match file

### DIFF
--- a/src/test/obj_sync/err0.log.match
+++ b/src/test/obj_sync/err0.log.match
@@ -1,1 +1,1 @@
-{obj_sync.c:$(N) mutex_write_worker} obj_sync/TEST0: pmemobj_mutex_lock
+{obj_sync.c:$(N) mutex_$(nW)_worker} obj_sync/TEST0: pmemobj_mutex_lock


### PR DESCRIPTION
After adding function name to error messages in commit
d915be3c3636adef5f08d072230154a31d5f392b the err0.log.match file didn't
match always due to race between mutex_write_worker and
mutex_check_worker. Add regex to match both write and check workers
which can print an error string.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/568)
<!-- Reviewable:end -->
