### PR TITLE
test: update suppression file for memcheck

### DIFF
--- a/src/test/memcheck-stdcpp.supp
+++ b/src/test/memcheck-stdcpp.supp
@@ -5,7 +5,7 @@
    fun:malloc
    obj:*/libstdc++.so.*
    fun:call_init.part.0
-   fun:call_init
+   ...
    fun:_dl_init
    obj:*/ld-*.so
 }


### PR DESCRIPTION
The existing suppression file didn't work for gcc 5.3.1 on Fedora 22.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/662)
<!-- Reviewable:end -->
