### PR TITLE
common: fix size parsing function

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -679,6 +679,11 @@ text file, which must start with the line containing a
 string,
 followed by the specification of all the pool parts in the next lines.
 For each part, the file size and the absolute path must be provided.
+The size has to be compliant with the format specified in IEC 80000-13,
+IEEE 1541 or the Metric Interchange Format. Standards accept SI units with
+obligatory B - kB, MB, GB ... (multiplier by 1000) and IEC units with
+optional "iB" - KiB, MiB, GiB, ..., K, M, G, ... - (multiplier by 1024).
+.PP
 The minimum file size of each part of the pool set is the same as the
 minimum size allowed for a transactional object store consisting
 of one file.  It is defined in

--- a/doc/pmempool-create.1
+++ b/doc/pmempool-create.1
@@ -95,8 +95,12 @@ option to create a pool of maximum available size on underlying file system.
 
 The
 .I size
-argument may be passed with multiplicative suffixes K=1024, M=1024*1024
-and so on for G, T and P or the suffixes KB=1000, MB=1000*1000 and so on for GB, TB and PB.
+argument may be passed in format that permits only the upper-case character
+for byte - B as specified in IEC 80000-13, IEEE 1541 and the Metric
+Interchange Format. Standards accept SI units with obligatory B -
+kB, MB, GB ... which means multiplier by 1000 and IEC units with optional
+"iB" - KiB, MiB, GiB, ..., K, M, G, ... - which means multiplier by 1024.
+
 .SS "Available options:"
 .PP
 .B -s, --size

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -90,6 +90,11 @@ static const char *parser_errstr[PARSER_MAX_CODE] = {
 	"" /* format correct */
 };
 
+struct suff {
+	const char *suff;
+	uint64_t mag;
+};
+
 /*
  * util_map_part -- (internal) map a header of a pool set
  */
