### PR TITLE
benchmark: check if linking librt is required

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -92,6 +92,9 @@ LDFLAGS = -L$(LIBS_PATH)
 LDFLAGS += -L../examples/libpmemobj/map
 LDFLAGS += $(EXTRA_LDFLAGS)
 LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm
+ifeq ($(call check_librt), n)
+LIBS += -lrt
+endif
 CFLAGS  = -std=gnu99
 CFLAGS += -Wall
 CFLAGS += -Werror

--- a/src/common.inc
+++ b/src/common.inc
@@ -49,6 +49,9 @@ check_cxx_flags = $(shell echo "int main(){return 0;}" |\
 check_Wconversion = $(shell echo "long int random(void); char test(void); char test(void){char a = 0; char b = 'a'; char ret = random() == 1 ? a : b; return ret;}" |\
 	$(CC) -c $(CFLAGS) -Wconversion -x c -o /dev/null - 2>/dev/null && echo y || echo n)
 
+check_librt = $(shell echo "int main() { struct timespec t; return clock_gettime(CLOCK_MONOTONIC, &t); }" |\
+	$(CC) $(CFLAGS) -x c -include time.h -o /dev/null - 2>/dev/null && echo y || echo n)
+
 define create-deps
 	@cp $(objdir)/$*.d $(objdir)/.deps/$*.P; \
 	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \


### PR DESCRIPTION
According to clock_gettime(3) man page, linking with librt explicitly
is required for glibc versions before 2.17.
Add a simple check if explicit linking is required.

Ref: pmem/issues#140

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/599)
<!-- Reviewable:end -->
