### PR TITLE
test: add EXTRA_CFLAGS after our CFLAGS

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -117,13 +117,13 @@ COMMON_FLAGS += -fno-common
 
 CXXFLAGS  = -std=c++11
 CXXFLAGS += -ggdb
-CXXFLAGS += $(EXTRA_CXXFLAGS)
 CXXFLAGS += $(COMMON_FLAGS)
+CXXFLAGS += $(EXTRA_CXXFLAGS)
 
 CFLAGS  = -std=gnu99
 CFLAGS += -Wmissing-prototypes
-CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += $(COMMON_FLAGS)
+CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS = -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)
 


### PR DESCRIPTION
Eg it's not possible to disable -Werror in tests.

Fixes regression from 7cd94abad4177d7766755092be21df8ccdb9f684.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/616)
<!-- Reviewable:end -->
