### PR TITLE
tests: fix timeouting obj_realloc test

### DIFF
--- a/src/test/obj_realloc/TEST0
+++ b/src/test/obj_realloc/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,12 +41,15 @@ export UNITTEST_NUM=0
 # standard unit test setup
 . ../unittest/unittest.sh
 
+require_fs_type any
+
 setup
 
 rm -f $DIR/testfile1
 expect_normal_exit $PMEMPOOL$EXESUFFIX\
 	create obj --layout realloc --size=64M $DIR/testfile1
 
+export PMEM_IS_PMEM_FORCE=1
 expect_normal_exit ./obj_realloc$EXESUFFIX $DIR/testfile1
 
 check


### PR DESCRIPTION
The obj_realloc test timeouts very often on non-pmem filesystem. Use
PMEM_IS_PMEM_FORCE to speed up the test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/613)
<!-- Reviewable:end -->
