### PR TITLE
common: remove directories from printed file names

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, Intel Corporation
+ * Copyright (c) 2014-2016, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -336,6 +336,9 @@ out_common(const char *file, int line, const char *func, int level,
 	const char *errstr = "";
 
 	if (file) {
+		char *f = rindex(file, '/');
+		if (f)
+			file = f + 1;
 		ret = out_snprintf(&buf[cc], MAXPRINT - cc,
 				"<%s>: <%d> [%s:%d %s] ",
 				Log_prefix, level, file, line, func);
@@ -405,6 +408,9 @@ out_error(const char *file, int line, const char *func,
 		cc = 0;
 
 		if (file) {
+			char *f = rindex(file, '/');
+			if (f)
+				file = f + 1;
 			ret = out_snprintf(&buf[cc], MAXPRINT,
 					"<%s>: <1> [%s:%d %s] ",
 					Log_prefix, file, line, func);

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -1,9 +1,9 @@
-<trace>: <1> [../../common/out.c:$(N) out_init] pid $(N): program: $(nW)
-<trace>: <1> [../../common/out.c:$(N) out_init] trace version 1.0
-<trace>: <1> [../../common/out.c:$(N) out_init] src version SRCVERSION:utversion
-$(OPT)<trace>: <1> [../../common/out.c:$(N) out_init] compiled with support for Valgrind pmemcheck
-$(OPT)<trace>: <1> [../../common/out.c:$(N) out_init] compiled with support for Valgrind helgrind
-$(OPT)<trace>: <1> [../../common/out.c:$(N) out_init] compiled with support for Valgrind memcheck
+<trace>: <1> [out.c:$(N) out_init] pid $(N): program: $(nW)
+<trace>: <1> [out.c:$(N) out_init] trace version 1.0
+<trace>: <1> [out.c:$(N) out_init] src version SRCVERSION:utversion
+$(OPT)<trace>: <1> [out.c:$(N) out_init] compiled with support for Valgrind pmemcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init] compiled with support for Valgrind helgrind
+$(OPT)<trace>: <1> [out.c:$(N) out_init] compiled with support for Valgrind memcheck
 <trace>: <1> [out_err.c:$(N) main] ERR #1
 <trace>: <1> [out_err.c:$(N) main] ERR #2: Success
 <trace>: <1> [out_err.c:$(N) main] ERR #3: Invalid argument


### PR DESCRIPTION
`<libpmem>: <1> [out.c:225 out_init] libpmem version 1.0`
instead of:
`<libpmem>: <1> [../../src/../src/common/out.c:225 out_init] libpmem version 1.0`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/621)
<!-- Reviewable:end -->
