### PR TITLE
obj: add persistent_ptr<> comparison and arith operators

### DIFF
--- a/src/include/libpmemobj/detail/specialization.hpp
+++ b/src/include/libpmemobj/detail/specialization.hpp
@@ -115,7 +115,7 @@ namespace detail
 	template<typename T>
 	struct sp_member_access
 	{
-		typedef T* type;
+		typedef T *type;
 	};
 
 	template<typename T>
@@ -135,7 +135,7 @@ namespace detail
 	template<typename T>
 	struct sp_array_access
 	{
-		typedef void type;
+		typedef T &type;
 	};
 
 	template<typename T>

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -115,7 +115,8 @@ OBJ_TESTS = \
 OBJ_CPP_TESTS = \
 	obj_cpp_ptr\
 	obj_cpp_p_ext\
-	obj_cpp_pool
+	obj_cpp_pool\
+	obj_cpp_ptr_arith
 
 OTHER_TESTS = \
        arch_flags\

--- a/src/test/match
+++ b/src/test/match
@@ -49,6 +49,7 @@
 #	$(FP)	a floating point number
 #	$(S)	ascii string
 #	$(X)	hex number
+#	$(XX)	hex number prefixed with 0x
 #	$(W)	whitespace
 #	$(nW)	non-whitespace
 #	$(*)	any string
