### PR TITLE
test: redirect pminvaders stderr to /dev/null

### DIFF
--- a/src/test/ex_libpmemobj/TEST15
+++ b/src/test/ex_libpmemobj/TEST15
@@ -67,7 +67,7 @@ if [ -t 1 -a -z "$NOTTY" ]
 then
 	expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 < $INPUT
 else
-	expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 >/dev/null < $INPUT
+	expect_normal_exit $EX_PATH/pminvaders $DIR/testfile1 >/dev/null 2>/dev/null < $INPUT
 fi
 
 pass

--- a/src/test/ex_libpmemobj/TEST16
+++ b/src/test/ex_libpmemobj/TEST16
@@ -67,7 +67,7 @@ if [ -t 1 -a -z "$NOTTY" ]
 then
 	expect_normal_exit $EX_PATH/pminvaders2 $DIR/testfile1 < $INPUT
 else
-	expect_normal_exit $EX_PATH/pminvaders2 $DIR/testfile1 >/dev/null < $INPUT
+	expect_normal_exit $EX_PATH/pminvaders2 $DIR/testfile1 >/dev/null 2>/dev/null < $INPUT
 fi
 
 pass


### PR DESCRIPTION
Without it ncurses initialization messes up stderr when pcheck is used
and one of the tests fails.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/627)
<!-- Reviewable:end -->
