### PR TITLE
common: remove dependency on libuuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - if [ "$CC" = "clang" ]; then export CXX="clang++"; else export CXX="g++"; fi
   - sudo add-apt-repository -y ppa:tmsz-kapela/valgrind-pmem
   - sudo apt-get update -qq
-  - sudo apt-get install -y uuid-dev valgrind libunwind7-dev autoconf devscripts
+  - sudo apt-get install -y valgrind libunwind7-dev autoconf devscripts
   - cp src/test/testconfig.sh.example src/test/testconfig.sh
   - sudo mount -t tmpfs none /tmp -osize=4G
 script:

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -91,7 +91,7 @@ OBJS=$(SRC:.c=.o)
 LDFLAGS = -L$(LIBS_PATH)
 LDFLAGS += -L../examples/libpmemobj/map
 LDFLAGS += $(EXTRA_LDFLAGS)
-LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm -luuid
+LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm
 CFLAGS  = -std=gnu99
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -42,7 +42,6 @@
 #include <errno.h>
 #include <time.h>
 #include <stdint.h>
-#include <uuid/uuid.h>
 #include <pthread.h>
 
 #include "libpmem.h"

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -129,7 +129,6 @@
 #include <stdint.h>
 #include <pthread.h>
 #include <endian.h>
-#include <uuid/uuid.h>
 
 #include "out.h"
 #include "util.h"
@@ -873,8 +872,13 @@ write_layout(struct btt *bttp, unsigned lane, int write)
 	/*
 	 * If a new layout is being written, generate the BTT's UUID.
 	 */
-	if (write)
-		uuid_generate(bttp->uuid);
+	if (write) {
+		int ret = util_uuid_generate(bttp->uuid);
+		if (ret < 0) {
+			LOG(2, "util_uuid_generate failed");
+			return -1;
+		}
+	}
 
 	/*
 	 * The number of arenas is the number of full arena of

--- a/src/libpmemlog/Makefile
+++ b/src/libpmemlog/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,4 +39,4 @@ SOURCE = libpmemlog.c log.c $(COMMON)/util.c $(COMMON)/set.c $(COMMON)/out.c
 
 include ../Makefile.inc
 
-LIBS += -luuid -pthread -lpmem
+LIBS +=  -pthread -lpmem

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -43,7 +43,6 @@
 #include <time.h>
 #include <stdint.h>
 #include <pthread.h>
-#include <uuid/uuid.h>
 #include <endian.h>
 
 #include "libpmem.h"

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,4 +41,4 @@ SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c list.c ctree.c bucket.c\
 
 include ../Makefile.inc
 
-LIBS += -luuid -pthread -lpmem
+LIBS += -pthread -lpmem

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -127,6 +127,7 @@ OTHER_TESTS = \
        traces\
        traces_custom_function\
        traces_pmem\
+       util_uuid_generate\
        util_file_create\
        util_file_open\
        util_map_proc\

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -57,7 +57,7 @@ LIBS += -ldl $(shell pkg-config --libs libunwind || echo -lunwind)
 endif
 
 LIBS += -L$(LIBS_DIR)/debug
-LIBS += -luuid -pthread
+LIBS += -pthread
 
 ifeq ($(LIBPMEMBLK), y)
 DYNAMIC_LIBS += -lpmemblk

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,7 +103,6 @@ extern "C" {
 #include <sys/mman.h>
 #include <sys/file.h>
 #include <sys/mount.h>
-#include <uuid/uuid.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <errno.h>

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -375,10 +375,6 @@ ut_start(const char *file, int line, const char *func,
 	out(0, NULL);
 
 	va_end(ap);
-
-	/* generate a uuid so the leaked fd gets recorded */
-	uuid_t u;
-	uuid_generate(u);
 
 	record_open_files();
 

--- a/src/test/util_uuid_generate/.gitignore
+++ b/src/test/util_uuid_generate/.gitignore
@@ -1,0 +1,1 @@
+util_uuid_generate

--- a/src/test/util_uuid_generate/Makefile
+++ b/src/test/util_uuid_generate/Makefile
@@ -1,4 +1,5 @@
-# Copyright (c) 2014-2016, Intel Corporation
+#
+# Copyright (c) 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +28,21 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemblk/Makefile -- Makefile for libpmemblk
 #
 
