### PR TITLE
ut: add pmemdetect as dependency for all tests

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -225,6 +225,11 @@ ifeq ($(USE_PMEMALLOC), y)
 all: $(TOOLS)/pmemalloc/pmemalloc
 endif
 
+$(TOOLS)/pmemdetect/pmemdetect.static-nondebug:
+	$(MAKE) -C $(TOOLS)/pmemdetect all
+
+all: $(TOOLS)/pmemdetect/pmemdetect.static-nondebug
+
 .PHONY: all check clean clobber cstyle pcheck test $(TSTCHECKS)
 
 -include .deps/*.P


### PR DESCRIPTION
It's used by require_fs_type pmem/non-pmem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/636)
<!-- Reviewable:end -->
