### PR TITLE
obj: cpp make_persistent_atomic implementation

### DIFF
--- a/src/include/libpmemobj/detail/integer_sequence.hpp
+++ b/src/include/libpmemobj/detail/integer_sequence.hpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LIBPMEMOBJ_INTEGER_SEQUENCE_HPP
+#define LIBPMEMOBJ_INTEGER_SEQUENCE_HPP
+
+/*
+ * integer_sequence.hpp -- create c++14 style index sequence
+ */
+
+namespace nvml {
+
+namespace detail {
+
+	/*
+	 * Base index type template.
+	 */
+	template<typename T, T...>
+	struct integer_sequence{};
+
+	/*
+	 * Size_t specialization of the integer sequence.
+	 */
+	template<size_t... Indices>
+	using index_sequence = integer_sequence<size_t, Indices...>;
+
+	/*
+	 * Empty base class.
+	 *
+	 * Subject of empty base optimization.
+	 */
+	template<typename T, T I, typename... Types>
+	struct make_integer_seq_impl;
+
+	/*
+	 * Class ending recursive variadic template peeling.
+	 */
+	template<typename T, T I, T... Indices>
+	struct make_integer_seq_impl<T, I, integer_sequence<T, Indices...> >
+	{
+		typedef integer_sequence<T, Indices...> type;
+	};
+
+	/*
+	 * Recursively create index while peeling off the types.
+	 */
+	template<typename N, N I, N... Indices, typename T, typename... Types>
+	struct make_integer_seq_impl<N, I, integer_sequence<N, Indices...>,
+	T, Types...>
+	{
+		typedef typename make_integer_seq_impl<N, I + 1,
+				integer_sequence<N, Indices..., I>,
+				Types...>::type type;
+	};
+
+	/*
+	 * Make index sequence entry point.
+	 */
+	template<typename... Types>
+	using make_index_sequence =
+			make_integer_seq_impl<size_t, 0,
+			integer_sequence<size_t>, Types...>;
+
+}  /* namespace detail */
+
+}  /* namespace nvml */
+
+#endif /* LIBPMEMOBJ_INTEGER_SEQUENCE_HPP */

--- a/src/include/libpmemobj/detail/make_atomic_impl.hpp
+++ b/src/include/libpmemobj/detail/make_atomic_impl.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * make_persistent_impl.hpp -- implementation details of atomic allocation
+ * and construction.
+ */
+
+#ifndef LIBPMEMOBJ_MAKE_ATOMIC_IMPL_HPP
+#define LIBPMEMOBJ_MAKE_ATOMIC_IMPL_HPP
+
+#include <new>
+
+#include "libpmemobj/detail/integer_sequence.hpp"
+
+namespace nvml {
+
+namespace detail {
+
+	/*
+	 * Calls the objects constructor.
+	 *
+	 * Unpacks the tuple to get constructor's parameters.
+	 */
+	template<typename T, size_t... Indices, typename... Args>
+	void create_object(void *ptr, index_sequence<Indices...>,
+			std::tuple<Args...> &tuple)
+	{
+		new (ptr) T(std::get<Indices>(tuple)...);
+	}
+
+	/*
+	 * C-style function called by the allocator.
+	 *
+	 * The arg is a tuple containing constructor parameters.
+	 */
+	template<typename T, typename... Args>
+	void obj_constructor(PMEMobjpool *pop, void *ptr, void *arg)
+	{
+		auto *arg_pack = static_cast<std::tuple<Args...> *>(arg);
+
+		typedef typename make_index_sequence<Args...>::type index;
+		create_object<T>(ptr, index(), *arg_pack);
+
+		pmemobj_persist(pop, ptr, sizeof(T));
+	}
+
+}  /* namespace detail */
+
+}  /* namespace nvml */
+
+#endif /* LIBPMEMOBJ_MAKE_ATOMIC_IMPL_HPP */

