### PR TITLE
pmempool: fix checking FLOG in pmemblk

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -232,6 +232,11 @@ TEST_BUILD = all
 TEST_FS = all
 TEST_TIME = 3m
 MEMCHECK = auto
+CHECK_POOL =
+
+ifeq ($(CHECK_POOL),y)
+CHECK_POOL_OPT="-c"
+endif
 
 all test cstyle: $(TESTS_BUILD)
 
@@ -254,7 +259,7 @@ memcheck-summary-leaks:
 	grep "in use at exit" */memcheck*.log | grep -v " 0 bytes in 0 blocks" || true
 
 check: test
-	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(TESTS)
+	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(TESTS)
 	@echo "No failures."
 
 pcheck: $(TESTS_BUILD)

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ usage()
 	[ "$1" ] && echo Error: $1
 	cat >&2 <<EOF
 Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
-	    [ -o timeout ] [-s test-file ] [ -m memcheck ] [tests...]
+	    [ -o timeout ] [-s test-file ] [ -m memcheck ] [ -c ] [tests...]
     build-types: debug, nondebug, static-debug, static-nondebug, all (default)
      test-types: check (default), short, long
        fs-types: local, pmem, non-pmem, all (default)
@@ -54,6 +54,7 @@ Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
        memcheck: auto (default, enable/disable based on test requirements),
                  force-enable (enable when test does not require memcheck, but
                                obey test's explicit memcheck disable)
+             -c: run pmempool check on pool files
 EOF
 	exit 1
 }
@@ -116,10 +117,12 @@ runtest() {
 				elif [ "$use_timeout" -a "$testtype" = "check" ]
 				then
 					[ "$verbose" ] && echo "RUNTESTS: Running: (in ./$1) TEST=$testtype FS=$fs BUILD=$build ./$runscript"
-					MEMCHECK=$memcheck TEST=$testtype FS=$fs BUILD=$build timeout --foreground $killopt $time ./$runscript
+					MEMCHECK=$memcheck CHECK_POOL=$check_pool VERBOSE=$verbose\
+						TEST=$testtype FS=$fs BUILD=$build timeout --foreground $killopt $time ./$runscript
 				else
 					[ "$verbose" ] && echo "RUNTESTS: Running: (in ./$1) TEST=$testtype FS=$fs BUILD=$build ./$runscript"
-					MEMCHECK=$memcheck TEST=$testtype FS=$fs BUILD=$build ./$runscript
+					MEMCHECK=$memcheck CHECK_POOL=$check_pool VERBOSE=$verbose\
+						TEST=$testtype FS=$fs BUILD=$build ./$runscript
 				fi
 
 				retval=$?
@@ -162,11 +165,12 @@ time='3m'
 use_timeout="ok"
 testfile=all
 memcheck=auto
+check_pool=0
 
 #
 # command-line argument processing...
 #
-args=`getopt nvb:t:f:o:s:m: $*`
+args=`getopt nvb:t:f:o:s:m:c $*`
 [ $? != 0 ] && usage
 set -- $args
 for arg
@@ -238,6 +242,10 @@ do
 		testfile="$2"
 		shift 2
 		;;
+	-c)
+		check_pool=1
+		shift
+		;;
 	--)
 		shift
 		break
@@ -253,6 +261,13 @@ done
 	echo "    test-type: $testtype"
 	echo "    fs-type: $fstype"
 	echo "    memcheck: $memcheck"
