### PR TITLE
test: prevent executing selected test as superuser

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -190,6 +190,7 @@ VMMALLOC_TESTS = \
        vmmalloc_out_of_memory\
        vmmalloc_realloc\
        vmmalloc_valgrind\
+       vmmalloc_valloc
 
 EXAMPLES_TESTS = \
        ex_libpmem\

--- a/src/test/blk_pool/TEST25
+++ b/src/test/blk_pool/TEST25
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=25
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/blk_pool/TEST26
+++ b/src/test/blk_pool/TEST26
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=26
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/log_pool/TEST24
+++ b/src/test/log_pool/TEST24
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=24
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/log_pool/TEST25
+++ b/src/test/log_pool/TEST25
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=25
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/obj_pool/TEST25
+++ b/src/test/obj_pool/TEST25
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=25
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/obj_pool/TEST26
+++ b/src/test/obj_pool/TEST26
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2015, Intel Corporation
+# Copyright (c) 2015-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,6 +39,8 @@ export UNITTEST_NUM=26
 
 # standard unit test setup
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 umask 0

--- a/src/test/pmempool_rm/TEST1
+++ b/src/test/pmempool_rm/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2014-2015, Intel Corporation
+# Copyright (c) 2014-2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,6 +37,8 @@ export UNITTEST_NAME=pmempool_rm/TEST1
 export UNITTEST_NUM=1
 
 . ../unittest/unittest.sh
+
+require_no_superuser
 
 setup
 


### PR DESCRIPTION
Add missing "require_no_superuser" macro to selected unit tests.
Add missing "vmmalloc_valloc" test to the main UT makefile.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/619)
<!-- Reviewable:end -->
