### PR TITLE
cpp: fix constructor and assignment operator

### DIFF
--- a/src/include/libpmemobj/persistent_ptr.hpp
+++ b/src/include/libpmemobj/persistent_ptr.hpp
@@ -86,12 +86,11 @@ namespace obj
 			verify_type();
 		}
 
-		template<typename Y>
+		template<typename Y, typename = typename
+		std::enable_if<std::is_convertible<Y*, T*>::value>::type>
 		persistent_ptr(const persistent_ptr<Y> &r) noexcept : oid(r.oid)
 		{
 			verify_type();
-			static_assert(std::is_convertible<Y, T>::value,
-				"constructor from inconvertible type");
 		}
 
 		persistent_ptr(const persistent_ptr &r) noexcept : oid(r.oid)
@@ -117,13 +116,11 @@ namespace obj
 			return *this;
 		}
 
-		template<typename Y>
+		template<typename Y, typename = typename
+		std::enable_if<std::is_convertible<Y*, T*>::value>::type>
 		persistent_ptr &
 		operator=(const persistent_ptr<Y> &r) noexcept
 		{
-			static_assert(std::is_convertible<Y, T>::value,
-				"assignment of inconvertible types");
-
 			if (pmemobj_tx_stage() == TX_STAGE_WORK) {
 				pmemobj_tx_add_range_direct(this,
 					sizeof (*this));

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -82,11 +82,6 @@ test_ptr_operators_null()
 	persistent_ptr<int> int_explicit_oid_null = OID_NULL;
 	test_null_ptr(int_explicit_oid_null);
 
-	persistent_ptr<float> float_base = nullptr;
-	persistent_ptr<int> int_converted = float_base;
-	int_converted = float_base;
-	test_null_ptr(int_converted);
-
 	persistent_ptr<int> int_base = nullptr;
 	persistent_ptr<int> int_same = int_base;
 	int_same = int_base;


### PR DESCRIPTION
Two small fixes to the copy constructor and assignment operator.
This is to properly disable conversion between incompatibile types.

closes pmem/issues#143

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/605)
<!-- Reviewable:end -->
