### PR TITLE
doc: libpmemobj: fix duplicate 'also' typo

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -2098,7 +2098,7 @@ the -1 value is returned from the caller and errno is set to
 The
 .I head
 cannot be OID_NULL.
-The allocated object is also also added to the internal container
+The allocated object is also added to the internal container
 associated with given
 .IR type_num .
 as described in section


### PR DESCRIPTION
Remove duplicate 'also' in libpmemobj man page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/695)
<!-- Reviewable:end -->
