### PR TITLE
benchmarks: fix factor in obj_tx_alloc

### DIFF
--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -46,7 +46,7 @@
 #include "benchmark.h"
 
 #define	LAYOUT_NAME "benchmark"
-#define	FACTOR ((float)(1.2))
+#define	FACTOR 4
 #define	ALLOC_OVERHEAD 64
 /*
  * operations number is limited to prevent stack overflow during


### PR DESCRIPTION
The 1.2 factor was too small for huge allocations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/675)
<!-- Reviewable:end -->