--- a/src/include/libpmemobj/make_persistent_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_atomic.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * make_persistent_atomic.hpp -- persistent_ptr atomic allocation functions
+ * for objects
+ */
+
+#ifndef PMEMOBJ_MAKE_PERSISTENT_ATOMIC_HPP
+#define PMEMOBJ_MAKE_PERSISTENT_ATOMIC_HPP
+
+#include "libpmemobj/detail/common.hpp"
+#include "libpmemobj/detail/pexceptions.hpp"
+#include "libpmemobj/detail/make_atomic_impl.hpp"
+#include "libpmemobj/detail/check_persistent_ptr_array.hpp"
+#include "libpmemobj/pool.hpp"
+#include "libpmemobj.h"
+
+namespace nvml {
+
+namespace obj {
+
+	/**
+	 * Atomically allocate and construct an object.
+	 *
+	 * Constructor parameters are passed through variadic parameters.
+	 *
+	 * @param[in,out] pool the pool from which the object will be allocated.
+	 * @param[in,out] ptr the persistent pointer to which the allocation
+	 * will take place.
+	 * @param[in] args variadic function parameter containing all parameters
+	 * passed to the objects constructor.
+	 *
+	 * @throw std::bad_alloc on allocation failure.
+	 */
+	template<typename T, typename... Args>
+	void make_persistent_atomic(pool_base &pool,
+			typename detail::pp_if_not_array<T>::type &ptr,
+			Args &&...args)
+	{
+		auto arg_pack = std::make_tuple(args...);
+		auto ret = pmemobj_alloc(pool.get_handle(), ptr.raw_ptr(),
+			sizeof (T), detail::type_num<T>(),
+			&detail::obj_constructor<T, Args...>,
+			static_cast<void*>(&arg_pack));
+
+		if (ret != 0)
+			throw std::bad_alloc();
+	}
+
+	/**
+	 * Atomically deallocate an object.
+	 *
+	 * There is no way to atomically destroy an object. Any object specific
+	 * cleanup must be performed elsewhere.
+	 *
+	 * param[in,out] ptr the persistent_ptr whose pointee is to be
+	 * deallocated.
+	 */
+	template<typename T>
+	void delete_persistent_atomic(typename
+			detail::pp_if_not_array<T>::type &ptr) noexcept
+	{
+		/* we CAN'T call the destructor */
+		pmemobj_free(ptr.raw_ptr());
+	}
+
+}  /* namespace obj */
+
+}  /* namespace nvml */
+
+#endif /* PMEMOBJ_MAKE_PERSISTENT_ATOMIC_HPP */

--- a/src/include/libpmemobj/persistent_ptr.hpp
+++ b/src/include/libpmemobj/persistent_ptr.hpp
@@ -368,8 +368,7 @@ namespace obj
 		 *
 		 * @param[in] pop Pmemobj pool
 		 */
-		template <typename Y>
-		void persist(pool<Y> &pop)
+		void persist(pool_base &pop)
 		{
 			pop.persist(this->get(), sizeof (T));
 		}
@@ -396,8 +395,7 @@ namespace obj
 		 *
 		 * @param[in] pop Pmemobj pool
 		 */
-		template <typename Y>
-		void flush(pool<Y> &pop)
+		void flush(pool_base &pop)
 		{
 			pop.flush(this->get(), sizeof (T));
 		}

--- a/src/include/libpmemobj/pool.hpp
+++ b/src/include/libpmemobj/pool.hpp
@@ -41,7 +41,6 @@
 
 #include "libpmemobj.h"
 #include "libpmemobj/detail/pexceptions.hpp"
-#include "libpmemobj/persistent_ptr.hpp"
 #include "libpmemobj/p.hpp"
 
 namespace nvml
