### PR TITLE
obj: fix pfree operations on unitialized zones

### DIFF
--- a/src/libpmemobj/bucket.c
+++ b/src/libpmemobj/bucket.c
@@ -313,7 +313,7 @@ static uint32_t
 bucket_calc_units(struct bucket *b, size_t size)
 {
 	ASSERTne(size, 0);
-	return (uint32_t)(((size - 1) / b->unit_size) + 1);
+	return CALC_SIZE_IDX(b->unit_size, size);
 }
 
 /*

--- a/src/libpmemobj/bucket.h
+++ b/src/libpmemobj/bucket.h
@@ -37,6 +37,9 @@
 #define	RUN_NALLOCS(_bs)\
 ((RUNSIZE / ((_bs))))
 
+#define	CALC_SIZE_IDX(_unit_size, _size)\
+((uint32_t)(((_size - 1) / _unit_size) + 1))
+
 enum block_container_type {
 	CONTAINER_UNKNOWN,
 	CONTAINER_CTREE,

--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -98,6 +98,8 @@ void heap_degrade_run_if_empty(PMEMobjpool *pop, struct bucket *b,
 struct memory_block heap_free_block(PMEMobjpool *pop, struct bucket *b,
 	struct memory_block m, void *hdr, uint64_t *op_result);
 
+size_t heap_get_chunk_block_size(PMEMobjpool *pop, struct memory_block m);
+
 #ifdef DEBUG
 int heap_block_is_allocated(PMEMobjpool *pop, struct memory_block m);
 #endif /* DEBUG */

--- a/src/test/obj_out_of_memory/TEST2
+++ b/src/test/obj_out_of_memory/TEST2
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of Intel Corporation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_out_of_memory/TEST2
+export UNITTEST_NUM=2
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type long
+
+setup
+
+export PMEM_IS_PMEM_FORCE=1
+export PMEMOBJ_LOG_LEVEL=1
+
+create_poolset $DIR/testset1 20G:$DIR/testfile1
+
+# allocate 64 kilobyte blocks so that runs are used
+expect_normal_exit\
+	./obj_out_of_memory$EXESUFFIX 32768 $DIR/testset1
+
+pass

--- a/src/test/obj_out_of_memory/obj_out_of_memory.c
+++ b/src/test/obj_out_of_memory/obj_out_of_memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Intel Corporation
+ * Copyright (c) 2015-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,11 +101,21 @@ main(int argc, char *argv[])
 
 		ASSERTeq(pmemobj_check(path, LAYOUT_NAME), 1);
 
+		/*
+		 * To prevent subsequent opens from receiving exactly the same
+		 * volatile memory addresses a dummy malloc has to be made.
+		 * This can expose issues in which traces of previous volatile
+		 * state are leftover in the persistent pool.
+		 */
+		void *heap_touch = MALLOC(1);
+
 		ASSERTne(pop = pmemobj_open(path, LAYOUT_NAME), NULL);
 
 		test_free(pop);
 
 		pmemobj_close(pop);
+
+		FREE(heap_touch);
 	}
 
 	DONE(NULL);


### PR DESCRIPTION
When a program tried to free memory from a zone that wasn't previously
processed in current volatile state the library tried to dereference
potentially old and invalid bucket memory address.
This patch changes the logic to completely skip the volatile state
update in case of frees to unitialized zones.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/598)
<!-- Reviewable:end -->