-LIBRARY_NAME = pmemblk
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+#
+# src/test/util_uuid_generate/Makefile -- create a uuid and verify it
+#
+vpath %.c ../../common
+vpath %.h ../../common
+TARGET = util_uuid_generate
+OBJS = util_uuid_generate.o util.o set.o out.o
 
+out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+util.o: CFLAGS += -DDEBUG
+set.o: CFLAGS += -DDEBUG
+
+LIBPMEM=y
 include ../Makefile.inc
 
-LIBS += -pthread -lpmem
+INCS += -I../../common

--- a/src/test/util_uuid_generate/TEST0
+++ b/src/test/util_uuid_generate/TEST0
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2016, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,24 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemblk/Makefile -- Makefile for libpmemblk
 #
 
-LIBRARY_NAME = pmemblk
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+#
+# src/test/util_uuid_generate/TEST0 -- unit test for util_uuid_generate.
+# No uuid string specified.
+#
+export UNITTEST_NAME=util_uuid_generate/TEST0
+export UNITTEST_NUM=0
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -pthread -lpmem
+require_fs_type non-pmem
+
+setup
+
+expect_normal_exit ./util_uuid_generate$EXESUFFIX
+
+check
+
+pass

--- a/src/test/util_uuid_generate/TEST1
+++ b/src/test/util_uuid_generate/TEST1
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2016, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,26 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemblk/Makefile -- Makefile for libpmemblk
 #
 
-LIBRARY_NAME = pmemblk
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+#
+# src/test/util_uuid_generate/TEST1 -- unit test for util_uuid_generate.
+# Valid uuid string specified.
+#
+export UNITTEST_NAME=util_uuid_generate/TEST1
+export UNITTEST_NUM=1
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -pthread -lpmem
+require_fs_type non-pmem
+
+setup
+
+# valid uuid string
+expect_normal_exit ./util_uuid_generate$EXESUFFIX \
+	563bb872-0d1d-441e-ac28-579c463be0a5 valid
+
+check
+
+pass

--- a/src/test/util_uuid_generate/TEST2
+++ b/src/test/util_uuid_generate/TEST2
@@ -1,4 +1,6 @@
-# Copyright (c) 2014-2016, Intel Corporation
+#!/bin/bash -e
+#
+# Copyright (c) 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,17 +29,24 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#
-# src/libpmemblk/Makefile -- Makefile for libpmemblk
 #
 
-LIBRARY_NAME = pmemblk
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+#
+# src/test/util_uuid_generate/TEST2 -- unit test for util_uuid_generate.
+# Invalid uuid string provided.
+#
+export UNITTEST_NAME=util_uuid_generate/TEST2
+export UNITTEST_NUM=2
 
-include ../Makefile.inc
+# standard unit test setup
+. ../unittest/unittest.sh
 
-LIBS += -pthread -lpmem
+require_fs_type non-pmem
+
+setup
+
+expect_normal_exit ./util_uuid_generate$EXESUFFIX sarah invalid
+
+check
+
+pass

--- a/src/test/util_uuid_generate/out0.log.match
+++ b/src/test/util_uuid_generate/out0.log.match
@@ -1,0 +1,3 @@
+util_uuid_generate/TEST0: START: util_uuid_generate
+ ./util_uuid_generate$(nW)
+util_uuid_generate/TEST0: Done

--- a/src/test/util_uuid_generate/out1.log.match
+++ b/src/test/util_uuid_generate/out1.log.match
@@ -1,0 +1,3 @@
+util_uuid_generate/TEST1: START: util_uuid_generate
+ ./util_uuid_generate$(nW) 563bb872-0d1d-441e-ac28-579c463be0a5 valid
+util_uuid_generate/TEST1: Done

--- a/src/test/util_uuid_generate/out2.log.match
+++ b/src/test/util_uuid_generate/out2.log.match
@@ -1,0 +1,4 @@
+util_uuid_generate/TEST2: START: util_uuid_generate
+ ./util_uuid_generate$(nW) sarah invalid
+util_uuid_generate: invalid uuid string
+util_uuid_generate/TEST2: Done

