### PR TITLE
vmem: fix reallocation to smaller size

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal.h.in
@@ -982,9 +982,33 @@ iralloct(void *ptr, size_t size, size_t extra, size_t alignment, bool zero,
 	}
 
 	if (size + extra <= arena_maxclass) {
-		return (arena_ralloc(arena, ptr, oldsize, size, extra,
+		void *ret;
+
+		ret = arena_ralloc(arena, ptr, oldsize, size, extra,
 		    alignment, zero, try_tcache_alloc,
-		    try_tcache_dalloc));
+		    try_tcache_dalloc);
+
+		if ((ret != NULL) || (size + extra > oldsize))
+			return (ret);
+
+		if (oldsize > chunksize) {
+			ret = huge_ralloc(arena, ptr, oldsize, chunksize, 0,
+			    alignment, zero, try_tcache_dalloc);
+
+			if (ret != NULL) {
+				void *ret2;
+
+				/* Now, it should succeed... */
+				ret2 = arena_ralloc(arena, ret, chunksize, size,
+				    extra, alignment, zero, try_tcache_alloc,
+				    try_tcache_dalloc);
+
+				if (ret2 != NULL)
+					ret = ret2;
+			}
+		}
+
+		return (ret != NULL) ? (ret) : (ptr);
 	} else {
 		return (huge_ralloc(arena, ptr, oldsize, size, extra,
 		    alignment, zero, try_tcache_dalloc));

--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -1350,7 +1350,7 @@ je_realloc(void *ptr, size_t size)
 		}
 		set_errno(ENOMEM);
 	}
-	if (config_stats && ret != NULL) {
+	if (config_stats && ret != NULL && ret != ptr) {
 		thread_allocated_t *ta;
 		assert(usize == isalloc(ret, config_prof));
 		ta = thread_allocated_tsd_get();
@@ -1358,8 +1358,9 @@ je_realloc(void *ptr, size_t size)
 		ta->deallocated += old_usize;
 	}
 	UTRACE(ptr, size, ret);
-	JEMALLOC_VALGRIND_REALLOC(true, ret, usize, true, ptr, old_usize,
-	    old_rzsize, true, false);
+	if (ret != ptr)
+		JEMALLOC_VALGRIND_REALLOC(true, ret, usize, true, ptr, old_usize,
+		    old_rzsize, true, false);
 	return (ret);
 }
 
@@ -2191,7 +2192,7 @@ je_pool_ralloc(pool_t *pool, void *ptr, size_t size)
 		}
 		set_errno(ENOMEM);
 	}
-	if (config_stats && ret != NULL) {
+	if (config_stats && ret != NULL && ret != ptr) {
 		thread_allocated_t *ta;
 		assert(usize == isalloc(ret, config_prof));
 		ta = thread_allocated_tsd_get();
@@ -2199,8 +2200,9 @@ je_pool_ralloc(pool_t *pool, void *ptr, size_t size)
 		ta->deallocated += old_usize;
 	}
 	UTRACE(ptr, size, ret);
-	JEMALLOC_VALGRIND_REALLOC(true, ret, usize, true, ptr, old_usize,
-	    old_rzsize, true, false);
+	if (ret != ptr)
+		JEMALLOC_VALGRIND_REALLOC(true, ret, usize, true, ptr, old_usize,
+		    old_rzsize, true, false);
 	return (ret);
 }
 


### PR DESCRIPTION
If shrinking the huge allocation (>=4MB) to some smaller size fails due
to the lack of memory for a new arena, return the original allocation
pointer instead of NULL.
For allocations larger than a single chunk, try to shrink them to a
single chunk first, then there is a chance that the actual reallocation
will succeed.

Ref: pmem/issues#24