+	if [ "$check_pool" ]
+	then
+		check_pool_str="yes"
+	else
+		check_pool_str="no"
+	fi
+	echo "    check-pool: $check_pool_str"
 	echo Tests: $*
 }
 

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -42,19 +42,28 @@ usage()
 {
 	[ "$1" ] && echo Error: $1
 	cat >&2 <<EOF
-Usage: $0 [ -nv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
-	    [ -o timeout ] [-s test-file ] [ -m memcheck ] [ -c ] [tests...]
-    build-types: debug, nondebug, static-debug, static-nondebug, all (default)
-     test-types: check (default), short, long
-       fs-types: local, pmem, non-pmem, all (default)
-        timeout: floating point number with an optional suffix: 's' for seconds
-		 (the default), 'm' for minutes, 'h' for hours or 'd' for days.
-		 Default value is 3 minutes.
-      test-file: all (default), TEST0, TEST1, ...
-       memcheck: auto (default, enable/disable based on test requirements),
-                 force-enable (enable when test does not require memcheck, but
-                               obey test's explicit memcheck disable)
-             -c: run pmempool check on pool files
+Usage: $0 [ -hnv ] [ -b build-type ] [ -t test-type ] [ -f fs-type ]
+	    [ -o timeout ] [ -s test-file ] [ -m memcheck ] [ -c ] [tests...]
+-h		print this help message
+-n		dry run
+-v		be verbose
+-b build-type	run only specified build type
+		build-type: debug, nondebug, static-debug, static-nondebug, all (default)
+-t test-type	run only specified test type
+		test-type: check (default), short, long
+-f fs-type	run tests only on specified file systems
+		fs-type: local, pmem, non-pmem, all (default)
+-o timeout	set timeout for test execution
+		timeout: floating point number with an optional suffix: 's' for seconds
+		(the default), 'm' for minutes, 'h' for hours or 'd' for days.
+		Default value is 3 minutes.
+-s test-file	run only specified test file
+		test-file: all (default), TEST0, TEST1, ...
+-m memcheck	run tests with memcheck
+		memcheck: auto (default, enable/disable based on test requirements),
+		force-enable (enable when test does not require memcheck, but
+		obey test's explicit memcheck disable)
+-c		check pool files with pmempool check utility
 EOF
 	exit 1
 }

--- a/src/test/blk_nblock/TEST0
+++ b/src/test/blk_nblock/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -139,6 +139,44 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 	4096:$DIR/testfile7.4096\
 	4160:$DIR/testfile7.4160\
 	4224:$DIR/testfile7.4224
+
+check_pools $DIR/testfile2.512\
+	$DIR/testfile2.512\
+	$DIR/testfile2.520\
+	$DIR/testfile2.528\
+	$DIR/testfile2.4096\
+	$DIR/testfile2.4160\
+	$DIR/testfile2.4224\
+	$DIR/testfile3.512\
+	$DIR/testfile3.520\
+	$DIR/testfile3.528\
+	$DIR/testfile3.4096\
+	$DIR/testfile3.4160\
+	$DIR/testfile3.4224\
+	$DIR/testfile4.512\
+	$DIR/testfile4.520\
+	$DIR/testfile4.528\
+	$DIR/testfile4.4096\
+	$DIR/testfile4.4160\
+	$DIR/testfile4.4224\
+	$DIR/testfile5.512\
+	$DIR/testfile5.520\
+	$DIR/testfile5.528\
+	$DIR/testfile5.4096\
+	$DIR/testfile5.4160\
+	$DIR/testfile5.4224\
+	$DIR/testfile6.512\
+	$DIR/testfile6.520\
+	$DIR/testfile6.528\
+	$DIR/testfile6.4096\
+	$DIR/testfile6.4160\
+	$DIR/testfile6.4224\
+	$DIR/testfile7.512\
+	$DIR/testfile7.520\
+	$DIR/testfile7.528\
+	$DIR/testfile7.4096\
+	$DIR/testfile7.4160\
+	$DIR/testfile7.4224
 
 check
 

--- a/src/test/blk_nblock/TEST1
+++ b/src/test/blk_nblock/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -91,6 +91,24 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 	1073741824:$DIR/testfile2.1073741824\
 	2147483648:$DIR/testfile2.2147483648\
 	-1:$DIR/testfile2.-1
+
+check_pools $DIR/testfile1.2096896\
+	$DIR/testfile1.2096897\
+	$DIR/testfile2.1\
+	$DIR/testfile2.17\
+	$DIR/testfile2.511\
+	$DIR/testfile2.1048576\
+	$DIR/testfile2.2097152\
+	$DIR/testfile2.4194304\
+	$DIR/testfile2.8388608\
+	$DIR/testfile2.16777216\
+	$DIR/testfile2.33554432\
+	$DIR/testfile2.67108864\
+	$DIR/testfile2.134217728\
+	$DIR/testfile2.268435456\
+	$DIR/testfile2.536870912\
+	$DIR/testfile2.1073741824\
+	$DIR/testfile2.2147483648\
 
 check
 

--- a/src/test/blk_nblock/TEST2
+++ b/src/test/blk_nblock/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ expect_normal_exit ./blk_nblock$EXESUFFIX\
 	512:$DIR/testset1\
 	512:$DIR/testset2
 
+check_pools $DIR/testset1\
+	$DIR/testset2
 check
 
 pass

--- a/src/test/blk_recovery/TEST0
+++ b/src/test/blk_recovery/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -57,6 +57,8 @@ truncate -s 2G $DIR/testfile1
 # that testfile1 is consistent (after recovery steps were taken).
 #
 expect_normal_exit ./blk_recovery$EXESUFFIX 4096 $DIR/testfile1 5 10
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST0
+++ b/src/test/blk_rw/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,6 +55,8 @@ truncate -s $MIN_POOL_SIZE $DIR/testfile1
 #
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 	r:0 r:1 r:32201 r:32202 z:0 z:1 r:0
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST1
+++ b/src/test/blk_rw/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,6 +58,8 @@ truncate -s 1026G $DIR/testfile1
 #
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 	r:0 r:1 r:4161480 r:2134997325 r:2134997326 z:0 z:4161480
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST2
+++ b/src/test/blk_rw/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,6 +58,8 @@ truncate -s 1026G $DIR/testfile1
 #
 expect_normal_exit ./blk_rw$EXESUFFIX 4096 $DIR/testfile1 c\
 	r:0 r:1 r:4161480 r:268696550 r:268696551 z:0 z:4161480
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST3
+++ b/src/test/blk_rw/TEST3
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,8 @@ setup
 truncate -s 1G $DIR/testfile1
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST4
+++ b/src/test/blk_rw/TEST4
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 	w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 o\
 	w:0 r:4 r:3 r:2 r:1 r:0 w:0 r:0
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST5
+++ b/src/test/blk_rw/TEST5
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,6 +54,8 @@ expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 	r:100 r:200 r:300 r:400\
 	e:100 w:200 e:300 w:400\
 	r:100 r:200 r:300 r:400
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST6
+++ b/src/test/blk_rw/TEST6
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,6 +54,8 @@ expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testfile1 c\
 		e:4 z:4 r:4\
 		w:5 e:5 z:5 r:5\
 		w:6 z:6 e:6 r:6
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST7
+++ b/src/test/blk_rw/TEST7
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -60,6 +60,8 @@ expect_normal_exit valgrind --tool=pmemcheck\
 		e:4 z:4 r:4\
 		w:5 e:5 z:5 r:5\
 		w:6 z:6 e:6 r:6
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw/TEST8
+++ b/src/test/blk_rw/TEST8
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,6 +50,8 @@ create_poolset $DIR/testset1 1G:$DIR/testfile1:x 1G:$DIR/testfile2:x
 expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testset1 c\
 	w:0 w:1 r:1 r:0\
 	w:4161445 r:4161445
+
+check_pool $DIR/testfile2
 
 check
 

--- a/src/test/blk_rw_mt/TEST0
+++ b/src/test/blk_rw_mt/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,8 @@ setup
 truncate -s 1G $DIR/testfile1
 # 5 threads, each doing 80 random I/Os
 expect_normal_exit ./blk_rw_mt$EXESUFFIX 4096 $DIR/testfile1 123 5 80
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw_mt/TEST1
+++ b/src/test/blk_rw_mt/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ setup
 truncate -s 1G $DIR/testfile1
 # 100 threads, each doing 100 random I/Os
 expect_normal_exit ./blk_rw_mt$EXESUFFIX 4096 $DIR/testfile1 456 100 100
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/blk_rw_mt/TEST2
+++ b/src/test/blk_rw_mt/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ setup
 truncate -s 1G $DIR/testfile1
 # 300 threads, each doing 100000 random I/Os
 expect_normal_exit ./blk_rw_mt$EXESUFFIX 4096 $DIR/testfile1 789 300 100000
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/ex_libpmemblk/TEST0
+++ b/src/test/ex_libpmemblk/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,6 +54,8 @@ expect_normal_exit $EX_PATH/asset_checkout $DIR/testfile1 2 Joe >> out$UNITTEST_
 expect_normal_exit $EX_PATH/asset_list $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/asset_checkin $DIR/testfile1 2 >> out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/asset_list $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/ex_libpmemlog/TEST0
+++ b/src/test/ex_libpmemlog/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,6 +54,8 @@ expect_normal_exit $EX_PATH/addlog $DIR/testfile1 "PMEMLOG" >> out$UNITTEST_NUM.
 expect_normal_exit $EX_PATH/printlog -t $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/addlog $DIR/testfile1 "NVML" >> out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/printlog -t $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST0
+++ b/src/test/log_basic/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,6 +53,8 @@ setup
 create_holey_file 2 $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 n t w r
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST1
+++ b/src/test/log_basic/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,6 +55,8 @@ setup
 create_holey_file 2 $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 a n t w r t w
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST2
+++ b/src/test/log_basic/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,6 +55,8 @@ setup
 create_holey_file 2 $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 v n t w r t w
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST3
+++ b/src/test/log_basic/TEST3
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -56,6 +56,8 @@ setup
 create_holey_file 2 $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 a n t w r t w v n t w r t w
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST4
+++ b/src/test/log_basic/TEST4
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,6 +61,8 @@ create_holey_file 2 $DIR/testfile1
 expect_normal_exit valgrind --tool=pmemcheck\
 	--log-file=valgrind$UNITTEST_NUM.log\
 	./log_basic$EXESUFFIX $DIR/testfile1 a n t w r t w v n t w r t w
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_basic/TEST5
+++ b/src/test/log_basic/TEST5
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ export PMEMLOG_LOG_LEVEL=10
 create_poolset $DIR/testset1 2M:$DIR/testfile1:x
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testset1 n
+
+check_pool $DIR/testset1
 
 check
 

--- a/src/test/log_basic/TEST6
+++ b/src/test/log_basic/TEST6
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,8 @@ setup
 create_poolset $DIR/testset1 2M:$DIR/testfile1:x 2M:$DIR/testfile2:x
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testset1 n
+
+check_pool $DIR/testset1
 
 check
 

--- a/src/test/log_recovery/TEST0
+++ b/src/test/log_recovery/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ export ASAN_OPTIONS=handle_segv=0
 touch $DIR/testfile1
 
 expect_normal_exit ./log_recovery$EXESUFFIX $DIR/testfile1 a
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_recovery/TEST1
+++ b/src/test/log_recovery/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ export ASAN_OPTIONS=handle_segv=0
 touch $DIR/testfile1
 
 expect_normal_exit ./log_recovery$EXESUFFIX $DIR/testfile1 v
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/log_walker/TEST0
+++ b/src/test/log_walker/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,6 +51,8 @@ export ASAN_OPTIONS=handle_segv=0
 touch $DIR/testfile1
 
 expect_normal_exit ./log_walker$EXESUFFIX $DIR/testfile1
+
+check_pool $DIR/testfile1
 
 check
 

--- a/src/test/pmempool_check/TEST0
+++ b/src/test/pmempool_check/TEST0
@@ -46,7 +46,24 @@ POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
+echo "PMEMLOG: consistent" >> $LOG
+rm -rf $POOL
+expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
+check_file $POOL
+expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL TEST
+expect_normal_exit $PMEMPOOL$EXESUFFIX check $POOL >> $LOG
+
+echo "PMEMBLK: consistent" >> $LOG
+rm -rf $POOL
+expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
+check_file $POOL
+expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 0:w:TEST0
+expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 1:w:TEST0
+expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 2:w:TEST0
+expect_normal_exit $PMEMPOOL$EXESUFFIX check $POOL >> $LOG
+
 echo "PMEMLOG: pool_hdr" >> $LOG
+rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOL
 check_file $POOL
 $PMEMSPOIL -v $POOL pool_hdr.signature=ERROR >> $LOG

--- a/src/test/pmempool_check/TEST0
+++ b/src/test/pmempool_check/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/out0.log.match
+++ b/src/test/pmempool_check/out0.log.match
@@ -1,3 +1,5 @@
+PMEMLOG: consistent
+PMEMBLK: consistent
 PMEMLOG: pool_hdr
 $(*): spoil: pool_hdr.signature=$(*)
 incorrect pool header checksum

--- a/src/test/pmempool_check/out7.log.match
+++ b/src/test/pmempool_check/out7.log.match
@@ -9,6 +9,7 @@ $(*)file.pool: repaired
 checking pool header
 pool header checksum correct
 checking pmemblk header
+no BTT layout
 pmemblk header correct
 checking BTT Info headers
 BTT Layout not written
@@ -25,6 +26,7 @@ $(*)file.pool: repaired
 checking pool header
 pool header checksum correct
 checking pmemblk header
+no BTT layout
 pmemblk header correct
 checking BTT Info headers
 BTT Layout not written
@@ -44,6 +46,7 @@ $(*)file.pool: repaired
 checking pool header
 pool header checksum correct
 checking pmemblk header
+no BTT layout
 pmemblk header correct
 checking BTT Info headers
 BTT Layout not written

--- a/src/test/pmempool_check/out8.log.match
+++ b/src/test/pmempool_check/out8.log.match
@@ -24,6 +24,7 @@ replica 0 part 2: pool header checksum correct
 replica 0 part 3: checking pool header
 replica 0 part 3: pool header checksum correct
 checking pmemblk header
+no BTT layout
 pmemblk header correct
 checking BTT Info headers
 BTT Layout not written


### PR DESCRIPTION
- Fix checking FLOG entries in pmemblk pool,
- Improve performance of pmempool check,
- Add a new mechanism for testing framework to run pmempool check on each pool used by a test,
- Minor fixes in pmemspoil,
- Change help message of RUNTEST script

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/589)
<!-- Reviewable:end -->
