### PR TITLE
pmem: add missing "const" qualifier

### DIFF
--- a/doc/libpmem.3
+++ b/doc/libpmem.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2014-2015, Intel Corporation
+.\" Copyright (c) 2014-2016, Intel Corporation
 .\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmem.3
 .\"
-.TH libpmem 3 "pmem API version 0.8.5" "NVM Library"
+.TH libpmem 3 "pmem API version 0.8.6" "NVM Library"
 .SH NAME
 libpmem \- persistent memory support library
 .SH SYNOPSIS
@@ -48,15 +48,15 @@ libpmem \- persistent memory support library
 .sp
 .B Most commonly used functions:
 .sp
-.BI "int pmem_is_pmem(void *" addr ", size_t " len );
-.BI "void pmem_persist(void *" addr ", size_t " len );
-.BI "int pmem_msync(void *" addr ", size_t " len );
+.BI "int pmem_is_pmem(const void *" addr ", size_t " len );
+.BI "void pmem_persist(const void *" addr ", size_t " len );
+.BI "int pmem_msync(const void *" addr ", size_t " len );
 .BI "void *pmem_map(int " fd );
 .BI "int pmem_unmap(void *" addr ", size_t " len );
 .sp
 .B Partial flushing operations:
 .sp
-.BI "void pmem_flush(void *" addr ", size_t " len );
+.BI "void pmem_flush(const void *" addr ", size_t " len );
 .BI "void pmem_drain(void);"
 .BI "int pmem_has_hw_drain(void);"
 .sp
@@ -139,7 +139,7 @@ and that wish to take on the responsibility for flushing stores to
 persistence will find the functions described in this section
 to be the most commonly used.
 .PP
-.BI "int pmem_is_pmem(void *" addr ", size_t " len );
+.BI "int pmem_is_pmem(const void *" addr ", size_t " len );
 .IP
 The
 .BR pmem_is_pmem ()
@@ -174,7 +174,7 @@ returns false may not do anything useful -- use
 .BR msync (2)
 instead.
 .PP
-.BI "void pmem_persist(void *" addr ", size_t " len );
+.BI "void pmem_persist(const void *" addr ", size_t " len );
 .IP
 Force any changes in the range
 .IR "" [ addr ", " addr + len )
@@ -209,7 +209,7 @@ before
 .BR pmem_persist ()
 is called.
 .PP
-.BI "int pmem_msync(void *" addr ", size_t " len );
+.BI "int pmem_msync(const void *" addr ", size_t " len );
 .IP
 The function
 .BR pmem_msync ()
@@ -309,7 +309,7 @@ than the
 .BR pmem_persist ()
 function described above.
 .PP
-.BI "void pmem_flush(void *" addr ", size_t " len );
+.BI "void pmem_flush(const void *" addr ", size_t " len );
 .br
 .BI "void pmem_drain(void);"
 .IP
@@ -321,7 +321,7 @@ can be thought of as this:
 .IP
 .nf
 void
-pmem_persist(void *addr, size_t len)
+pmem_persist(const void *addr, size_t len)
 {
     /* flush the processor caches */
     pmem_flush(addr, len);

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemobj.3
 .\"
-.TH libpmemobj 3 "pmemobj API version 0.4.21" "NVM Library"
+.TH libpmemobj 3 "pmemobj API version 0.4.22" "NVM Library"
 .SH NAME
 libpmemobj \- persistent memory transactional object store
 .SH SYNOPSIS
@@ -59,8 +59,8 @@ libpmemobj \- persistent memory transactional object store
 .BI "     const void *" src ", size_t " len );
 .BI "void *pmemobj_memset_persist(PMEMobjpool *" pop ", void *" dest ,
 .BI "     int " c ", size_t " len );
-.BI "void pmemobj_persist(PMEMobjpool *" pop ", void *" addr ", size_t " len );
-.BI "void pmemobj_flush(PMEMobjpool *" pop ", void *" addr ", size_t " len );
+.BI "void pmemobj_persist(PMEMobjpool *" pop ", const void *" addr ", size_t " len );
+.BI "void pmemobj_flush(PMEMobjpool *" pop ", const void *" addr ", size_t " len );
 .BI "void pmemobj_drain(PMEMobjpool *" pop );
 .sp
 .B Locking:
