### PR TITLE
test: dump contents of file that didn't match

### DIFF
--- a/src/test/match
+++ b/src/test/match
@@ -192,6 +192,10 @@ sub match {
 	}
 
 	if ($output ne '') {
+		if (!$opt_v) {
+			print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+		}
+
 		# make it a little more print-friendly...
 		$output =~ s/\n/\\n/g;
 		die "line $line_pat: unexpected output: \"$output\"\n";


### PR DESCRIPTION
... when all lines from the ".match" were already processed.
We already print the whole file when matching fails in the middle
of a match file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/650)
<!-- Reviewable:end -->
