### PR TITLE
obj: add primitives to pool and persistent_ptr

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -120,6 +120,7 @@ OBJ_CPP_TESTS = \
 	obj_cpp_ptr_arith\
 	obj_cpp_mutex_posix\
 	obj_cpp_shared_mutex_posix\
+	obj_cpp_pool_primitives
 
 CHRONO_TESTS = \
 	obj_cpp_mutex\

--- a/src/test/obj_cpp_pool_primitives/.gitignore
+++ b/src/test/obj_cpp_pool_primitives/.gitignore
@@ -1,0 +1,1 @@
+obj_cpp_pool_primitives

--- a/src/test/obj_cpp_pool_primitives/Makefile
+++ b/src/test/obj_cpp_pool_primitives/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_cpp_pool_primitives/Makefile -- build obj_cpp_pool_primitives
+# test
+#
+TARGET = obj_cpp_pool_primitives
+OBJS = obj_cpp_pool_primitives.o
+COMPILE_LANG = cpp
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_cpp_pool_primitives/TEST0
+++ b/src/test/obj_cpp_pool_primitives/TEST0
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_cpp_pool_primitives/TEST0 -- unit test for cpp pool primitives
+#
+export UNITTEST_NAME=obj_cpp_pool_primitives/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+
+setup
+umask 0
+
+expect_normal_exit ./obj_cpp_pool_primitives$EXESUFFIX $DIR/testfile
+
+check_file $DIR/testfile
+
+pass

--- a/src/test/obj_cpp_pool_primitives/TEST1
+++ b/src/test/obj_cpp_pool_primitives/TEST1
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_cpp_pool_primitives/TEST1 -- unit test for cpp pool primitives
+#
+export UNITTEST_NAME=obj_cpp_pool_primitives/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+require_valgrind_pmemcheck
+
+setup
+umask 0
+
+expect_normal_exit valgrind --tool=pmemcheck\
+	--log-file=pmemcheck$UNITTEST_NUM.log\
+	./obj_cpp_pool_primitives$EXESUFFIX $DIR/testfile
+
+check_file $DIR/testfile
+
+check
+
+pass

