### PR TITLE
cstyle: fix issues found by perl 5.22

### DIFF
--- a/utils/cstyle
+++ b/utils/cstyle
@@ -191,7 +191,11 @@ my $no_errs = 0;		# set for CSTYLED-protected lines
 sub err($) {
 	my ($error) = @_;
 	unless ($no_errs) {
-		printf $fmt, $filename, $., $error, $line;
+		if ($verbose) {
+			printf $fmt, $filename, $., $error, $line;
+		} else {
+			printf $fmt, $filename, $., $error;
+		}
 		$err_stat = 1;
 	}
 }
@@ -637,7 +641,7 @@ line: while (<$filehandle>) {
 	if (/^\s*\(void\)[^ ]/) {
 		err("missing space after (void) cast");
 	}
-	if (/\S{/ && !/{{/) {
+	if (/\S\{/ && !/\{\{/) {
 		err("missing space before left brace");
 	}
 	if ($in_function && /^\s+{/ &&


### PR DESCRIPTION
... as found in Debian testing.

Issues:

Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/\S{ <-- HERE / at ../../../src/../utils/cstyle line 640.
Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/{{ <-- HERE / at ../../../src/../utils/cstyle line 640.

Redundant argument in printf at ../../../src/../utils/cstyle line 194, <GEN3> line 138.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/657)
<!-- Reviewable:end -->