@@ -330,7 +335,8 @@ parser_get_next_token(char **line)
 static enum parser_codes
 parser_read_line(char *line, size_t *size, char **path)
 {
-	char *size_str, *path_str, *endptr;
+	int ret;
+	char *size_str, *path_str;
 
 	size_str = parser_get_next_token(&line);
 	path_str = parser_get_next_token(&line);
@@ -350,50 +356,12 @@ parser_read_line(char *line, size_t *size, char **path)
 	if (path_str[0] != '/')
 		return PARSER_WRONG_PATH; /* must be an absolute path */
 
-	*path = Strdup(path_str);
-
-	/* check format of size */
-	int ufound = 0;
-	*size = strtoull(size_str, &endptr, 10);
-	while (endptr && endptr[0] != '\0') {
-		if ((endptr[0] == 'b' || endptr[0] == 'B') &&
-		    (endptr[1] == '\0'))
-			return PARSER_CONTINUE;
-
-		if (ufound) {
-			Free(*path);
-			*path = NULL;
-			return PARSER_WRONG_SIZE;
-		}
-
-		/* multiply size by a unit */
-		switch (endptr[0]) {
-			case 'k':
-			case 'K':
-				*size *= 1ULL << 10; /* 1 KB */
-				break;
-			case 'm':
-			case 'M':
-				*size *= 1ULL << 20; /* 1 MB */
-				break;
-			case 'g':
-			case 'G':
-				*size *= 1ULL << 30; /* 1 GB */
-				break;
-			case 't':
-			case 'T':
-				*size *= 1ULL << 40; /* 1 TB */
-				break;
-			default:
-				Free(*path);
-				*path = NULL;
-				return PARSER_WRONG_SIZE;
-		}
-
-		ufound = 1;
-		endptr++;
+	ret = util_parse_size(size_str, size);
+	if (ret != 0 || *size == 0) {
+		return PARSER_WRONG_SIZE;
 	}
 
+	*path = Strdup(path_str);
 	return PARSER_CONTINUE;
 }
 
@@ -1681,4 +1649,52 @@ util_poolset_size(const char *path)
 err_close:
 	close(fd);
 	return size;
+}
+
+/*
+ * util_parse_size -- parse size from string
+ */
+int
+util_parse_size(const char *str, uint64_t *sizep)
+{
+	const struct suff suffixes[] = {
+		{ "K", 1UL << 10 },		/* JEDEC */
+		{ "M", 1UL << 20 },
+		{ "G", 1UL << 30 },
+		{ "T", 1UL << 40 },
+		{ "P", 1UL << 50 },
+		{ "KiB", 1UL << 10 },		/* IEC */
+		{ "MiB", 1UL << 20 },
+		{ "GiB", 1UL << 30 },
+		{ "TiB", 1UL << 40 },
+		{ "PiB", 1UL << 50 },
+		{ "kB", 1000UL },		/* SI */
+		{ "MB", 1000UL * 1000 },
+		{ "GB", 1000UL * 1000 * 1000 },
+		{ "TB", 1000UL * 1000 * 1000 * 1000 },
+		{ "PB", 1000UL * 1000 * 1000 * 1000 * 1000 }
+	};
+	int res = -1;
+	unsigned i;
+	uint64_t size = 0;
+	char unit[4] = {0};
+
+	int ret = sscanf(str, "%lu%4s", &size, unit);
+	if (ret == 1) {
+		res = 0;
+	} else if (ret == 2) {
+		for (i = 0; i < ARRAY_SIZE(suffixes); ++i) {
+			if (strcmp(suffixes[i].suff, unit) == 0) {
+				size = size * suffixes[i].mag;
+				res = 0;
+				break;
+			}
+		}
+	} else {
+		return -1;
+	}
+
+	if (sizep && res == 0)
+		*sizep = size;
+	return res;
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -67,6 +67,13 @@ void *util_map_tmpfile(const char *dir, size_t size, size_t req_align);
 #define	ALIGNMENT_DESC_BITS		4
 
 /*
+ * Macro calculates number of elements in given table
+ */
+#ifndef	ARRAY_SIZE
+#define	ARRAY_SIZE(x)	(sizeof (x) / sizeof ((x)[0]))
+#endif
+
+/*
  * architecture identification flags
  *
  * These flags allow to unambiguously determine the architecture
@@ -251,6 +258,7 @@ int util_pool_open_nocheck(struct pool_set **setp, const char *path,
 int util_pool_open(struct pool_set **setp, const char *path, int rdonly,
 	size_t minsize, const char *sig,
 	uint32_t major, uint32_t compat, uint32_t incompat, uint32_t ro_compat);
+int util_parse_size(const char *str, uint64_t *sizep);
 
 
 #define	COMPILE_ERROR_ON(cond) ((void)sizeof (char[(cond) ? -1 : 1]))

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -143,6 +143,7 @@ OTHER_TESTS = \
        util_file_create\
        util_file_open\
        util_map_proc\
+       util_parse_size\
        util_poolset\
        util_poolset_parse\
        util_is_poolset\

--- a/src/test/util_parse_size/.gitignore
+++ b/src/test/util_parse_size/.gitignore
@@ -1,0 +1,1 @@
+util_parse_size

--- a/src/test/util_parse_size/Makefile
+++ b/src/test/util_parse_size/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/util_parse_size/Makefile -- check parsing results
+#
+vpath %.c ../../common
+vpath %.h ../../common
+TARGET = util_parse_size
+OBJS = util_parse_size.o util.o set.o out.o
+
+out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
+util.o: CFLAGS += -DDEBUG
+set.o: CFLAGS += -DDEBUG
+
+LIBPMEM=y
+include ../Makefile.inc
+
+INCS += -I../../common

--- a/src/test/util_parse_size/TEST0
+++ b/src/test/util_parse_size/TEST0
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/util_parse_size/TEST0 -- unit test for util_parse_size.
+#
+export UNITTEST_NAME=util_parse_size/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type none
+
+setup
+
+expect_normal_exit ./util_parse_size$EXESUFFIX 11K 11M 11G 11T 11P\
+		11KiB 11MiB 11GiB 11TiB 11PiB 11kB 11MB 11GB 11TB 11PB\
+		10k 10KB 10mB 10mb 10Mb 10B B 10ki 10KiC KiD\
+		10Kiboli 10Kboli 10boli 10KiBoli
+
+check
+
+pass

--- a/src/test/util_parse_size/out0.log.match
+++ b/src/test/util_parse_size/out0.log.match
@@ -1,0 +1,32 @@
+util_parse_size/TEST0: START: util_parse_size
+ ./util_parse_size$(S)
+11K - correct 11264
+11M - correct 11534336
+11G - correct 11811160064
+11T - correct 12094627905536
+11P - correct 12384898975268864
+11KiB - correct 11264
+11MiB - correct 11534336
+11GiB - correct 11811160064
+11TiB - correct 12094627905536
+11PiB - correct 12384898975268864
+11kB - correct 11000
+11MB - correct 11000000
+11GB - correct 11000000000
+11TB - correct 11000000000000
+11PB - correct 11000000000000000
+10k - incorrect
+10KB - incorrect
+10mB - incorrect
+10mb - incorrect
+10Mb - incorrect
+10B - incorrect
+B - incorrect
+10ki - incorrect
+10KiC - incorrect
+KiD - incorrect
+10Kiboli - incorrect
+10Kboli - incorrect
+10boli - incorrect
+10KiBoli - incorrect
+util_parse_size/TEST0: Done

--- a/src/test/util_parse_size/util_parse_size.c
+++ b/src/test/util_parse_size/util_parse_size.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * util_parse_size.c -- unit test for parsing a size
+ */
+
+#include "unittest.h"
+#include "util.h"
+
+int
+main(int argc, char *argv[])
+{
+	int ret = 0;
+	uint64_t size = 0;
+	uint64_t *sizeptr;
+
+	START(argc, argv, "util_parse_size");
+
+	for (int arg = 1; arg < argc; ++arg) {
+		sizeptr = NULL;
+		ret = util_parse_size(argv[arg], sizeptr);
+		sizeptr = &size;
+		ret |= util_parse_size(argv[arg], sizeptr);
+		if (ret == 0) {
+			OUT("%s - correct %lu", argv[arg], *sizeptr);
+		} else {
+			OUT("%s - incorrect", argv[arg]);
+		}
+	}
+	DONE(NULL);
+}

--- a/src/test/util_poolset_parse/pool24.set
+++ b/src/test/util_poolset_parse/pool24.set
@@ -1,17 +1,17 @@
 PMEMPOOLSET
 # comment #1
-100k /mountpoint0/myfile.part0
-200m /mountpoint0/myfile.part0
-300g /mountpoint1/myfile.part1
-400t /mountpoint2/myfile.part2
+100K /mountpoint0/myfile.part0
+200M /mountpoint0/myfile.part0
+300G /mountpoint1/myfile.part1
+400T /mountpoint2/myfile.part2
 # comment #2
 REPLICA
 # comment #3
-500k /mountpoint3/mymirror0.part0
-200m /mountpoint4/mymirror0.part1
+500K /mountpoint3/mymirror0.part0
+200M /mountpoint4/mymirror0.part1
 # comment #4
 REPLICA
-300g /mountpoint5/mymirror1.part0
+300G /mountpoint5/mymirror1.part0
 # comment #5
-400t /mountpoint6/mymirror1.part1
+400T /mountpoint6/mymirror1.part1
 # comment #6

--- a/src/test/util_poolset_parse/pool26.set
+++ b/src/test/util_poolset_parse/pool26.set
@@ -1,30 +1,15 @@
 PMEMPOOLSET
 # bytes
-1000000B /mountpoint1/mymirror0.part0
-2000000b /mountpoint1/mymirror0.part1
-3000000  /mountpoint1/mymirror0.part2
-4000000  /mountpoint1/mymirror0.part3
+1000000 /mountpoint1/mymirror0.part0
 REPLICA
 # kilobytes
-1000kb	/mountpoint2/myfile.part0
-2000k	/mountpoint3/myfile.part1
-3000KB	/mountpoint2/myfile.part2
-4000K	/mountpoint2/myfile.part3
-3000kB	/mountpoint2/myfile.part4
-4000Kb	/mountpoint2/myfile.part5
+1000kB	/mountpoint2/myfile.part0
+2000K	/mountpoint3/myfile.part1
 REPLICA
 # gigabytes
-10gb	 	/mountpoint3/mymirror0.part0
-20g	  	/mountpoint3/mymirror0.part1
-30GB	   	/mountpoint3/mymirror0.part2
-40G	    	/mountpoint3/mymirror0.part3
-30gB	    	/mountpoint3/mymirror0.part4
-40Gb	     	/mountpoint3/mymirror0.part5
+10GB	 	/mountpoint3/mymirror0.part0
+20G	  	/mountpoint3/mymirror0.part1
 REPLICA
 # terabytes
-1tb 	  /mountpoint4/mymirror0.part0
-2t  	  /mountpoint4/mymirror0.part1
-3TB 	  /mountpoint4/mymirror0.part2
-4T  	  /mountpoint4/mymirror0.part3
-3tB 	  /mountpoint4/mymirror0.part4
-4Tb 	  /mountpoint4/mymirror0.part5
+1TB 	  /mountpoint4/mymirror0.part0
+2T  	  /mountpoint4/mymirror0.part1

--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -117,50 +117,6 @@ util_pool_hdr_valid(struct pool_hdr *hdrp)
 		util_checksum(hdrp, sizeof (*hdrp), &hdrp->checksum, 0);
 }
 
