### PR TITLE
obj: change typeof to more universal __typeof__

### DIFF
--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -343,9 +343,9 @@ pmemobj_direct(PMEMoid oid)
 }
 
 #define	DIRECT_RW(o) (\
-{typeof (o) _o; _o._type = NULL; (void)_o;\
-(typeof (*(o)._type) *)pmemobj_direct((o).oid); })
-#define	DIRECT_RO(o) ((const typeof (*(o)._type) *)pmemobj_direct((o).oid))
+{__typeof__(o) _o; _o._type = NULL; (void)_o;\
+(__typeof__(*(o)._type) *)pmemobj_direct((o).oid); })
+#define	DIRECT_RO(o) ((const __typeof__(*(o)._type) *)pmemobj_direct((o).oid))
 
 #define	D_RW	DIRECT_RW
 #define	D_RO	DIRECT_RO
@@ -492,7 +492,7 @@ PMEMoid pmemobj_next(PMEMoid oid);
 _pobj_ret; })
 
 #define	POBJ_NEXT(o) (\
-{ typeof (o) _pobj_ret = (typeof (o))pmemobj_next((o).oid);\
+{ __typeof__(o) _pobj_ret = (__typeof__(o))pmemobj_next((o).oid);\
 _pobj_ret; })
 
 #define	POBJ_NEW(pop, o, t, constr, arg) (\
@@ -584,7 +584,7 @@ for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_FOREACH_SAFE")\
  */
 #define	POBJ_FOREACH_TYPE(pop, var)\
 for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_FOREACH_TYPE")\
-	var = (typeof (var))pmemobj_first((pop),\
+	var = (__typeof__(var))pmemobj_first((pop),\
 		TOID_TYPE_NUM_OF(var));\
 		TOID_IS_NULL(var) == 0;\
 		var = POBJ_NEXT(var))
@@ -595,7 +595,7 @@ for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_FOREACH_TYPE")\
  */
 #define	POBJ_FOREACH_SAFE_TYPE(pop, var, nvar)\
 for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_FOREACH_SAFE_TYPE")\
-	var = (typeof (var))pmemobj_first((pop),\
+	var = (__typeof__(var))pmemobj_first((pop),\
 	TOID_TYPE_NUM_OF(var));\
 	TOID_IS_NULL(var) == 0 &&\
 	(nvar = POBJ_NEXT(var), 1);\
@@ -662,84 +662,84 @@ for (_POBJ_DEBUG_NOTICE_IN_TX_FOR("POBJ_LIST_FOREACH_REVERSE")\
 
 #define	POBJ_LIST_INSERT_HEAD(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), OID_NULL,\
 	POBJ_LIST_DEST_HEAD, (elm).oid)
 
 #define	POBJ_LIST_INSERT_TAIL(pop, head, elm, field)\
 pmemobj_list_insert((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), OID_NULL,\
 	POBJ_LIST_DEST_TAIL, (elm).oid)
 
 #define	POBJ_LIST_INSERT_AFTER(pop, head, listelm, elm, field)\
 pmemobj_list_insert((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), (listelm).oid,\
 	0 /* after */, (elm).oid)
 
 #define	POBJ_LIST_INSERT_BEFORE(pop, head, listelm, elm, field)\
 pmemobj_list_insert((pop), \
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), (listelm).oid,\
 	1 /* before */, (elm).oid)
 
 #define	POBJ_LIST_INSERT_NEW_HEAD(pop, head, field, size, constr, arg)\
 pmemobj_list_insert_new((pop),\
-	offsetof(typeof (*((head)->pe_first._type)), field),\
+	offsetof(__typeof__ (*((head)->pe_first._type)), field),\
 	(head), OID_NULL, POBJ_LIST_DEST_HEAD, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_INSERT_NEW_TAIL(pop, head, field, size, constr, arg)\
 pmemobj_list_insert_new((pop),\
-	offsetof(typeof (*((head)->pe_first._type)), field),\
+	offsetof(__typeof__ (*((head)->pe_first._type)), field),\
 	(head), OID_NULL, POBJ_LIST_DEST_TAIL, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_INSERT_NEW_AFTER(pop, head, listelm, field, size,\
 	constr, arg)\
 pmemobj_list_insert_new((pop),\
-	offsetof(typeof (*((head)->pe_first._type)), field),\
+	offsetof(__typeof__ (*((head)->pe_first._type)), field),\
 	(head), (listelm).oid, 0 /* after */, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_INSERT_NEW_BEFORE(pop, head, listelm, field, size,\
 		constr, arg)\
 pmemobj_list_insert_new((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), (listelm).oid, 1 /* before */, (size),\
 	TOID_TYPE_NUM_OF((head)->pe_first), (constr), (arg))
 
 #define	POBJ_LIST_REMOVE(pop, head, elm, field)\
 pmemobj_list_remove((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), (elm).oid, 0 /* no free */)
 
 #define	POBJ_LIST_REMOVE_FREE(pop, head, elm, field)\
 pmemobj_list_remove((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head), (elm).oid, 1 /* free */)
 
 #define	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, head, head_new, elm, field, field_new)\
 pmemobj_list_move((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
 	(head_new), OID_NULL, POBJ_LIST_DEST_HEAD, (elm).oid)
 
 #define	POBJ_LIST_MOVE_ELEMENT_TAIL(pop, head, head_new, elm, field, field_new)\
 pmemobj_list_move((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
 	(head_new), OID_NULL, POBJ_LIST_DEST_TAIL, (elm).oid)
 
 #define	POBJ_LIST_MOVE_ELEMENT_AFTER(pop,\
 	head, head_new, listelm, elm, field, field_new)\
 pmemobj_list_move((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
 	(head_new),\
 	(listelm).oid,\
 	0 /* after */, (elm).oid)
@@ -747,9 +747,9 @@ pmemobj_list_move((pop),\
 #define	POBJ_LIST_MOVE_ELEMENT_BEFORE(pop,\
 	head, head_new, listelm, elm, field, field_new)\
 pmemobj_list_move((pop),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head)._type)), field),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head)._type)), field),\
 	(head),\