@@ -500,7 +500,7 @@ to use these functions in conjunction with
 objects, instead of using low-level memory manipulations functions from
 .BR libpmem .
 .PP
-.BI "void pmemobj_persist(PMEMobjpool *" pop ", void *" addr ", size_t " len );
+.BI "void pmemobj_persist(PMEMobjpool *" pop ", const void *" addr ", size_t " len );
 .IP
 Forces any changes in the range
 .IR "" [ addr ", " addr + len )
@@ -535,7 +535,7 @@ before
 .BR pmemobj_persist ()
 is called.
 .PP
-.BI "void pmemobj_flush(PMEMobjpool *" pop ", void *" addr ", size_t " len );
+.BI "void pmemobj_flush(PMEMobjpool *" pop ", const void *" addr ", size_t " len );
 .br
 .BI "void pmemobj_drain(PMEMobjpool *" pop );
 .IP
@@ -547,7 +547,7 @@ can be thought of as this:
 .IP
 .nf
 void
-pmemobj_persist(PMEMobjpool *" pop ", void *addr, size_t len)
+pmemobj_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
     /* flush the processor caches */
     pmemobj_flush(pop, addr, len);

--- a/src/include/libpmem.h
+++ b/src/include/libpmem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,10 +51,10 @@ extern "C" {
 
 void *pmem_map(int fd);
 int pmem_unmap(void *addr, size_t len);
-int pmem_is_pmem(void *addr, size_t len);
-void pmem_persist(void *addr, size_t len);
-int pmem_msync(void *addr, size_t len);
-void pmem_flush(void *addr, size_t len);
+int pmem_is_pmem(const void *addr, size_t len);
+void pmem_persist(const void *addr, size_t len);
+int pmem_msync(const void *addr, size_t len);
+void pmem_flush(const void *addr, size_t len);
 void pmem_drain(void);
 int pmem_has_hw_drain(void);
 void *pmem_memmove_persist(void *pmemdest, const void *src, size_t len);

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -456,12 +456,12 @@ void *pmemobj_memset_persist(PMEMobjpool *pop, void *dest, int c, size_t len);
 /*
  * Pmemobj version of pmem_persist.
  */
-void pmemobj_persist(PMEMobjpool *pop, void *addr, size_t len);
+void pmemobj_persist(PMEMobjpool *pop, const void *addr, size_t len);
 
 /*
  * Pmemobj version of pmem_flush.
  */
-void pmemobj_flush(PMEMobjpool *pop, void *addr, size_t len);
+void pmemobj_flush(PMEMobjpool *pop, const void *addr, size_t len);
 
 /*
  * Pmemobj version of pmem_drain.

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -340,7 +340,7 @@ pmem_drain(void)
  * flush_clflush -- (internal) flush the CPU cache, using clflush
  */
 static void
-flush_clflush(void *addr, size_t len)
+flush_clflush(const void *addr, size_t len)
 {
 	LOG(15, "addr %p len %zu", addr, len);
 
@@ -359,7 +359,7 @@ flush_clflush(void *addr, size_t len)
  * flush_clwb -- (internal) flush the CPU cache, using clwb
  */
 static void
-flush_clwb(void *addr, size_t len)
+flush_clwb(const void *addr, size_t len)
 {
 	LOG(15, "addr %p len %zu", addr, len);
 
@@ -379,7 +379,7 @@ flush_clwb(void *addr, size_t len)
  * flush_clflushopt -- (internal) flush the CPU cache, using clflushopt
  */
 static void
-flush_clflushopt(void *addr, size_t len)
+flush_clflushopt(const void *addr, size_t len)
 {
 	LOG(15, "addr %p len %zu", addr, len);
 
@@ -402,13 +402,13 @@ flush_clflushopt(void *addr, size_t len)
  * Func_flush is set to flush_clflushopt().  That's the most common case
  * on modern hardware that supports persistent memory.
  */
-static void (*Func_flush)(void *, size_t) = flush_clflush;
+static void (*Func_flush)(const void *, size_t) = flush_clflush;
 
 /*
  * pmem_flush -- flush processor cache for the given range
  */
 void
-pmem_flush(void *addr, size_t len)
+pmem_flush(const void *addr, size_t len)
 {
 	LOG(10, "addr %p len %zu", addr, len);
 
@@ -421,7 +421,7 @@ pmem_flush(void *addr, size_t len)
  * pmem_persist -- make any cached changes to a range of pmem persistent
  */
 void
-pmem_persist(void *addr, size_t len)
+pmem_persist(const void *addr, size_t len)
 {
 	LOG(15, "addr %p len %zu", addr, len);
 
@@ -437,7 +437,7 @@ pmem_persist(void *addr, size_t len)
  * pmem_persist() which is only safe where pmem_is_pmem() returns true.
  */
 int
-pmem_msync(void *addr, size_t len)
+pmem_msync(const void *addr, size_t len)
 {
 	LOG(15, "addr %p len %zu", addr, len);
 
@@ -479,7 +479,7 @@ pmem_msync(void *addr, size_t len)
  * is_pmem_always -- (internal) always true version of pmem_is_pmem()
  */
 static int
-is_pmem_always(void *addr, size_t len)
+is_pmem_always(const void *addr, size_t len)
 {
 	LOG(3, NULL);
 
@@ -490,7 +490,7 @@ is_pmem_always(void *addr, size_t len)
  * is_pmem_never -- (internal) never true version of pmem_is_pmem()
  */
 static int
-is_pmem_never(void *addr, size_t len)
+is_pmem_never(const void *addr, size_t len)
 {
 	LOG(3, NULL);
 
@@ -518,9 +518,9 @@ is_pmem_never(void *addr, size_t len)
  * in which case it stops the loop and returns immediately.
  */
 static int
-is_pmem_proc(void *addr, size_t len)
+is_pmem_proc(const void *addr, size_t len)
 {
-	char *caddr = addr;
+	const char *caddr = addr;
 
 	FILE *fp;
 	if ((fp = fopen("/proc/self/smaps", "r")) == NULL) {
@@ -598,13 +598,13 @@ is_pmem_proc(void *addr, size_t len)
  * Func_is_pmem is set to is_pmem_proc().  That's the most common case
  * on modern hardware.
  */
-static int (*Func_is_pmem)(void *addr, size_t len) = is_pmem_never;
+static int (*Func_is_pmem)(const void *addr, size_t len) = is_pmem_never;
 
 /*
  * pmem_is_pmem -- return true if entire range is persistent Memory
  */
 int
-pmem_is_pmem(void *addr, size_t len)
+pmem_is_pmem(const void *addr, size_t len)
 {
 	LOG(10, "addr %p len %zu", addr, len);
 

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -174,7 +174,7 @@ obj_norep_memset_persist(PMEMobjpool *pop, void *dest, int c, size_t len)
  * obj_norep_persist -- (internal) persist w/o replication
  */
 static void
-obj_norep_persist(PMEMobjpool *pop, void *addr, size_t len)
+obj_norep_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 
@@ -185,7 +185,7 @@ obj_norep_persist(PMEMobjpool *pop, void *addr, size_t len)
  * obj_norep_flush -- (internal) flush w/o replication
  */
 static void
-obj_norep_flush(PMEMobjpool *pop, void *addr, size_t len)
+obj_norep_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 
@@ -242,7 +242,7 @@ obj_rep_memset_persist(PMEMobjpool *pop, void *dest, int c, size_t len)
  * obj_rep_persist -- (internal) persist with replication
  */
 static void
-obj_rep_persist(PMEMobjpool *pop, void *addr, size_t len)
+obj_rep_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 
@@ -259,7 +259,7 @@ obj_rep_persist(PMEMobjpool *pop, void *addr, size_t len)
  * obj_rep_flush -- (internal) flush with replication
  */
 static void
-obj_rep_flush(PMEMobjpool *pop, void *addr, size_t len)
+obj_rep_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 
@@ -1577,7 +1577,7 @@ pmemobj_memset_persist(PMEMobjpool *pop, void *dest, int c, size_t len)
  * pmemobj_persist -- pmemobj version of pmem_persist
  */
 void
-pmemobj_persist(PMEMobjpool *pop, void *addr, size_t len)
+pmemobj_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 
@@ -1588,7 +1588,7 @@ pmemobj_persist(PMEMobjpool *pop, void *addr, size_t len)
  * pmemobj_flush -- pmemobj version of pmem_flush
  */
 void
-pmemobj_flush(PMEMobjpool *pop, void *addr, size_t len)
+pmemobj_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	LOG(15, "pop %p addr %p len %zu", pop, addr, len);
 

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,14 +102,14 @@
 #define	OBJ_STORE_ITEM_PADDING\
 	(_POBJ_CL_ALIGNMENT - (sizeof (struct list_head) % _POBJ_CL_ALIGNMENT))
 
-typedef void (*persist_local_fn)(void *, size_t);
-typedef void (*flush_local_fn)(void *, size_t);
+typedef void (*persist_local_fn)(const void *, size_t);
+typedef void (*flush_local_fn)(const void *, size_t);
 typedef void (*drain_local_fn)(void);
 typedef void *(*memcpy_local_fn)(void *dest, const void *src, size_t len);
 typedef void *(*memset_local_fn)(void *dest, int c, size_t len);
 
-typedef void (*persist_fn)(PMEMobjpool *pop, void *, size_t);
-typedef void (*flush_fn)(PMEMobjpool *pop, void *, size_t);
+typedef void (*persist_fn)(PMEMobjpool *pop, const void *, size_t);
+typedef void (*flush_fn)(PMEMobjpool *pop, const void *, size_t);
 typedef void (*drain_fn)(PMEMobjpool *pop);
 typedef void *(*memcpy_fn)(PMEMobjpool *pop, void *dest, const void *src,
 					size_t len);

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -56,7 +56,7 @@ struct mock_pop {
 };
 
 static void
-obj_heap_persist(PMEMobjpool *pop, void *ptr, size_t sz)
+obj_heap_persist(PMEMobjpool *pop, const void *ptr, size_t sz)
 {
 	pmem_msync(ptr, sz);
 }

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -146,7 +146,7 @@ pmem_drain_nop(void)
  * obj_persist -- pmemobj version of pmem_persist w/o replication
  */
 static void
-obj_persist(PMEMobjpool *pop, void *addr, size_t len)
+obj_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->persist_local(addr, len);
 }
@@ -155,7 +155,7 @@ obj_persist(PMEMobjpool *pop, void *addr, size_t len)
  * obj_flush -- pmemobj version of pmem_flush w/o replication
  */
 static void
-obj_flush(PMEMobjpool *pop, void *addr, size_t len)
+obj_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->flush_local(addr, len);
 }

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -79,7 +79,7 @@ drain_empty(void)
  * obj_persist -- pmemobj version of pmem_persist w/o replication
  */
 static void
-obj_persist(PMEMobjpool *pop, void *addr, size_t len)
+obj_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->persist_local(addr, len);
 }
@@ -88,7 +88,7 @@ obj_persist(PMEMobjpool *pop, void *addr, size_t len)
  * obj_flush -- pmemobj version of pmem_flush w/o replication
  */
 static void
-obj_flush(PMEMobjpool *pop, void *addr, size_t len)
+obj_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->flush_local(addr, len);
 }

--- a/src/test/obj_redo_log/obj_redo_log.c
+++ b/src/test/obj_redo_log/obj_redo_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Intel Corporation
+ * Copyright (c) 2015-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,7 +79,7 @@ pmem_drain_nop(void)
  * obj_persist -- pmemobj version of pmem_persist w/o replication
  */
 static void
-obj_persist(PMEMobjpool *pop, void *addr, size_t len)
+obj_persist(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->persist_local(addr, len);
 }
@@ -88,7 +88,7 @@ obj_persist(PMEMobjpool *pop, void *addr, size_t len)
  * obj_flush -- pmemobj version of pmem_flush w/o replication
  */
 static void
-obj_flush(PMEMobjpool *pop, void *addr, size_t len)
+obj_flush(PMEMobjpool *pop, const void *addr, size_t len)
 {
 	pop->flush_local(addr, len);
 }

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Intel Corporation
+ * Copyright (c) 2015-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -233,7 +233,7 @@ cleanup(char test_type)
 }
 
 static void
-obj_sync_persist(PMEMobjpool *pop, void *ptr, size_t sz)
+obj_sync_persist(PMEMobjpool *pop, const void *ptr, size_t sz)
 {
 	pmem_msync(ptr, sz);
 }


### PR DESCRIPTION
Add missing "const" qualifier to the "addr" argument of selected libpmem
and libpmemobj interfaces, like pmem_is_pmem(), pmem_flush(),
pmem_msync(), ...).

Ref: pmem/issues#139

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/600)
<!-- Reviewable:end -->