@@ -60,67 +59,34 @@ namespace obj
 	class pool_base {
 	public:
 		/**
-		 * Default virtual destructor.
-		 */
-		virtual ~pool_base() noexcept = default;
-
-	protected:
-
-		/**
-		 * Protected constructor
-		 *
-		 * Prohibits base class object initialization.
-		 */
-		pool_base() noexcept = default;
-	};
-
-	/**
-	 * PMEMobj pool class
-	 *
-	 * This class is the pmemobj pool handler. It provides basic primitives
-	 * for operations on pmemobj pools. The template parameter defines the
-	 * type of the root object within the pool.
-	 */
-	template<typename T>
-	class pool : public pool_base
-	{
-	public:
-		/**
 		 * Defaulted constructor.
 		 */
-		pool() noexcept : pop(nullptr) {}
+		pool_base() noexcept : pop(nullptr) {}
 
 		/**
 		 * Defaulted copy constructor.
 		 */
-		pool(const pool&) noexcept = default;
+		pool_base(const pool_base&) noexcept = default;
 
 		/**
 		 * Defaulted move constructor.
 		 */
-		pool(pool&&) noexcept = default;
+		pool_base(pool_base&&) noexcept = default;
 
 		/**
 		 * Defaulted copy assignment operator.
 		 */
-		pool &operator=(const pool&) noexcept = default;
+		pool_base &operator=(const pool_base&) noexcept = default;
 
 		/**
 		 * Defaulted move assignment operator.
 		 */
-		pool &operator=(pool&&) noexcept = default;
+		pool_base &operator=(pool_base&&) noexcept = default;
 
 		/**
-		 * Retrieves pool's root object.
-		 *
-		 * @return persistent pointer to the root object.
+		 * Default virtual destructor.
 		 */
-		persistent_ptr<T> get_root() noexcept
-		{
-			persistent_ptr<T> root = pmemobj_root(this->pop,
-					sizeof (T));
-			return root;
-		}
+		virtual ~pool_base() noexcept = default;
 
 		/**
 		 * Opens an existing object store memory pool.
@@ -134,7 +100,7 @@ namespace obj
 		 *
 		 * @throw nvml::pool_error when an error during opening occurs.
 		 */
-		static pool<T> open(const std::string &path,
+		static pool_base open(const std::string &path,
 				const std::string &layout)
 		{
 			pmemobjpool *pop = pmemobj_open(path.c_str(),
@@ -142,7 +108,7 @@ namespace obj
 			if (pop == nullptr)
 				throw pool_error("Failed opening pool");
 
-			return pool(pop);
+			return pool_base(pop);
 		}
 
 		/**
@@ -151,8 +117,8 @@ namespace obj
 		 * @param path System path to the file to be created. If exists
 		 *	the pool can be created in-place depending on the size
 		 *	parameter. Existing file must be zeroed.
-		 * @param layout Unique identifier of the pool, can be NULL or
-		 *	any NULL-terminated string.
+		 * @param layout Unique identifier of the pool, can be a
+		 *	NULL-terminated string.
 		 * @param size Size of the pool in bytes. If zero and the file
 		 *	exists the pool is created in-place.
 		 * @param mode File mode for the new file.
@@ -161,7 +127,7 @@ namespace obj
 		 *
 		 * @throw nvml::pool_error when an error during creation occurs.
 		 */
-		static pool<T> create(const std::string &path,
+		static pool_base create(const std::string &path,
 				const std::string &layout,
 				std::size_t size = PMEMOBJ_MIN_POOL,
 				mode_t mode = S_IWUSR | S_IRUSR)
@@ -171,7 +137,7 @@ namespace obj
 			if (pop == nullptr)
 				throw pool_error("Failed creating pool");
 
-			return pool(pop);
+			return pool_base(pop);
 		}
 
 		/**
@@ -323,18 +289,142 @@ namespace obj
 			return this->pop;
 		}
 
+	protected:
+		/* The pool opaque handle */
+		PMEMobjpool *pop;
+
 	private:
 		/*
 		 * Private constructor.
 		 *
 		 * Enforce using factory methods for object creation.
 		 */
-		pool(pmemobjpool *_pop) noexcept : pop(_pop)
+		pool_base(pmemobjpool *_pop) noexcept : pop(_pop)
 		{
 		}
+	};
 
-		/* The pool opaque handle */
-		PMEMobjpool *pop;
+	/**
+	 * PMEMobj pool class
+	 *
+	 * This class is the pmemobj pool handler. It provides basic primitives
+	 * for operations on pmemobj pools. The template parameter defines the
+	 * type of the root object within the pool.
+	 */
+	template<typename T>
+	class pool : public pool_base
+	{
+	public:
+		/**
+		 * Defaulted constructor.
+		 */
+		pool() noexcept = default;
+
+		/**
+		 * Defaulted copy constructor.
+		 */
+		pool(const pool&) noexcept = default;
+
+		/**
+		 * Defaulted move constructor.
+		 */
+		pool(pool&&) noexcept = default;
+
+		/**
+		 * Defaulted copy assignment operator.
+		 */
+		pool &operator=(const pool&) noexcept = default;
+
+		/**
+		 * Defaulted move assignment operator.
+		 */
+		pool &operator=(pool&&) noexcept = default;
+
+		/**
+		 * Default destructor.
+		 */
+		~pool() noexcept = default;
+
+		/**
+		 * Defaulted copy constructor.
+		 */
+		explicit pool(const pool_base &pb) noexcept : pool_base(pb) {}
+
+		/**
+		 * Defaulted move constructor.
+		 */
+		explicit pool(pool_base &&pb) noexcept : pool_base(pb) {}
+
+		/**
+		 * Retrieves pool's root object.
+		 *
+		 * @return persistent pointer to the root object.
+		 */
+		persistent_ptr<T> get_root() noexcept
+		{
+			persistent_ptr<T> root = pmemobj_root(this->pop,
+					sizeof (T));
+			return root;
+		}
+
+		/**
+		 * Opens an existing object store memory pool.
+		 *
+		 * @param path System path to the file containing the memory
+		 *	pool or a pool set.
+		 * @param layout Unique identifier of the pool as specified at
+		 *	pool creation time.
+		 *
+		 * @return handle to the opened pool.
+		 *
+		 * @throw nvml::pool_error when an error during opening occurs.
+		 */
+		static pool<T> open(const std::string &path,
+				const std::string &layout)
+		{
+			return pool<T>(pool_base::open(path, layout));
+		}
+
+		/**
+		 * Creates a new transactional object store pool.
+		 *
+		 * @param path System path to the file to be created. If exists
+		 *	the pool can be created in-place depending on the size
+		 *	parameter. Existing file must be zeroed.
+		 * @param layout Unique identifier of the pool, can be a
+		 *	NULL-terminated string.
+		 * @param size Size of the pool in bytes. If zero and the file
+		 *	exists the pool is created in-place.
+		 * @param mode File mode for the new file.
+		 *
+		 * @return handle to the created pool.
+		 *
+		 * @throw nvml::pool_error when an error during creation occurs.
+		 */
+		static pool<T> create(const std::string &path,
+				const std::string &layout,
+				std::size_t size = PMEMOBJ_MIN_POOL,
+				mode_t mode = S_IWUSR | S_IRUSR)
+		{
+			return pool<T>(pool_base::create(path, layout,
+					size, mode));
+		}
+
+		/**
+		 * Checks if a given pool is consistent.
+		 *
+		 * @param path System path to the file containing the memory
+		 *	pool or a pool set.
+		 * @param layout Unique identifier of the pool as specified at
+		 *	pool creation time.
+		 *
+		 * @return -1 on error, 1 if file is consistent, 0 otherwise.
+		 */
+		static int check(const std::string &path,
+				const std::string &layout)
+		{
+			return pool_base::check(path, layout);
+		}
 	};
 
 } /* namespace obj */

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -118,7 +118,8 @@ OBJ_CPP_TESTS = \
 	obj_cpp_mutex_posix\
 	obj_cpp_shared_mutex_posix\
 	obj_cpp_pool_primitives\
-	obj_cpp_make_persistent
+	obj_cpp_make_persistent\
+	obj_cpp_make_persistent_atomic
 
 CHRONO_TESTS = \
 	obj_cpp_mutex\

--- a/src/test/obj_cpp_make_persistent_atomic/.gitignore
+++ b/src/test/obj_cpp_make_persistent_atomic/.gitignore
@@ -1,0 +1,1 @@
+obj_cpp_make_persistent_atomic

--- a/src/test/obj_cpp_make_persistent_atomic/Makefile
+++ b/src/test/obj_cpp_make_persistent_atomic/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_cpp_make_persistent_atomic/Makefile -- build
+# obj_cpp_make_persistent_atomic test
+#
+TARGET = obj_cpp_make_persistent_atomic
+OBJS = obj_cpp_make_persistent_atomic.o
+COMPILE_LANG = cpp
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_cpp_make_persistent_atomic/TEST0
+++ b/src/test/obj_cpp_make_persistent_atomic/TEST0
@@ -1,0 +1,47 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_make_persistent_atomic/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+
+setup
+
+expect_normal_exit\
+    ./obj_cpp_make_persistent_atomic$EXESUFFIX $DIR/testfile1
+
+pass

--- a/src/test/obj_cpp_make_persistent_atomic/TEST1
+++ b/src/test/obj_cpp_make_persistent_atomic/TEST1
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_make_persistent_atomic/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_cxx11
+require_valgrind_pmemcheck
+
+setup
+
+expect_normal_exit\
+    valgrind --tool=pmemcheck --log-file=valgrind$UNITTEST_NUM.log\
+    ./obj_cpp_make_persistent_atomic$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_cpp_make_persistent_atomic.cpp -- cpp make_persistent_atomic test for
+ * objects
+ */
+
+#include "unittest.h"
+
+#include <libpmemobj/persistent_ptr.hpp>
+#include <libpmemobj/p.hpp>
+#include <libpmemobj/pool.hpp>
+#include <libpmemobj/make_persistent_atomic.hpp>
+
+#define LAYOUT "cpp"
+
+using namespace nvml::obj;
+
+namespace {
+
+const int TEST_ARR_SIZE = 10;
+
+class foo {
+public:
+	foo() : bar(1) {
+		for (int i = 0; i < TEST_ARR_SIZE; ++i)
+			this->arr[i] = 1;
+	}
+
+	foo(int val) : bar(val) {
+		for (int i = 0; i < TEST_ARR_SIZE; ++i)
+			this->arr[i] = val;
+	}
+
+	foo(int val, char arr_val) : bar(val) {
+		for (int i = 0; i < TEST_ARR_SIZE; ++i)
+			this->arr[i] = arr_val;
+	}
+
+	/*
+	 * Assert values of foo.
+	 */
+	void check_foo(int val, char arr_val)
+	{
+		ASSERTeq(val, this->bar);
+		for (int i = 0; i < TEST_ARR_SIZE; ++i)
+			ASSERTeq(arr_val, this->arr[i]);
+	}
+
+	p<int> bar;
+	p<char> arr[TEST_ARR_SIZE];
+};
+
+struct root {
+	persistent_ptr<foo> pfoo;
+};
+
+/*
+ * test_make_no_args -- (internal) test make_persitent without arguments
+ */
+void
+test_make_no_args(pool<struct root> &pop)
+{
+	persistent_ptr<root> r = pop.get_root();
+
+	ASSERT(r->pfoo == nullptr);
+
+	make_persistent_atomic<foo>(pop, r->pfoo);
+	r->pfoo->check_foo(1, 1);
+
+	delete_persistent_atomic<foo>(r->pfoo);
+	ASSERT(r->pfoo == nullptr);
+}
+
+/*
+ * test_make_args -- (internal) test make_persitent with arguments
+ */
+void
+test_make_args(pool<struct root> &pop)
+{
+	persistent_ptr<root> r = pop.get_root();
+	ASSERT(r->pfoo == nullptr);
+
+	make_persistent_atomic<foo>(pop, r->pfoo, 2);
+	r->pfoo->check_foo(2, 2);
+
+	delete_persistent_atomic<foo>(r->pfoo);
+	ASSERT(r->pfoo == nullptr);
+
+	make_persistent_atomic<foo>(pop, r->pfoo, 3, 4);
+	r->pfoo->check_foo(3, 4);
+
+	delete_persistent_atomic<foo>(r->pfoo);
+	ASSERT(r->pfoo == nullptr);
+}
+
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_cpp_make_persistent_atomic");
+
+	if (argc != 2)
+		FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+
+	pool<struct root> pop;
+
+	try {
+		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
+			S_IWUSR | S_IRUSR);
+	} catch (nvml::pool_error &pe) {
+		FATAL("!pool::create: %s %s", pe.what(), path);
+	}
+
+	test_make_no_args(pop);
+	test_make_args(pop);
+
+	pop.close();
+
+	DONE(NULL);
+}

--- a/src/test/obj_cpp_make_persistent_atomic/valgrind1.log.match
+++ b/src/test/obj_cpp_make_persistent_atomic/valgrind1.log.match
@@ -1,0 +1,8 @@
+==$(N)== pmemcheck-$(nW), a simple persistent store checker
+==$(N)== Copyright (c) $(nW), Intel Corporation
+==$(N)== Using Valgrind-$(nW) and LibVEX; rerun with -h for copyright info
+==$(N)== Command: ./obj_cpp_make_persistent_atomic$(nW) $(nW)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== Number of stores not made persistent: 0


### PR DESCRIPTION
Use C++14-style make_integer_sequence to unpack variadic tuple.

Refs: pmem/issues#155

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/686)
<!-- Reviewable:end -->