-	offsetof(typeof (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
+	offsetof(__typeof__ (*(POBJ_LIST_FIRST(head_new)._type)), field_new),\
 	(head_new),\
 	(listelm).oid,\
 	1 /* before */, (elm).oid)
@@ -979,7 +979,7 @@ int pmemobj_tx_free(PMEMoid oid);
 pmemobj_tx_add_range((o).oid, 0, sizeof (*(o)._type))
 
 #define	TX_ADD_FIELD(o, field)\
-pmemobj_tx_add_range((o).oid, offsetof(typeof (*(o)._type), field),\
+pmemobj_tx_add_range((o).oid, offsetof(__typeof__ (*(o)._type), field),\
 		sizeof (D_RO(o)->field))
 
 #define	TX_NEW(t) (\
@@ -999,11 +999,13 @@ TOID_TYPE_NUM(t)); _pobj_ret; })
 TOID_TYPE_NUM(t)); _pobj_ret; })
 
 #define	TX_REALLOC(o, size) (\
-{ typeof (o) _pobj_ret = (typeof (o))pmemobj_tx_realloc((o).oid, (size),\
+{ __typeof__(o) _pobj_ret =\
+(__typeof__(o))pmemobj_tx_realloc((o).oid, (size),\
 TOID_TYPE_NUM_OF(o)); _pobj_ret; })
 
 #define	TX_ZREALLOC(o, size) (\
-{ typeof (o) _pobj_ret = (typeof (o))pmemobj_tx_zrealloc((o).oid, (size),\
+{ __typeof__(o) _pobj_ret =\
+(__typeof__(o))pmemobj_tx_zrealloc((o).oid, (size),\
 TOID_TYPE_NUM_OF(o)); _pobj_ret; })
 
 #define	TX_STRDUP(s, type_num)\


### PR DESCRIPTION
In an effort to make our header file usable with a broad spectrum
of standards (-std=c++11 in particular) typeof has to be changed to an
alternate keyword. This solution is suggested by gcc documentation:
https://gcc.gnu.org/onlinedocs/gcc/Typeof.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/594)
<!-- Reviewable:end -->