--- a/src/test/util_uuid_generate/util_uuid_generate.c
+++ b/src/test/util_uuid_generate/util_uuid_generate.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * util_uuid_generate.c -- unit test for generating a uuid
+ *
+ * usage: util_uuid_generate [string] [valid|invalid]
+ */
+
+#include "unittest.h"
+#include "util.h"
+#include <unistd.h>
+#include <string.h>
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "util_uuid_generate");
+
+	uuid_t uuid;
+	uuid_t uuid1;
+	int ret;
+	char conv_uu[POOL_HDR_UUID_STR_LEN];
+	char uu[POOL_HDR_UUID_STR_LEN];
+
+	/*
+	 * No string passed in.  Generate uuid.
+	 */
+	if (argc == 1) {
+		/*
+		 * Read uuid string from /proc/sys/kernel/random/uuid
+		 * and translate to a uuid_t.
+		 */
+		int fd = OPEN(POOL_HDR_UUID_GEN_FILE, O_RDONLY);
+		ssize_t num = READ(fd, uu, POOL_HDR_UUID_STR_LEN);
+		ASSERTeq(num, POOL_HDR_UUID_STR_LEN);
+
+		uu[POOL_HDR_UUID_STR_LEN - 1] = '\0';
+
+		/*
+		 * Convert the the string to a uuid, convert generated
+		 * uuid back to a string and compare strings.
+		 */
+		ret = util_uuid_from_string(uu, (struct uuid *)&uuid);
+		ASSERTeq(ret, 0);
+
+		ret = util_uuid_to_string(uuid, conv_uu);
+		ASSERTeq(ret, 0);
+
+		ASSERT(strncmp(uu, conv_uu, POOL_HDR_UUID_STR_LEN) == 0);
+
+		/*
+		 * Generate uuid from util_uuid_generate and translate to
+		 * string then back to uuid to verify they match.
+		 */
+		memset(uuid, 0, sizeof (uuid_t));
+		memset(uu, 0, POOL_HDR_UUID_STR_LEN);
+		memset(conv_uu, 0, POOL_HDR_UUID_STR_LEN);
+
+		ret = util_uuid_generate(uuid);
+		ASSERTeq(ret, 0);
+
+		ret = util_uuid_to_string(uuid, uu);
+		ASSERTeq(ret, 0);
+
+		ret  = util_uuid_from_string(uu, (struct uuid *)&uuid1);
+		ASSERTeq(ret, 0);
+		ASSERT(memcmp(&uuid, &uuid1, sizeof (uuid_t)) == 0);
+		CLOSE(fd);
+	} else {
+		/*
+		 * Caller passed in string.
+		 */
+		if (strcmp(argv[2], "valid") == 0) {
+			ret = util_uuid_from_string(argv[1],
+				(struct uuid *)&uuid);
+			ASSERTeq(ret, 0);
+
+			ret = util_uuid_to_string(uuid, conv_uu);
+			ASSERTeq(ret, 0);
+		} else {
+			ret = util_uuid_from_string(argv[1],
+				(struct uuid *)&uuid);
+			ASSERT(ret < 0);
+			OUT("util_uuid_generate: invalid uuid string");
+		}
+	}
+	DONE(NULL);
+}

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -82,7 +82,7 @@ endif
 PMEMOBJ_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemobj/libpmemobj_unscoped.o
 PMEMBLK_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemblk/libpmemblk_unscoped.o
 
-LIBS += -pthread -luuid
+LIBS += -pthread
 
 ifeq ($(LIBPMEMBLK), y)
 DYNAMIC_LIBS += -lpmemblk

--- a/src/tools/pmempool/check.c
+++ b/src/tools/pmempool/check.c
@@ -759,7 +759,12 @@ pmempool_check_uuids_single(struct pmempool_check *pcp, struct pool_hdr *hdrp)
 				return CHECK_RESULT_CANNOT_REPAIR;
 			}
 