--- a/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
+++ b/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_cpp_pool_primitives.c -- cpp pool implementation test for:
+ * - persist
+ * - flush
+ * - drain
+ * - memcpy_persist
+ * - memset_persist
+ */
+
+#include "unittest.h"
+
+#include <libpmemobj/pool.hpp>
+#include <libpmemobj/persistent_ptr.hpp>
+#include <libpmemobj/p.hpp>
+
+using namespace nvml::obj;
+
+namespace {
+
+int TEST_VAL = 1;
+size_t MB = ((size_t)1 << 20);
+
+struct root {
+	p<int> val;
+	persistent_ptr<root> me;
+};
+
+/*
+ * pool_test_memset -- (internal) test memset_persist primitive
+ */
+void
+pool_test_memset(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	void *ret = pop.memset_persist(&root->val, TEST_VAL,
+			sizeof (root->val));
+	ASSERTeq(ret, &root->val);
+
+	int c;
+	memset(&c, TEST_VAL, sizeof (c));
+	ASSERTeq(root->val, c);
+}
+
+/*
+ * pool_test_memcpy -- (internal) test memcpy_persist primitive
+ */
+void
+pool_test_memcpy(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	int v = TEST_VAL;
+	void *ret = pop.memcpy_persist(&root->val, &v,
+			sizeof (root->val));
+	ASSERTeq(ret, &root->val);
+	ASSERTeq(root->val, v);
+}
+
+/*
+ * pool_test_drain -- (internal) test drain primitive
+ */
+void
+pool_test_drain(pool<root> &pop)
+{
+	pop.drain();
+}
+
+/*
+ * pool_test_flush -- (internal) test flush primitive
+ */
+void
+pool_test_flush(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->val = TEST_VAL;
+
+	pop.flush(&root->val, sizeof (root->val));
+}
+
+/*
+ * pool_test_flush_p -- (internal) test flush primitive on pmem property
+ */
+void
+pool_test_flush_p(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->val = TEST_VAL;
+
+	pop.flush(root->val);
+}
+
+/*
+ * pool_test_flush_ptr -- (internal) test flush primitive on pmem pointer
+ */
+void
+pool_test_flush_ptr(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+
+	pop.flush(root->me);
+}
+
+/*
+ * pool_test_flush_ptr_obj -- (internal) test flush primitive on pmem pointer
+ * object
+ */
+void
+pool_test_flush_ptr_obj(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+	root->val = TEST_VAL;
+
+	root.flush(pop);
+}
+
+/*
+ * pool_test_flush_ptr_obj_no_pop -- (internal) test flush primitive on
+ * pmem pointer object, without using pop
+ */
+void
+pool_test_flush_ptr_obj_no_pop(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+	root->val = TEST_VAL;
+
+	root.flush();
+}
+
+/*
+ * pool_test_persist -- (internal) test persist primitive
+ */
+void
+pool_test_persist(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->val = TEST_VAL;
+
+	pop.persist(&root->val, sizeof (root->val));
+}
+
+/*
+ * pool_test_persist_p -- (internal) test persist primitive on pmem property
+ */
+void
+pool_test_persist_p(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->val = TEST_VAL;
+
+	pop.persist(root->val);
+}
+
+/*
+ * pool_test_persist_ptr -- (internal) test persist primitive on pmem pointer
+ */
+void
+pool_test_persist_ptr(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+
+	pop.persist(root->me);
+}
+
+/*
+ * pool_test_persist_ptr_obj -- (internal) test persist primitive on pmem
+ * pointer object
+ */
+void
+pool_test_persist_ptr_obj(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+	root->val = TEST_VAL;
+
+	root.persist(pop);
+}
+
+/*
+ * pool_test_persist_ptr_obj_no_pop -- (internal) test persist primitive on
+ * pmem pointer object, without using pop
+ */
+void
+pool_test_persist_ptr_obj_no_pop(pool<root> &pop)
+{
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	root->me = root;
+	root->val = TEST_VAL;
+
+	root.persist();
+}
+
+/*
+ * pool_create -- (internal) test pool create
+ */
+pool<root>
+pool_create(const char *path, const char *layout, size_t poolsize,
+	unsigned mode)
+{
+	pool<root> pop = pool<root>::create(path, layout, poolsize,
+			mode);
+	persistent_ptr<root> root = pop.get_root();
+	ASSERT(root != nullptr);
+
+	return pop;
+}
+
+
+} /* namespace */
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_cpp_pool_primitives");
+
+	if (argc != 2)
+		FATAL("usage: %s path", argv[0]);
+
+	pool<root> pop = pool_create(argv[1], "layout", 32 * MB, 0666);
+
+	pool_test_persist(pop);
+	pool_test_persist_p(pop);
+	pool_test_persist_ptr(pop);
+	pool_test_persist_ptr_obj(pop);
+	pool_test_persist_ptr_obj_no_pop(pop);
+	pool_test_flush(pop);
+	pool_test_flush_p(pop);
+	pool_test_flush_ptr(pop);
+	pool_test_flush_ptr_obj(pop);
+	pool_test_flush_ptr_obj_no_pop(pop);
+	pool_test_drain(pop);
+	pool_test_memcpy(pop);
+	pool_test_memset(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_cpp_pool_primitives/pmemcheck1.log.match
+++ b/src/test/obj_cpp_pool_primitives/pmemcheck1.log.match
@@ -1,0 +1,8 @@
+==$(N)== pmemcheck-$(*), a simple persistent store checker
+==$(N)== Copyright (c) $(*), Intel Corporation
+==$(N)== Using Valgrind-$(*) and LibVEX; rerun with -h for copyright info
+==$(N)== Command: ./obj_cpp_pool_primitives$(*) $(*)test_obj_cpp_pool_primitives1/testfile
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== Number of stores not made persistent: 0


### PR DESCRIPTION
-Add the following methods to the pool class:
-- persist
-- flush
-- drain
-- memcpy_persist
-- memset_persist
- And the following methods to the persistent_ptr class:
-- persist
-- flush
- Add noexcept operator to relevant functions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/664)
<!-- Reviewable:end -->
