### PR TITLE
pmem: fix pmem_map test

### DIFF
--- a/src/test/pmem_map/out1.log.match
+++ b/src/test/pmem_map/out1.log.match
@@ -32,7 +32,7 @@ $(nW)/testfile11 4096 CX 666 1 1
 pmem_map_file: Invalid argument
 $(nW)/testfile12 2305843009213693951 CE 666 1 1
 posix_fallocate: off 0 len 2305843009213693951
-pmem_map_file: No space left on device
+pmem_map_file: $(*)
 $(nW) 0 T 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 T 666 1 1


### PR DESCRIPTION
The pmem_map/TEST1 test expected the ENOSPC errno returned from
posix_fallocate when trying to allocate very big file, but in fact the
posix_fallocate can return EFBIG errno as well for such a big file.
Change the match file to accept both error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/693)
<!-- Reviewable:end -->