-
-/*
- * util_parse_size -- parse size from string
- */
-int
-util_parse_size(const char *str, uint64_t *sizep)
-{
-	uint64_t size = 0;
-	int shift = 0;
-	char unit[3] = {0};
-	int ret = sscanf(str, "%lu%2s", &size, unit);
-	if (ret <= 0)
-		return -1;
-	if (ret == 2) {
-		if ((unit[1] != '\0' && unit[1] != 'B') ||
-			unit[2] != '\0')
-			return -1;
-		switch (unit[0]) {
-		case 'K':
-			shift = 10;
-			break;
-		case 'M':
-			shift = 20;
-			break;
-		case 'G':
-			shift = 30;
-			break;
-		case 'T':
-			shift = 40;
-			break;
-		case 'P':
-			shift = 50;
-			break;
-		default:
-			return -1;
-		}
-	}
-
-	if (sizep)
-		*sizep = size << shift;
-
-	return 0;
-}
-
 /*
  * util_parse_mode -- parse file mode from octal string
  */


### PR DESCRIPTION
Parsing the size of pool sets/replicas and
pmempool create was inconsistent. This fix
unifies parsing method and makes it compliant
with standards specified in IEC 80000-13,
IEEE 1541 and Metric Interchange Format.

Ref: pmem/issues#132 pmem/issues#133 pmem/issues#134

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/661)
<!-- Reviewable:end -->