@@ -163,6 +164,7 @@ sub match {
 		s/\\\$\\\(\\\*\\\)/.*/g;
 		s/\\\$\\\(S\\\)/\\P{IsC}+/g;
 		s/\\\$\\\(X\\\)/\\p{IsXDigit}+/g;
+		s/\\\$\\\(XX\\\)/0x\\p{IsXDigit}+/g;
 		s/\\\$\\\(W\\\)/\\s*[^\n]/g;
 		s/\\\$\\\(nW\\\)/\\S*/g;
 		s/\\\$\\\(DD\\\)/\\d+\\+\\d+ records in\n\\d+\\+\\d+ records out\n\\d+ bytes \\\(\\d+ .B\\\) copied, [.0-9e-]+[^,]*, [.0-9]+ .B.s/g;

--- a/src/test/obj_cpp_ptr_arith/.gitignore
+++ b/src/test/obj_cpp_ptr_arith/.gitignore
@@ -1,0 +1,1 @@
+obj_cpp_ptr_arith

--- a/src/test/obj_cpp_ptr_arith/Makefile
+++ b/src/test/obj_cpp_ptr_arith/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_cpp_ptr_arith/Makefile -- build obj_cpp_ptr_arith test
+#
+TARGET = obj_cpp_ptr_arith
+OBJS = obj_cpp_ptr_arith.o
+COMPILE_LANG = cpp
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_cpp_ptr_arith/TEST0
+++ b/src/test/obj_cpp_ptr_arith/TEST0
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_ptr_arith/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+
+setup
+
+expect_normal_exit\
+    ./obj_cpp_ptr_arith$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_cpp_ptr_arith/TEST1
+++ b/src/test/obj_cpp_ptr_arith/TEST1
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_ptr_arith/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+require_valgrind_pmemcheck
+
+setup
+
+expect_normal_exit\
+    valgrind --tool=pmemcheck --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_cpp_ptr_arith$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_cpp_ptr_arith/TEST2
+++ b/src/test/obj_cpp_ptr_arith/TEST2
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_ptr_arith/TEST2
+export UNITTEST_NUM=2
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+require_valgrind
+
+setup
+
+expect_normal_exit\
+    valgrind --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_cpp_ptr_arith$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_cpp_ptr_arith.cpp -- cpp bindings test
+ *
+ */
+
+#include "unittest.h"
+
+#include <libpmemobj/persistent_ptr.hpp>
+#include <libpmemobj/p.hpp>
+
+#include <sstream>
+
+#define LAYOUT "cpp"
+
+using namespace nvml::obj;
+
+namespace {
+
+const int TEST_ARR_SIZE = 10;
+
+/*
+ * prepare_array -- preallocate and fill a persistent array
+ */
+template<typename T>
+persistent_ptr<T>
+prepare_array(PMEMobjpool *pop)
+{
+	int ret;
+
+	persistent_ptr<T> parr_vsize;
+	ret = pmemobj_alloc(pop, parr_vsize.raw_ptr(),
+		sizeof (T) * TEST_ARR_SIZE,
+		0, NULL, NULL);
+	ASSERTeq(ret, 0);
+
+	T *parray = parr_vsize.get();
+
+	TX_BEGIN(pop) {
+		for (int i = 0; i < TEST_ARR_SIZE; ++i) {
+			parray[i] = i;
+		}
+	} TX_ONABORT {
+		FATAL("Transactional prepare_array aborted");
+	} TX_END;
+
+	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
+		ASSERTeq(parray[i], i);
+	}
+
+	return parr_vsize;
+}
+
+/*
+ * test_arith -- test arithmetic operations on persistent pointers
+ */
+void
+test_arith(PMEMobjpool *pop)
+{
+	persistent_ptr<p<int>> parr_vsize = prepare_array<p<int>>(pop);
+
+	/* test prefix postfix operators */
+	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
+		ASSERTeq(*parr_vsize, i);
+		parr_vsize++;
+	}
+
+	for (int i = TEST_ARR_SIZE; i > 0; --i) {
+		parr_vsize--;
+		ASSERTeq(*parr_vsize, i - 1);
+	}
+
+	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
+		ASSERTeq(*parr_vsize, i);
+		++parr_vsize;
+	}
+
+	for (int i = TEST_ARR_SIZE; i > 0; --i) {
+		--parr_vsize;
+		ASSERTeq(*parr_vsize, i - 1);
+	}
+
+	/* test addition assignment and subtraction */
+	parr_vsize += 2;
+	ASSERTeq(*parr_vsize, 2);
+
+	parr_vsize -= 2;
+	ASSERTeq(*parr_vsize, 0);
+
+	/* test strange invocations, parameter ignored */
+	parr_vsize.operator++(5);
+	ASSERTeq(*parr_vsize, 1);
+
+	parr_vsize.operator--(2);
+	ASSERTeq(*parr_vsize, 0);
+
+	/* test subtraction and addition */
+	for (int i = 0; i < TEST_ARR_SIZE; ++i)
+		ASSERTeq(*(parr_vsize + i), i);
+
+	/* using STL one-pas-end style */
+	persistent_ptr<p<int>> parr_end = parr_vsize + TEST_ARR_SIZE;
+
+	for (int i = TEST_ARR_SIZE; i > 0; --i)
+		ASSERTeq(*(parr_end - i), TEST_ARR_SIZE - i);
+
+	ASSERTeq(parr_end - parr_vsize, TEST_ARR_SIZE);
+
+	/* check ostream operator */
+	std::stringstream stream;
+	stream << parr_vsize;
+	OUT("%s", stream.str().c_str());
+}
+
+/*
+ * test_relational -- test relational operators on persistent pointers
+ */
+void
+test_relational(PMEMobjpool *pop)
+{
+
+	persistent_ptr<p<int>> first_elem = prepare_array<p<int>>(pop);
+	persistent_ptr<p<int>> last_elem = first_elem + TEST_ARR_SIZE - 1;
+
+	ASSERT(first_elem != last_elem);
+	ASSERT(first_elem <= last_elem);
+	ASSERT(first_elem < last_elem);
+	ASSERT(last_elem > first_elem );
+	ASSERT(last_elem >= first_elem );
+	ASSERT(first_elem == first_elem);
+	ASSERT(first_elem >= first_elem);
+	ASSERT(first_elem <= first_elem);
+
+	/* nullptr comparisons */
+	ASSERT(first_elem != nullptr);
+	ASSERT(nullptr != first_elem);
+	ASSERT(!(first_elem == nullptr));
+	ASSERT(!(nullptr == first_elem));
+
+	ASSERT(nullptr < first_elem);
+	ASSERT(!(first_elem < nullptr));
+	ASSERT(nullptr <= first_elem);
+	ASSERT(!(first_elem <= nullptr));
+
+	ASSERT(first_elem > nullptr);
+	ASSERT(!(nullptr > first_elem));
+	ASSERT(first_elem >= nullptr);
+	ASSERT(!(nullptr >= first_elem));
+
+	persistent_ptr<p<double>> different_array =
+			prepare_array<p<double>>(pop);
+
+	/* only verify if this compiles */
+	ASSERT((first_elem < different_array) || true);
+}
+
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_cpp_ptr_arith");
+
+	if (argc != 2)
+		FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+
+	PMEMobjpool *pop = NULL;
+
+	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
+			S_IWUSR | S_IRUSR)) == NULL)
+		FATAL("!pmemobj_create: %s", path);
+
+	test_arith(pop);
+	test_relational(pop);
+
+	pmemobj_close(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_cpp_ptr_arith/out0.log.match
+++ b/src/test/obj_cpp_ptr_arith/out0.log.match
@@ -1,0 +1,4 @@
+obj_cpp_ptr_arith/TEST0: START: obj_cpp_ptr_arith
+ ./obj_cpp_ptr_arith$(nW) $(nW)/testfile1
+$(XX), $(XX)
+obj_cpp_ptr_arith/TEST0: Done

--- a/src/test/obj_cpp_ptr_arith/valgrind1.log.match
+++ b/src/test/obj_cpp_ptr_arith/valgrind1.log.match
@@ -1,0 +1,8 @@
+==$(N)== pmemcheck-$(nW), a simple persistent store checker
+==$(N)== Copyright (c) $(nW), Intel Corporation
+==$(N)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(N)== Command: ./obj_cpp_ptr_arith$(nW) $(nW)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== Number of stores not made persistent: 0

--- a/src/test/obj_cpp_ptr_arith/valgrind2.log.match
+++ b/src/test/obj_cpp_ptr_arith/valgrind2.log.match
@@ -1,0 +1,15 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright (C) $(nW), and GNU GPL'd, by Julian Seward et al.
+==$(N)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(N)== Command: ./obj_cpp_ptr_arith$(nW) $(nW)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 0 bytes in 0 blocks
+==$(N)==   total heap usage: $(nW) allocs, $(nW) frees, $(nW) bytes allocated
+==$(N)== 
+==$(N)== All heap blocks were freed -- no leaks are possible
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: $(N) from $(N))


### PR DESCRIPTION
Add all essential arithmetic and pointer operators to the
persistent_ptr<>.

Initial implementation by @pbalcer

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/632)
<!-- Reviewable:end -->