-			uuid_generate(hdrp->uuid);
+			int ret = util_uuid_generate(hdrp->uuid);
+			if (ret < 0) {
+				outv(1, "uuid generation failed\n");
+				return CHECK_RESULT_CANNOT_REPAIR;
+			}
+
 			outv(1, "setting UUIDs to: %s\n",
 				out_get_uuid_str(hdrp->uuid));
 			pmempool_check_set_all_uuids(&hdrp->uuid, 5, 0);

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -337,8 +337,11 @@ out_get_uuid_str(uuid_t uuid)
 {
 	static char uuid_str[UUID_STR_MAX] = {0, };
 
-	uuid_unparse(uuid, uuid_str);
-
+	int ret = util_uuid_to_string(uuid, uuid_str);
+	if (ret != 0) {
+		outv(2, "failed to covert uuid to string");
+		return NULL;
+	}
 	return uuid_str;
 }
 

--- a/src/tools/pmempool/output.h
+++ b/src/tools/pmempool/output.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,7 +34,6 @@
  * output.h -- declarations of output printing related functions
  */
 
-#include <uuid/uuid.h>
 #include <time.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -111,7 +111,7 @@ Maintainer: $PACKAGE_MAINTAINER
 Section: misc
 Priority: optional
 Standards-version: 3.9.4
-Build-Depends: debhelper (>= 9), uuid-dev
+Build-Depends: debhelper (>= 9)
 
 Package: libpmem
 Architecture: any
@@ -122,7 +122,7 @@ Description: NVML libpmem library
 Package: libpmem-dev
 Section: libdevel
 Architecture: any
-Depends: libpmem (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmem (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmem
  Development files for libpmem library.
 
@@ -135,7 +135,7 @@ Description: NVML libpmemblk library
 Package: libpmemblk-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemblk (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemblk (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemblk
  Development files for libpmemblk library.
 
@@ -148,7 +148,7 @@ Description: NVML libpmemlog library
 Package: libpmemlog-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemlog (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemlog (=\${binary:Version}),  \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemlog
  Development files for libpmemlog library.
 
@@ -161,7 +161,7 @@ Description: NVML libpmemobj library
 Package: libpmemobj-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemobj (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemobj (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemobj
  Development files for libpmemobj-dev library.
 
@@ -174,7 +174,7 @@ Description: NVML libvmem library
 Package: libvmem-dev
 Section: libdevel
 Architecture: any
-Depends: libvmem (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libvmem (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libvmem
  Development files for libvmem library.
 
@@ -187,7 +187,7 @@ Description: NVML libvmmalloc library
 Package: libvmmalloc-dev
 Section: libdevel
 Architecture: any
-Depends: libvmmalloc (=\${binary:Version}), uuid-dev, \${shlibs:Depends}, \${misc:Depends}
+Depends: libvmmalloc (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libvmmalloc
  Development files for libvmmalloc library.
 
@@ -195,7 +195,7 @@ Package: $PACKAGE_NAME-dbg
 Section: debug
 Priority: extra
 Architecture: any
-Depends: libvmem (=\${binary:Version}), libvmmalloc (=\${binary:Version}), libpmem (=\${binary:Version}), libpmemblk (=\${binary:Version}), libpmemlog (=\${binary:Version}), libpmemobj (=\${binary:Version}), uuid-dev, \${misc:Depends}
+Depends: libvmem (=\${binary:Version}), libvmmalloc (=\${binary:Version}), libpmem (=\${binary:Version}), libpmemblk (=\${binary:Version}), libpmemlog (=\${binary:Version}), libpmemobj (=\${binary:Version}), \${misc:Depends}
 Description: Debug symbols for NVML libraries
  Debug symbols for all NVML libraries.
 

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -132,7 +132,6 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:	gcc glibc-devel
 BuildRequires:	autoconf, automake, make
-BuildRequires:	libuuid-devel
 BuildArch:	x86_64
 
 %description
@@ -304,7 +303,6 @@ Development files for NVML libvmmalloc library
 %package tools
 Group:		%{package_group}
 Summary:	Tools for %{name}
-Requires:	libuuid-devel
 
 %description tools
 Usefull applications for administration and diagnostic purposes.


### PR DESCRIPTION
The BSD libuuid library has one file that is licensed as LGPL. Some consumers
of NVML require that there be no dependency on LGPL license. As a result we
implemented our own functions that we require in NVML.

Ref: pmem/issues#122

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/597)
<!-- Reviewable:end -->
