### PR TITLE
pmemobjfs: add required version of FUSE

### DIFF
--- a/src/examples/libpmemobj/pmemobjfs/Makefile
+++ b/src/examples/libpmemobj/pmemobjfs/Makefile
@@ -39,7 +39,9 @@ include $(TOP)/src/common.inc
 vpath %.c ../tree_map/
 vpath %.c ../map/
 
-FUSE := $(call check_package, fuse)
+FUSE_REQ_VER = 2.9.1
+
+FUSE := $(call check_package, fuse --atleast-version $(FUSE_REQ_VER))
 ifeq ($(FUSE), y)
 LINKS = mkfs.pmemobjfs\
        pmemobjfs.tx_begin\
@@ -47,7 +49,7 @@ LINKS = mkfs.pmemobjfs\
        pmemobjfs.tx_abort
 PROGS = pmemobjfs
 else
-$(info NOTE: Skipping pmemobjfs because fuse is missing \
+$(info NOTE: Skipping pmemobjfs because fuse (version >= $(FUSE_REQ_VER)) is missing \
 -- see src/examples/libpmemobj/pmemobjfs/README for details.)
 endif
 

--- a/src/examples/libpmemobj/pmemobjfs/README
+++ b/src/examples/libpmemobj/pmemobjfs/README
@@ -52,8 +52,8 @@ $ ls /mnt/pmemobjfs/dir1
 file1
 
 ** DEPENDENCIES: **
-In order to build pmemobjfs you need to install fuse development
-package.
+In order to build pmemobjfs you need to install fuse (version >= 2.9.1)
+development package.
 
 rpm-based systems : fuse-devel
 dpkg-based systems: libfuse-dev


### PR DESCRIPTION
The required version for FUSE is  2.9.1 because in this version the
fallocate function was introduced.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/637)
<!-- Reviewable:end -->
