### PR TITLE
benchmarks: fix determining the pool size

### DIFF
--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -46,7 +46,8 @@
 #include "benchmark.h"
 
 #define	LAYOUT_NAME "benchmark"
-#define	FACTOR 16
+#define	FACTOR ((float)(1.2))
+#define	ALLOC_OVERHEAD 64
 /*
  * operations number is limited to prevent stack overflow during
  * performing recursive functions.
@@ -1049,7 +1050,9 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 	 */
 	size_t dsize = obj_bench.obj_args->rsize > args->dsize ?
 					obj_bench.obj_args->rsize : args->dsize;
-	size_t psize = args->n_ops_per_thread * dsize * args->n_threads;
+
+	size_t psize = args->n_ops_per_thread *
+		(dsize + ALLOC_OVERHEAD) * args->n_threads;
 	if (psize < PMEMOBJ_MIN_POOL)
 		psize = PMEMOBJ_MIN_POOL;
 	psize *= FACTOR;


### PR DESCRIPTION
The allocation overhead is approximately 64 bytes. If the requested
allocation size is for example 1b it would require the FACTOR to be at
least 64. This patch adds the allocation overhead to the allocation
size in order to allocate enough space in pmemobj pool.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/633)
<!-- Reviewable:end -->
