### PR TITLE
obj: add "flags" to various APIs & remove pmemobj_{tx_}{zalloc|zrealloc}

### DIFF
--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -135,11 +135,7 @@ libpmemobj \- persistent memory transactional object store
 .sp
 .BI "int pmemobj_alloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .BI "    uint64_t " type_num ", pmemobj_constr " constructor ", void *" arg ", int " flags );
-.BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num ", int " flags );
 .BI "int pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num ", int " flags );
-.BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .BI "    uint64_t " type_num ", int " flags );
 .BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ,
 .BI "    uint64_t " type_num ", int " flags );
@@ -732,7 +728,7 @@ They provide semantics similar to standard
 .B pthread
 locks, except that they are considered initialized by zeroing them.
 So allocating the locks with
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 or
 .BR pmemobj_tx_alloc ()
 with
@@ -762,7 +758,7 @@ function explicitly initializes pmem-aware mutex pointed by
 by zeroing it.
 Initialization is not necessary if the object containing the mutex has been
 allocated using
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 or
 .BR pmemobj_tx_alloc ()
 with
@@ -827,7 +823,7 @@ by
 by zeroing it.
 Initialization is not necessary if the object containing the lock has been
 allocated using
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 or
 .BR pmemobj_tx_alloc ()
 with
@@ -928,7 +924,7 @@ The
 function explicitly initializes pmem-aware condition variable by zeroing it.
 Initialization is not necessary if the object containing the condition
 variable has been allocated using
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 or
 .BR pmemobj_tx_alloc ()
 with
@@ -1568,54 +1564,10 @@ returns non-zero value, sets the errno and leaves the
 untouched.
 The allocated object is added to the internal container associated with given
 .IR type_num .
-.I flags
-must be always equal to 0.
-.PP
-.BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.br
-.BI "    uint64_t " type_num ", int " flags );
-.IP
-The
-.BR pmemobj_zalloc ()
-function allocates a new zeroed object from the the persistent memory heap
-associated with memory pool
-.IR pop .
-The
-.B PMEMoid
-of allocated object is stored in
-.IR oidp .
-If NULL is passed as
-.IR oidp ,
-then the newly allocated object may be accessed only by iterating objects
-in the object container associated with given
-.IR type_num ,
-as described in
-.B OBJECT CONTAINERS
-section.
-If the
-.I oidp
-points to memory location from the
-.B pmemobj
-heap the
-.I oidp
-is modified atomically.
-The
-.I size
-can be any non-zero value, however due to internal padding and object metadata,
-the actual size of the allocation will differ from the requested one by at least
-64 bytes.  For this reason, making the allocations of a size
-less than 64 bytes is extremely inefficient and discouraged.
-If
-.I size
-equals 0, then
-.BR pmemobj_zalloc ()
-returns non-zero value, sets the errno and leaves the
-.I oidp
-untouched.
-The allocated object is added to the internal container associated with given
-.IR type_num .
-.I flags
-must be always equal to 0.
+.IR flags
+is a bitmask of 0 or more modifiers. For now only one modifier is defined:
+.IR PMEMOBJ_FLAG_ZERO ,
+which instructs the library to zero the allocated memory.
 .PP
 .BI "void pmemobj_free(PMEMoid *" oidp );
 .IP
@@ -1628,11 +1580,9 @@ persistent memory heap.
 It frees the memory space represented by
 .IR oidp ,
 which must have been returned by a previous call to
-.BR pmemobj_alloc (),
-.BR pmemobj_zalloc (),
-.BR pmemobj_realloc (),
+.BR pmemobj_alloc ()
 or
-.BR pmemobj_zrealloc ().
+.BR pmemobj_realloc ().
 If
 .I oidp
 is NULL or if it points to the root object's OID,
@@ -1694,11 +1644,9 @@ Unless
 is
 .IR OID_NULL ,
 it must have been returned by an earlier call to
-.BR pmemobj_alloc (),
-.BR pmemobj_zalloc (),
-.BR pmemobj_realloc (),
+.BR pmemobj_alloc ()
 or
-.BR pmemobj_zrealloc ().
+.BR pmemobj_realloc ().
 Note that the object handle value may change in result of reallocation.
 If the object was moved, a memory space represented by
 .I oid
@@ -1713,71 +1661,11 @@ If
 .BR pmemobj_realloc ()
 is unable to satisfy the allocation request, a non-zero value is returned and
 errno is set appropriately.
-.I flags
-must be always equal to 0.
-.PP
-.BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.br
-.BI "    uint64_t " type_num ", int " flags );
-.IP
-The
-.BR pmemobj_zrealloc ()
-function provide similar semantics to
-.BR realloc (3),
-but operates on the persistent memory heap associated with memory pool
-.IR pop .
-It changes the size of the object represented by
-.IR oid ,
-to
-.I size
-bytes.  The resized object is also added or moved to the internal
-container associated with given
-.IR type_num .
-The contents will be unchanged in the range from the start of the region
-up to the minimum of the old and new sizes.
-If the new size is larger than the old size, the added memory will be zeroed.
-If
-.I oidp
-is NULL or if it points to the root object's OID,
-behavior of the function is undefined.
-If it points to
-.IR OID_NULL ,
-then the call is equivalent to
-.BI "pmemobj_zalloc(" pop ", " size ", " type_num ")."
-If
-.I size
-is equal to zero, and
-.I oidp
-doesn't point to
-.IR OID_NULL ,
-then the call is equivalent to
-.BI "pmemobj_free(" pop ", " oid ")."
-Unless
-.I oidp
-points to
-.IR OID_NULL ,
-it must have been returned by an earlier call to
-.BR pmemobj_alloc (),
-.BR pmemobj_zalloc (),
-.BR pmemobj_realloc (),
-or
-.BR pmemobj_zrealloc ().
-Note that the object handle value may change in result of reallocation.
-If the object was moved, a memory space represented by
-.I oidp
-is reclaimed. If
-.I oidp
-points to memory location from the
-.B pmemobj
-heap the
-.I oidp
-is changed atomically.
-If
-.BR pmemobj_zrealloc ()
-is unable to satisfy the allocation request, OID_NULL is
-returned and errno is set appropriately.
-.I flags
-must be always equal to 0.
+.IR flags
+is a bitmask of 0 or more modifiers. For now only one modifier is defined:
+.IR PMEMOBJ_FLAG_ZERO ,
+which instructs the library to zero the new space if the new size is larger than
+the old size (otherwise it's left unitialized).
 .PP
 .BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ,
 .br
@@ -1885,13 +1773,13 @@ it takes a pointer to typed OID of
 The
 .B POBJ_ZNEW
 macro is a wrapper around the
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 function which takes the type name
 .B TYPE
 and passes the size and type number to
 the
-.BR pmemobj_zalloc ()
-function from the typed OID.
+.BR pmemobj_alloc ()
+function from the typed OID and sets flags to PMEMOBJ_FLAG_ZERO.
 Instead of taking a pointer to
 .B PMEMoid
 it takes a pointer to typed OID of
@@ -1902,14 +1790,14 @@ it takes a pointer to typed OID of
 The
 .B POBJ_ZALLOC
 macro is a wrapper around the
-.BR pmemobj_zalloc ()
+.BR pmemobj_alloc ()
 function which takes the type name
 .BR TYPE ,
 the size of allocation
 .I size
 and passes the type number to the
-.BR pmemobj_zalloc ()
-function from the typed OID.
+.BR pmemobj_alloc ()
+function from the typed OID and sets flags to PMEMOBJ_FLAG_ZERO.
 Instead of taking a pointer to
 .B PMEMoid
 it takes a pointer to typed OID of
@@ -1936,12 +1824,12 @@ it takes a pointer to typed OID of
 The
 .B POBJ_ZREALLOC
 macro is a wrapper around the
-.BR pmemobj_zrealloc ()
+.BR pmemobj_realloc ()
 function which takes the type name
 .B TYPE
 and passes the type number to the
-.BR pmemobj_zrealloc ()
-function from the typed OID.
+.BR pmemobj_realloc ()
+function from the typed OID and sets flags to PMEMOBJ_FLAG_ZERO.
 Instead of taking a pointer to
 .B PMEMoid
 it takes a pointer to typed OID of

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -264,9 +264,7 @@ libpmemobj \- persistent memory transactional object store
 .BI "int pmemobj_tx_add_range(PMEMoid " oid ", uint64_t " off ", size_t " size ", int " flags );
 .BI "int pmemobj_tx_add_range_direct(const void *" ptr ", size_t " size ", int " flags );
 .BI "PMEMoid pmemobj_tx_alloc(size_t " size ", uint64_t " type_num ", int " flags );
-.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num ", int " flags );
 .BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
-.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
 .BI "PMEMoid pmemobj_tx_strdup(const char *" s ", uint64_t " type_num ", int " flags );
 .BI "int pmemobj_tx_free(PMEMoid " oid );
 .sp
@@ -732,7 +730,9 @@ locks, except that they are considered initialized by zeroing them.
 So allocating the locks with
 .BR pmemobj_zalloc ()
 or
-.BR pmemobj_tx_zalloc ()
+.BR pmemobj_tx_alloc ()
+with
+.BR PMEMOBJ_FLAG_ZERO
 does not require another initialization step.
 .PP
 The fundamental property of pmem-aware locks is their automatic
@@ -757,11 +757,12 @@ function explicitly initializes pmem-aware mutex pointed by
 .I mutexp
 by zeroing it.
 Initialization is not necessary if the object containing the mutex has been
-allocated using one of
+allocated using
 .BR pmemobj_zalloc ()
 or
-.BR pmemobj_tx_zalloc ()
-functions.
+.BR pmemobj_tx_alloc ()
+with
+.BR PMEMOBJ_FLAG_ZERO .
 .PP
 .BI "int pmemobj_mutex_lock(PMEMobjpool *" pop ", PMEMmutex *" mutexp );
 .IP
@@ -821,11 +822,12 @@ by
 .I rwlockp
 by zeroing it.
 Initialization is not necessary if the object containing the lock has been
-allocated using one of
+allocated using
 .BR pmemobj_zalloc ()
 or
-.BR pmemobj_tx_zalloc ()
-functions.
+.BR pmemobj_tx_alloc ()
+with
+.BR PMEMOBJ_FLAG_ZERO .
 .PP
 .BI "int pmemobj_rwlock_rdlock(PMEMobjpool *" pop ", PMEMrwlock *" rwlockp );
 .IP
@@ -921,11 +923,12 @@ The
 .BR pmemobj_cond_zero ()
 function explicitly initializes pmem-aware condition variable by zeroing it.
 Initialization is not necessary if the object containing the condition
-variable has been allocated using one of
+variable has been allocated using
 .BR pmemobj_zalloc ()
 or
-.BR pmemobj_tx_zalloc ()
-functions.
+.BR pmemobj_tx_alloc ()
+with
+.BR PMEMOBJ_FLAG_ZERO .
 .PP
 .BI "int pmemobj_cond_broadcast(PMEMobjpool *" pop ", PMEMcond *" condp );
 .sp
@@ -2781,34 +2784,16 @@ transactionally allocates a new object of given
 .I size
 and
 .IR type_num .
+.IR flags
+is a bitmask of 0 or more modifiers. For now only one modifier is defined:
+.IR PMEMOBJ_FLAG_ZERO ,
+which instructs the library to zero the allocated memory.
 In contrast to the non-transactional allocations, the objects are
 added to the internal object containers of given
 .I type_num
 only after the transaction is committed, making the objects visible to the
 .B POBJ_FOREACH_*
 macros.
-.I flags
-must be always equal to 0.
-If successful, returns a handle to the newly allocated object.  Otherwise, stage
-changes to
-.IR TX_STAGE_ONABORT ,
-OID_NULL is returned, and errno is set appropriately.
-If
-.I size
-equals 0, OID_NULL is returned and errno is set appropriately.
-This function must be called during
-.IR TX_STAGE_WORK .
-.PP
-.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num ", int " flags );
-.IP
-The pmemobj_tx_zalloc ()
-.BR
-function transactionally allocates new zeroed object of given
-.I size
-and
-.IR type_num .
-.I flags
-must be always equal to 0.
 If successful, returns a handle to the newly allocated object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
@@ -2837,31 +2822,12 @@ is equal to zero and
 .I oid
 is not OID_NULL, then the call is equivalent to
 .BI "pmemobj_tx_free(" oid ")."
-If the new size is larger than the old size, the added memory will
-.I not
-be initialized.
-.I flags
-must be always equal to 0.
-If successful, returns returns a handle to the resized object.  Otherwise, stage
-changes to
-.IR TX_STAGE_ONABORT ,
-OID_NULL is returned, and errno is set appropriately.
-Note that the object handle value may change in result of reallocation.
-This function must be called during
-.IR TX_STAGE_WORK .
-.PP
-.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
-.IP
-The
-.BR pmemobj_tx_zrealloc ()
-function transactionally resizes an existing object to the given
-.I size
-and changes its type to
-.IR type_num .
-If the new size is larger than the old size, the extended new space is zeroed.
-.I flags
-must be always equal to 0.
-If successful, returns returns a handle to the resized object.  Otherwise, stage
+.IR flags
+is a bitmask of 0 or more modifiers. For now only one modifier is defined:
+.IR PMEMOBJ_FLAG_ZERO ,
+which instructs the library to zero the new space if the new size is larger than
+the old size (otherwise it's left unitialized).
+If successful, returns a handle to the resized object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
 OID_NULL is returned, and errno is set appropriately.

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -134,15 +134,15 @@ libpmemobj \- persistent memory transactional object store
 .BI "    void *" ptr ", void *" arg ");
 .sp
 .BI "int pmemobj_alloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num ", pmemobj_constr " constructor ", void *" arg );
+.BI "    uint64_t " type_num ", pmemobj_constr " constructor ", void *" arg ", int " flags );
 .BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .BI "int pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ,
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .BI "void pmemobj_free(PMEMoid *" oidp );
 .BI "size_t pmemobj_alloc_usable_size(PMEMoid " oid );
 .BI "PMEMobjpool *pmemobj_pool_by_oid(PMEMoid " oid );
@@ -162,9 +162,9 @@ libpmemobj \- persistent memory transactional object store
 .sp
 .B Root object management:
 .sp
-.BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size );
+.BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size ", int " flags );
 .BI "PMEMoid pmemobj_root_construct(PMEMobjpool *" pop ", size_t " size ,
-.BI "    pmemobj_constr " constructor ", void *" arg );
+.BI "    pmemobj_constr " constructor ", void *" arg ", int " flags );
 .BI "size_t pmemobj_root_size(PMEMobjpool *" pop );
 .sp
 .BI "POBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
@@ -1405,7 +1405,7 @@ should have the root object at the end of its reference path.
 It may be assumed that for each persistent memory pool the root object always
 exists, and there is exactly one root object in each pool.
 .PP
-.BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size );
+.BI "PMEMoid pmemobj_root(PMEMobjpool *" pop ", size_t " size ", int " flags );
 .IP
 The
 .BR pmemobj_root ()
@@ -1431,11 +1431,13 @@ function shall not fail, except for the case if the requested object size
 is larger than the maximum allocation size supported for given pool,
 or if there is not enough free space in the pool to satisfy the reallocation
 of the root object.  In such case, OID_NULL is returned.
+.I flags
+must be always equal to 0.
 .PP
 .PP
 .BI "PMEMoid pmemobj_root_construct(PMEMobjpool *" pop ", size_t " size ,
 .br
-.BI "    pmemobj_constr " constructor ", void *" arg )
+.BI "    pmemobj_constr " constructor ", void *" arg ", int " flags )
 .IP
 The
 .BR pmemobj_root_construct ()
@@ -1453,6 +1455,8 @@ The
 .BR pmemobj_root_size ()
 can be used in the constructor to check whether it's the first call to the
 constructor.
+.I flags
+must be always equal to 0.
 .PP
 .BI "POBJ_ROOT(PMEMobjpool *" pop ", " TYPE )
 .IP
@@ -1509,7 +1513,7 @@ is an user-defined argument passed to an appropriate function.
 .PP
 .BI "int pmemobj_alloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
-.BI "    uint64_t " type_num ", pmemobj_constr " constructor " , void *" arg );
+.BI "    uint64_t " type_num ", pmemobj_constr " constructor " , void *" arg ", int " flags );
 .IP
 The
 .B pmemobj_alloc
@@ -1564,10 +1568,12 @@ returns non-zero value, sets the errno and leaves the
 untouched.
 The allocated object is added to the internal container associated with given
 .IR type_num .
+.I flags
+must be always equal to 0.
 .PP
 .BI "int pmemobj_zalloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_zalloc ()
@@ -1608,6 +1614,8 @@ returns non-zero value, sets the errno and leaves the
 untouched.
 The allocated object is added to the internal container associated with given
 .IR type_num .
+.I flags
+must be always equal to 0.
 .PP
 .BI "void pmemobj_free(PMEMoid *" oidp );
 .IP
@@ -1645,7 +1653,7 @@ is changed atomically.
 .PP
 .BI "int pmemobj_realloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_realloc ()
@@ -1705,10 +1713,12 @@ If
 .BR pmemobj_realloc ()
 is unable to satisfy the allocation request, a non-zero value is returned and
 errno is set appropriately.
+.I flags
+must be always equal to 0.
 .PP
 .BI "int pmemobj_zrealloc(PMEMobjpool *" pop ", PMEMoid *" oidp ", size_t " size ,
 .br
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_zrealloc ()
@@ -1766,10 +1776,12 @@ If
 .BR pmemobj_zrealloc ()
 is unable to satisfy the allocation request, OID_NULL is
 returned and errno is set appropriately.
+.I flags
+must be always equal to 0.
 .PP
 .BI "int pmemobj_strdup(PMEMobjpool *" pop ", PMEMoid *" oidp ", const char *" s ,
 .br
-.BI "    uint64_t " type_num );
+.BI "    uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_strdup ()
@@ -1809,6 +1821,8 @@ If
 .BR pmemobj_strdup ()
 is unable to satisfy the allocation request, OID_NULL is
 returned and errno is set appropriately.
+.I flags
+must be always equal to 0.
 .PP
 .BI "size_t pmemobj_alloc_usable_size(PMEMoid " oid );
 .IP

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -261,13 +261,13 @@ libpmemobj \- persistent memory transactional object store
 .BI "int pmemobj_tx_errno(void);
 .BI "void pmemobj_tx_process(void);
 .sp
-.BI "int pmemobj_tx_add_range(PMEMoid " oid ", uint64_t " off ", size_t " size );
-.BI "int pmemobj_tx_add_range_direct(const void *" ptr ", size_t " size );
-.BI "PMEMoid pmemobj_tx_alloc(size_t " size ", uint64_t " type_num );
-.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num );
-.BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num );
-.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num );
-.BI "PMEMoid pmemobj_tx_strdup(const char *" s ", uint64_t " type_num );
+.BI "int pmemobj_tx_add_range(PMEMoid " oid ", uint64_t " off ", size_t " size ", int " flags );
+.BI "int pmemobj_tx_add_range_direct(const void *" ptr ", size_t " size ", int " flags );
+.BI "PMEMoid pmemobj_tx_alloc(size_t " size ", uint64_t " type_num ", int " flags );
+.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num ", int " flags );
+.BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
+.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
+.BI "PMEMoid pmemobj_tx_strdup(const char *" s ", uint64_t " type_num ", int " flags );
 .BI "int pmemobj_tx_free(PMEMoid " oid );
 .sp
 .BI "TX_BEGIN_LOCK(PMEMobjpool *" pop ", " ... )
@@ -2727,7 +2727,7 @@ and makes the transition to the next stage. It must be called in transaction.
 Current stage must always be obtained by a call to
 .BR pmemobj_tx_stage ().
 .PP
-.BI "int pmemobj_tx_add_range(PMEMoid " oid ", uint64_t " off ", size_t " size );
+.BI "int pmemobj_tx_add_range(PMEMoid " oid ", uint64_t " off ", size_t " size ", int " flags );
 .IP
 The
 .BR pmemobj_tx_add_range ()
@@ -2741,13 +2741,15 @@ and saves it to the undo log.  The application is then free to directly modify
 the object in that memory range.  In case of a failure or abort, all the changes
 within this range will be rolled-back.  The supplied block of memory has to be within
 the pool registered in the transaction.
+.I flags
+must be always equal to 0.
 If successful, returns zero.  Otherwise, state changes to
 .I TX_STAGE_ONABORT
 and an error number is returned.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "int pmemobj_tx_add_range_direct(const void *" ptr ", size_t " size );
+.BI "int pmemobj_tx_add_range_direct(const void *" ptr ", size_t " size ", int " flags );
 .IP
 The
 .BR pmemobj_tx_add_range_direct ()
@@ -2763,13 +2765,15 @@ in the virtual memory space and saves it to the undo log.  The application is th
 free to directly modify the object in that memory range.  In case of a failure
 or abort, all the changes within this range will be rolled-back.  The supplied
 block of memory has to be within the pool registered in the transaction.
+.I flags
+must be always equal to 0.
 If successful, returns zero.  Otherwise, state changes to
 .I TX_STAGE_ONABORT
 and an error number is returned.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "PMEMoid pmemobj_tx_alloc(size_t " size ", uint64_t " type_num );
+.BI "PMEMoid pmemobj_tx_alloc(size_t " size ", uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_tx_alloc ()
@@ -2783,6 +2787,8 @@ added to the internal object containers of given
 only after the transaction is committed, making the objects visible to the
 .B POBJ_FOREACH_*
 macros.
+.I flags
+must be always equal to 0.
 If successful, returns a handle to the newly allocated object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
@@ -2793,7 +2799,7 @@ equals 0, OID_NULL is returned and errno is set appropriately.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num );
+.BI "PMEMoid pmemobj_tx_zalloc(size_t " size ", uint64_t " type_num ", int " flags );
 .IP
 The pmemobj_tx_zalloc ()
 .BR
@@ -2801,6 +2807,8 @@ function transactionally allocates new zeroed object of given
 .I size
 and
 .IR type_num .
+.I flags
+must be always equal to 0.
 If successful, returns a handle to the newly allocated object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
@@ -2811,9 +2819,7 @@ equals 0, OID_NULL is returned and errno is set appropriately.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ,
-.br
-.BI "    uint64_t " type_num );
+.BI "PMEMoid pmemobj_tx_realloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_tx_realloc ()
@@ -2834,6 +2840,8 @@ is not OID_NULL, then the call is equivalent to
 If the new size is larger than the old size, the added memory will
 .I not
 be initialized.
+.I flags
+must be always equal to 0.
 If successful, returns returns a handle to the resized object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
@@ -2842,9 +2850,7 @@ Note that the object handle value may change in result of reallocation.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ,
-.br
-.BI "    uint64_t " type_num );
+.BI "PMEMoid pmemobj_tx_zrealloc(PMEMoid " oid ", size_t " size ", uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_tx_zrealloc ()
@@ -2853,6 +2859,8 @@ function transactionally resizes an existing object to the given
 and changes its type to
 .IR type_num .
 If the new size is larger than the old size, the extended new space is zeroed.
+.I flags
+must be always equal to 0.
 If successful, returns returns a handle to the resized object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,
@@ -2861,7 +2869,7 @@ Note that the object handle value may change in result of reallocation.
 This function must be called during
 .IR TX_STAGE_WORK .
 .PP
-.BI "PMEMoid pmemobj_tx_strdup(const char *" s ", uint64_t " type_num );
+.BI "PMEMoid pmemobj_tx_strdup(const char *" s ", uint64_t " type_num ", int " flags );
 .IP
 The
 .BR pmemobj_tx_strdup ()
@@ -2870,6 +2878,8 @@ string
 .I s
 and assigns it a type
 .IR type_num .
+.I flags
+must be always equal to 0.
 If successful, returns a handle to the newly allocated object.  Otherwise, stage
 changes to
 .IR TX_STAGE_ONABORT ,

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -48,9 +48,9 @@ libpmemobj \- persistent memory transactional object store
 .sp
 .B Most commonly used functions:
 .sp
-.BI "PMEMobjpool *pmemobj_open(const char *" path ", const char *" layout );
+.BI "PMEMobjpool *pmemobj_open(const char *" path ", const char *" layout ", int " flags );
 .BI "PMEMobjpool *pmemobj_create(const char *" path ", const char *" layout ,
-.BI "    size_t " poolsize ", mode_t " mode );
+.BI "    size_t " poolsize ", mode_t " mode ", int " flags );
 .BI "void pmemobj_close(PMEMobjpool *" pop );
 .sp
 .B Low-level memory manipulation:
@@ -307,7 +307,7 @@ libpmemobj \- persistent memory transactional object store
 .BI "    void (*" free_func ")(void *" ptr ),
 .BI "    void *(*" realloc_func ")(void *" ptr ", size_t " size ),
 .BI "    char *(*" strdup_func ")(const char *" s ));
-.BI "int pmemobj_check(const char *" path ", const char *" layout );
+.BI "int pmemobj_check(const char *" path ", const char *" layout ", int " flags );
 .sp
 .B Error handling:
 .sp
@@ -402,7 +402,7 @@ There is no need for applications to flush changes directly
 when using the obj memory API provided by
 .BR libpmemobj .
 .PP
-.BI "PMEMobjpool *pmemobj_open(const char *" path ", const char *" layout );
+.BI "PMEMobjpool *pmemobj_open(const char *" path ", const char *" layout ", int " flags );
 .IP
 The
 .BR pmemobj_open ()
@@ -420,6 +420,8 @@ when the pool was first created.  This can be used to verify
 the layout of the pool matches what was expected.
 The application must have permission to open the file and memory map
 it with read/write permissions.
+.I flags
+must be always equal to 0.
 If an error prevents the pool from being opened,
 or if the given
 .I layout
@@ -429,7 +431,7 @@ returns NULL and sets errno appropriately.
 .PP
 .BI "PMEMobjpool *pmemobj_create(const char *" path ", const char *" layout ,
 .br
-.BI "    size_t " poolsize ", mode_t " mode );
+.BI "    size_t " poolsize ", mode_t " mode ", int " flags );
 .IP
 The
 .BR pmemobj_create ()
@@ -474,6 +476,8 @@ file size allowed by the library for a transactional object store is defined in
 .B <libpmemobj.h>
 as
 .BR PMEMOBJ_MIN_POOL .
+.I flags
+must be always equal to 0.
 .PP
 .BI "void pmemobj_close(PMEMobjpool *" pop );
 .IP
@@ -3327,7 +3331,7 @@ default function to be used.
 The library does not make heavy use of the system malloc functions, but
 it does allocate approximately 4-8 kilobytes for each memory pool in use.
 .PP
-.BI "int pmemobj_check(const char *" path ", const char *" layout );
+.BI "int pmemobj_check(const char *" path ", const char *" layout ", int " flags );
 .IP
 The
 .BR pmemobj_check ()
@@ -3347,6 +3351,8 @@ will provide additional details on inconsistencies when
 is at least 1, as described in the
 .B "DEBUGGING AND ERROR HANDLING"
 section below.
+.I flags
+must be always equal to 0.
 .BR pmemobj_check ()
 will return -1 and set errno if it cannot perform the
 consistency check due to other errors.

--- a/src/benchmarks/map_bench.c
+++ b/src/benchmarks/map_bench.c
@@ -575,7 +575,7 @@ map_common_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	map_bench->pop = pmemobj_create(args->fname, "map_bench",
-			map_bench->pool_size, args->fmode);
+			map_bench->pool_size, args->fmode, 0);
 	if (!map_bench->pop) {
 		fprintf(stderr, "pmemobj_create: %s\n", pmemobj_errormsg());
 		goto err_free_bench;

--- a/src/benchmarks/map_bench.c
+++ b/src/benchmarks/map_bench.c
@@ -284,7 +284,7 @@ map_insert_alloc_op(struct map_bench *map_bench, uint64_t key)
 
 	TX_BEGIN(map_bench->pop) {
 		PMEMoid oid = pmemobj_tx_alloc(map_bench->args->dsize,
-				OBJ_TYPE_NUM);
+				OBJ_TYPE_NUM, 0);
 		ret = map_insert(map_bench->mapc, map_bench->map, key, oid);
 	} TX_ONABORT {
 		ret = -1;
@@ -669,7 +669,7 @@ map_keys_init(struct benchmark *bench, struct benchmark_args *args)
 
 			if (targs->alloc)
 				oid = pmemobj_tx_alloc(args->dsize,
-						OBJ_TYPE_NUM);
+						OBJ_TYPE_NUM, 0);
 			else
 				oid = map_bench->root_oid;
 

--- a/src/benchmarks/obj_lanes.c
+++ b/src/benchmarks/obj_lanes.c
@@ -104,7 +104,7 @@ lanes_init(struct benchmark *bench, struct benchmark_args *args)
 
 	/* create pmemobj pool */
 	ob->pop = pmemobj_create(args->fname,
-			"obj_lanes", psize, args->fmode);
+			"obj_lanes", psize, args->fmode, 0);
 	if (ob->pop == NULL) {
 		fprintf(stderr, "%s\n", pmemobj_errormsg());
 		goto err;

--- a/src/benchmarks/obj_locks.c
+++ b/src/benchmarks/obj_locks.c
@@ -579,7 +579,7 @@ locks_init(struct benchmark *bench, struct benchmark_args *args)
 
 	mb->pop = pmemobj_create(args->fname,
 			POBJ_LAYOUT_NAME(pmembench_lock_layout),
-			poolsize, args->fmode);
+			poolsize, args->fmode, 0);
 
 	if (mb->pop == NULL) {
 		ret = -1;

--- a/src/benchmarks/obj_pmalloc.c
+++ b/src/benchmarks/obj_pmalloc.c
@@ -144,7 +144,7 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 	}
 
 	ob->pop = pmemobj_create(args->fname, POBJ_LAYOUT_NAME(pmalloc_layout),
-			poolsize, args->fmode);
+			poolsize, args->fmode, 0);
 	if (ob->pop == NULL) {
 		fprintf(stderr, "%s\n", pmemobj_errormsg());
 		goto free_ob;

--- a/src/benchmarks/pmemobj_atomic_lists.c
+++ b/src/benchmarks/pmemobj_atomic_lists.c
@@ -449,7 +449,7 @@ obj_init_list(struct worker_info *worker, size_t n_oids, size_t list_len)
 		size_t size = obj_bench.alloc_sizes[i];
 		PMEMoid *tmp = (PMEMoid *)&obj_worker->oids[i];
 		if (pmemobj_alloc(obj_bench.pop, tmp, size, type_num,
-							NULL, NULL) != 0)
+							NULL, NULL, 0) != 0)
 			goto err_oids;
 	}
 	for (i = 0; i < list_len; i++)

--- a/src/benchmarks/pmemobj_atomic_lists.c
+++ b/src/benchmarks/pmemobj_atomic_lists.c
@@ -1008,8 +1008,9 @@ obj_init(struct benchmark *bench, struct benchmark_args *args)
 		}
 
 		/* Create pmemobj pool. */
-		if ((obj_bench.pop = pmemobj_create(args->fname, LAYOUT_NAME,
-						psize, args->fmode)) == NULL) {
+		obj_bench.pop = pmemobj_create(args->fname, LAYOUT_NAME, psize,
+				args->fmode, 0);
+		if (obj_bench.pop == NULL) {
 			perror(pmemobj_errormsg());
 			goto free_all;
 		}

--- a/src/benchmarks/pmemobj_gen.c
+++ b/src/benchmarks/pmemobj_gen.c
@@ -469,7 +469,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 			snprintf((char *)bench_priv->sets[i], path_len,
 					"%s%s%02x", args->fname, PART_NAME, i);
 			bench_priv->pop[i] = pmemobj_create(bench_priv->sets[i],
-						LAYOUT_NAME, psize, FILE_MODE);
+					LAYOUT_NAME, psize, FILE_MODE, 0);
 			if (bench_priv->pop[i] == NULL) {
 				perror(pmemobj_errormsg());
 				goto free_sets;
@@ -486,7 +486,7 @@ pobj_init(struct benchmark *bench, struct benchmark_args *args)
 		}
 		bench_priv->sets[0] = (const char *)args->fname;
 		bench_priv->pop[0] = pmemobj_create(bench_priv->sets[0],
-				LAYOUT_NAME, psize, FILE_MODE);
+				LAYOUT_NAME, psize, FILE_MODE, 0);
 		if (bench_priv->pop[0] == NULL) {
 			perror(pmemobj_errormsg());
 			goto free_pools;
@@ -616,7 +616,8 @@ pobj_open_op(struct benchmark *bench, struct operation_info *info)
 	struct pobj_bench *bench_priv = pmembench_get_priv(bench);
 	unsigned int idx = bench_priv->pool(info->worker->index);
 	pmemobj_close(bench_priv->pop[idx]);
-	bench_priv->pop[idx] = pmemobj_open(bench_priv->sets[idx], LAYOUT_NAME);
+	bench_priv->pop[idx] = pmemobj_open(bench_priv->sets[idx], LAYOUT_NAME,
+			0);
 	if (bench_priv->pop[idx] == NULL)
 		return -1;
 	return 0;

--- a/src/benchmarks/pmemobj_gen.c
+++ b/src/benchmarks/pmemobj_gen.c
@@ -578,7 +578,7 @@ pobj_init_worker(struct benchmark *bench, struct benchmark_args
 	for (i = 0; i < bench_priv->args_priv->n_objs; i++) {
 		size_t size = bench_priv->fn_size(bench_priv, i);
 		unsigned int type = bench_priv->fn_type_num(bench_priv, idx, i);
-		if (pmemobj_alloc(pop,	&pw->oids[i], size, type, NULL, NULL)
+		if (pmemobj_alloc(pop,	&pw->oids[i], size, type, NULL, NULL, 0)
 									!= 0) {
 			perror("pmemobj_alloc");
 			goto out;

--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -1094,7 +1094,7 @@ obj_tx_init(struct benchmark *bench, struct benchmark_args *args)
 		psize = 0;
 	}
 	obj_bench.pop = pmemobj_create(args->fname, LAYOUT_NAME,
-						psize, args->fmode);
+						psize, args->fmode, 0);
 	if (obj_bench.pop == NULL) {
 		perror("pmemobj_create");
 		goto free_all;

--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -392,7 +392,7 @@ alloc_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	int type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
 	struct obj_tx_worker *obj_worker = worker->priv;
 	if (pmemobj_alloc(obj_bench->pop, &obj_worker->oids[idx].oid,
-			obj_bench->sizes[idx], type_num, NULL, NULL) != 0) {
+			obj_bench->sizes[idx], type_num, NULL, NULL, 0) != 0) {
 		perror("pmemobj_alloc");
 		return -1;
 	}
@@ -485,7 +485,7 @@ realloc_pmem(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	if (obj_bench->obj_args->change_type)
 		type_num++;
 	if (pmemobj_realloc(obj_bench->pop, &obj_worker->oids[idx].oid,
-			obj_bench->resizes[idx], type_num) != 0) {
+			obj_bench->resizes[idx], type_num, 0) != 0) {
 		perror("pmemobj_realloc");
 		return -1;
 	}

--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -410,7 +410,7 @@ alloc_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	int type_num = obj_bench->fn_type_num(obj_bench, worker->index, idx);
 	struct obj_tx_worker *obj_worker = worker->priv;
 	obj_worker->oids[idx].oid = pmemobj_tx_alloc(obj_bench->sizes[idx],
-								type_num);
+								type_num, 0);
 	if (OID_IS_NULL(obj_worker->oids[idx].oid)) {
 		perror("pmemobj_tx_alloc");
 		return -1;
@@ -505,7 +505,7 @@ realloc_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 		type_num++;
 	obj_worker->oids[idx].oid =
 			pmemobj_tx_realloc(obj_worker->oids[idx].oid,
-			obj_bench->sizes[idx], type_num);
+			obj_bench->sizes[idx], type_num, 0);
 	if (OID_IS_NULL(obj_worker->oids[idx].oid)) {
 		perror("pmemobj_tx_realloc");
 		return -1;
@@ -528,7 +528,7 @@ add_range_nested_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 			struct offset offset = obj_bench->fn_off(obj_bench,
 						obj_worker->tx_level);
 			ret = pmemobj_tx_add_range(obj_worker->oids[n_oid].oid,
-					offset.off, offset.size);
+					offset.off, offset.size, 0);
 			obj_worker->tx_level++;
 			ret = add_range_nested_tx(obj_bench, worker, idx);
 		}
@@ -554,7 +554,7 @@ add_range_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 			size_t n_oid = obj_bench->n_oid(i);
 			struct offset offset = obj_bench->fn_off(obj_bench, i);
 			ret = pmemobj_tx_add_range(obj_worker->oids[n_oid].oid,
-						offset.off, offset.size);
+						offset.off, offset.size, 0);
 		}
 	} TX_ONABORT {
 		fprintf(stderr, "transaction failed\n");

--- a/src/examples/libpmemobj/array/README
+++ b/src/examples/libpmemobj/array/README
@@ -10,10 +10,9 @@ are supported: int, PMEMoid and TOID with structure containing int variable.
 
 Persistent pointer can be treated as a pointer to the first element of array.
 TOID with user's defined structure can be allocated by using POBJ_ALLOC or
-POBJ_ZALLOC macros (similarly when using PMEMoid there are pmemobj_alloc() and
-pmemobj_zalloc() functions) with proper number elements multiplied by
-user-defined structure's size. Access to array's elements can be executed by
-using pmemobj_direct() function or just using proper macro.
+POBJ_ZALLOC macros with proper number elements multiplied by user-defined
+structure's size. Access to array's elements can be executed by using
+pmemobj_direct() function or just using proper macro.
 For example D_RW(test1)[0] points to first element of test1 array.
 
 To allocate new array using application run the following command:

--- a/src/examples/libpmemobj/array/array.c
+++ b/src/examples/libpmemobj/array/array.c
@@ -494,12 +494,12 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(array),
-			PMEMOBJ_MIN_POOL, S_IRWXU)) == NULL) {
+			PMEMOBJ_MIN_POOL, S_IRWXU, 0)) == NULL) {
 			printf("failed to create pool\n");
 			return 1;
 		}
 	} else {
-		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(array)))
+		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(array), 0))
 								== NULL) {
 			printf("failed to open pool\n");
 			return 1;

--- a/src/examples/libpmemobj/array/array.c
+++ b/src/examples/libpmemobj/array/array.c
@@ -249,8 +249,8 @@ realloc_pmemoid(PMEMoid *info, size_t prev_size, size_t size)
 {
 	TOID(PMEMoid) array;
 	TOID_ASSIGN(array, *info);
-	pmemobj_zrealloc(pop, &array.oid, sizeof (PMEMoid) * size,
-						TOID_TYPE_NUM(PMEMoid), 0);
+	pmemobj_realloc(pop, &array.oid, sizeof (PMEMoid) * size,
+				TOID_TYPE_NUM(PMEMoid), PMEMOBJ_FLAG_ZERO);
 
 	for (int i = prev_size; i < size; i++) {
 		if (pmemobj_alloc(pop, &D_RW(array)[i],
@@ -271,9 +271,9 @@ realloc_toid(PMEMoid *info, size_t prev_size, size_t size)
 {
 	TOID_ARRAY(TOID(struct array_elm)) array;
 	TOID_ASSIGN(array, *info);
-	pmemobj_zrealloc(pop, &array.oid,
+	pmemobj_realloc(pop, &array.oid,
 			sizeof (TOID(struct array_elm)) * size,
-			TOID_TYPE_NUM_OF(array), 0);
+			TOID_TYPE_NUM_OF(array), PMEMOBJ_FLAG_ZERO);
 	for (int i = prev_size; i < size; i++) {
 		POBJ_NEW(pop, &D_RW(array)[i], struct array_elm,
 						elm_constructor, &i);

--- a/src/examples/libpmemobj/array/array.c
+++ b/src/examples/libpmemobj/array/array.c
@@ -250,12 +250,12 @@ realloc_pmemoid(PMEMoid *info, size_t prev_size, size_t size)
 	TOID(PMEMoid) array;
 	TOID_ASSIGN(array, *info);
 	pmemobj_zrealloc(pop, &array.oid, sizeof (PMEMoid) * size,
-							TOID_TYPE_NUM(PMEMoid));
+						TOID_TYPE_NUM(PMEMoid), 0);
 
 	for (int i = prev_size; i < size; i++) {
 		if (pmemobj_alloc(pop, &D_RW(array)[i],
 			sizeof (struct array_elm), TOID_TYPE_NUM(PMEMoid),
-							elm_constructor, &i)) {
+						elm_constructor, &i, 0)) {
 			fprintf(stderr, "pmemobj_alloc\n");
 			assert(0);
 		}
@@ -273,7 +273,7 @@ realloc_toid(PMEMoid *info, size_t prev_size, size_t size)
 	TOID_ASSIGN(array, *info);
 	pmemobj_zrealloc(pop, &array.oid,
 			sizeof (TOID(struct array_elm)) * size,
-			TOID_TYPE_NUM_OF(array));
+			TOID_TYPE_NUM_OF(array), 0);
 	for (int i = prev_size; i < size; i++) {
 		POBJ_NEW(pop, &D_RW(array)[i], struct array_elm,
 						elm_constructor, &i);
@@ -335,7 +335,7 @@ alloc_pmemoid(size_t size)
 	for (int i = 0; i < size; i++) {
 		if (pmemobj_alloc(pop, &D_RW(array)[i],
 			sizeof (struct array_elm),
-			TOID_TYPE_NUM(PMEMoid), elm_constructor, &i)) {
+			TOID_TYPE_NUM(PMEMoid), elm_constructor, &i, 0)) {
 			fprintf(stderr, "pmemobj_alloc\n");
 		}
 	}

--- a/src/examples/libpmemobj/btree.c
+++ b/src/examples/libpmemobj/btree.c
@@ -173,13 +173,13 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(btree),
-			PMEMOBJ_MIN_POOL, 0666)) == NULL) {
+			PMEMOBJ_MIN_POOL, 0666, 0)) == NULL) {
 			perror("failed to create pool\n");
 			return 1;
 		}
 	} else {
 		if ((pop = pmemobj_open(path,
-				POBJ_LAYOUT_NAME(btree))) == NULL) {
+				POBJ_LAYOUT_NAME(btree), 0)) == NULL) {
 			perror("failed to open pool\n");
 			return 1;
 		}

--- a/src/examples/libpmemobj/cpp/queue.cpp
+++ b/src/examples/libpmemobj/cpp/queue.cpp
@@ -106,7 +106,7 @@ public:
 		int error = 0;
 		TX_BEGIN(pop) {
 			persistent_ptr<pmem_entry> n =
-				pmemobj_tx_alloc(sizeof (pmem_entry), 0);
+				pmemobj_tx_alloc(sizeof (pmem_entry), 0, 0);
 			n->value = value;
 			n->next = nullptr;
 

--- a/src/examples/libpmemobj/cpp/queue.cpp
+++ b/src/examples/libpmemobj/cpp/queue.cpp
@@ -187,12 +187,12 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, LAYOUT,
-			PMEMOBJ_MIN_POOL, S_IRWXU)) == NULL) {
+			PMEMOBJ_MIN_POOL, S_IRWXU, 0)) == NULL) {
 			std::cerr << "failed to create pool" << std::endl;
 			return 1;
 		}
 	} else {
-		if ((pop = pmemobj_open(path, LAYOUT)) == NULL) {
+		if ((pop = pmemobj_open(path, LAYOUT, 0)) == NULL) {
 			std::cerr << "failed to open pool" << std::endl;
 			return 1;
 		}

--- a/src/examples/libpmemobj/cpp/queue.cpp
+++ b/src/examples/libpmemobj/cpp/queue.cpp
@@ -198,7 +198,8 @@ main(int argc, char *argv[])
 		}
 	}
 
-	persistent_ptr<pmem_queue> q = pmemobj_root(pop, sizeof (pmem_queue));
+	persistent_ptr<pmem_queue> q = pmemobj_root(pop, sizeof (pmem_queue),
+			0);
 	switch (op) {
 		case QUEUE_PUSH:
 			q->push(pop, atoll(argv[3]));

--- a/src/examples/libpmemobj/hashmap/hashmap_tx.c
+++ b/src/examples/libpmemobj/hashmap/hashmap_tx.c
@@ -143,7 +143,7 @@ hm_tx_rebuild(PMEMobjpool *pop, TOID(struct hashmap_tx) hashmap, size_t new_len)
 		TOID(struct buckets) buckets_new =
 				TX_ZALLOC(struct buckets, sz_new);
 		D_RW(buckets_new)->nbuckets = new_len;
-		pmemobj_tx_add_range(buckets_old.oid, 0, sz_old);
+		pmemobj_tx_add_range(buckets_old.oid, 0, sz_old, 0);
 
 		for (size_t i = 0; i < D_RO(buckets_old)->nbuckets; ++i) {
 			while (!TOID_IS_NULL(D_RO(buckets_old)->bucket[i])) {

--- a/src/examples/libpmemobj/libart/art.c
+++ b/src/examples/libpmemobj/libart/art.c
@@ -651,7 +651,7 @@ add_child48(PMEMobjpool *pop, TOID(art_node48) n, TOID(art_node_u) *ref,
 		TOID(art_node_u)  newnode_u = alloc_node(pop, NODE256);
 		TOID(art_node256) newnode = D_RO(newnode_u)->u.an256;
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		for (int i = 0; i < 256; i++) {
 			if (D_RO(n)->keys[i]) {
@@ -753,7 +753,7 @@ add_child4(PMEMobjpool *pop, TOID(art_node4) n, TOID(art_node_u) *ref,
 		TOID(art_node_u) newnode_u = alloc_node(pop, NODE16);
 		TOID(art_node16) newnode = D_RO(newnode_u)->u.an16;
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		// Copy the child pointers and the key map
 		PMEMOIDcopy(&(D_RW(newnode)->children[0].oid),
@@ -853,8 +853,7 @@ recursive_insert(PMEMobjpool *pop, TOID(art_node_u) n, TOID(art_node_u) *ref,
 		}
 
 		// New value, we must split the leaf into a node4
-		pmemobj_tx_add_range_direct(ref,
-		    sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 		TOID(art_node_u) newnode_u = alloc_node(pop, NODE4);
 		TOID(art_node4)  newnode = D_RO(newnode_u)->u.an4;
 		art_node *newnode_n = &(D_RW(newnode)->n);
@@ -900,9 +899,8 @@ recursive_insert(PMEMobjpool *pop, TOID(art_node_u) n, TOID(art_node_u) *ref,
 		}
 
 		// Create a new node
-		pmemobj_tx_add_range_direct(ref,
-		    sizeof (TOID(art_node_u)));
-		pmemobj_tx_add_range_direct(n_an, sizeof (art_node));
+		TX_ADD_DIRECT(ref);
+		TX_ADD_DIRECT(n_an);
 		TOID(art_node_u) newnode_u = alloc_node(pop, NODE4);
 		TOID(art_node4)  newnode = D_RO(newnode_u)->u.an4;
 		art_node *newnode_n = &(D_RW(newnode)->n);
@@ -1027,7 +1025,7 @@ remove_child256(PMEMobjpool *pop,
 		TOID(art_node_u) newnode_u = alloc_node(pop, NODE48);
 		TOID(art_node48) newnode_an48 = D_RO(newnode_u)->u.an48;
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		*ref = newnode_u;
 		copy_header(&(D_RW(newnode_an48)->n), n_an);
@@ -1063,7 +1061,7 @@ remove_child48(PMEMobjpool *pop,
 		TOID(art_node_u) newnode_u = alloc_node(pop, NODE16);
 		TOID(art_node16) newnode_an16 = D_RO(newnode_u)->u.an16;
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		*ref = newnode_u;
 		copy_header(&(D_RW(newnode_an16)->n), n_an);
@@ -1104,7 +1102,7 @@ remove_child16(PMEMobjpool *pop,
 		TOID(art_node_u) newnode_u	 = alloc_node(pop, NODE4);
 		TOID(art_node4)  newnode_an4 = D_RO(newnode_u)->u.an4;
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		*ref = newnode_u;
 		copy_header(&(D_RW(newnode_an4)->n), &(D_RW(n)->n));
@@ -1136,7 +1134,7 @@ remove_child4(PMEMobjpool *pop,
 		TOID(art_node_u) child_u = D_RO(n)->children[0];
 		art_node *child = &(D_RW(D_RW(child_u)->u.an4)->n);
 
-		pmemobj_tx_add_range_direct(ref, sizeof (TOID(art_node_u)));
+		TX_ADD_DIRECT(ref);
 
 		if (!IS_LEAF(D_RO(child_u))) {
 			// Concatenate the prefixes

--- a/src/examples/libpmemobj/libart/arttree.c
+++ b/src/examples/libpmemobj/libart/arttree.c
@@ -262,12 +262,12 @@ art_tree_map_init(struct datastore *ds, struct ds_context *ctx)
 			error_string = "pmemobj_create";
 			ctx->pop = pmemobj_create(ctx->filename,
 				    POBJ_LAYOUT_NAME(arttree_tx),
-				    ctx->psize, ctx->fmode);
+				    ctx->psize, ctx->fmode, 0);
 			ctx->newpool = 1;
 		} else {
 			error_string = "pmemobj_open";
 			ctx->pop = pmemobj_open(ctx->filename,
-				    POBJ_LAYOUT_NAME(arttree_tx));
+				    POBJ_LAYOUT_NAME(arttree_tx), 0);
 		}
 		if (ctx->pop == NULL) {
 			perror(error_string);

--- a/src/examples/libpmemobj/manpage.c
+++ b/src/examples/libpmemobj/manpage.c
@@ -56,10 +56,10 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop;
 
 	/* create the pmemobj pool or open it if it already exists */
-	pop = pmemobj_create(path, LAYOUT_NAME, POOL_SIZE, 0666);
+	pop = pmemobj_create(path, LAYOUT_NAME, POOL_SIZE, 0666, 0);
 
 	if (pop == NULL)
-	    pop = pmemobj_open(path, LAYOUT_NAME);
+	    pop = pmemobj_open(path, LAYOUT_NAME, 0);
 
 	if (pop == NULL) {
 		perror(path);

--- a/src/examples/libpmemobj/map/data_store.c
+++ b/src/examples/libpmemobj/map/data_store.c
@@ -151,13 +151,13 @@ int main(int argc, const char *argv[]) {
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(data_store),
-			PMEMOBJ_MIN_POOL, 0666)) == NULL) {
+			PMEMOBJ_MIN_POOL, 0666, 0)) == NULL) {
 			perror("failed to create pool\n");
 			return 1;
 		}
 	} else {
 		if ((pop = pmemobj_open(path,
-				POBJ_LAYOUT_NAME(data_store))) == NULL) {
+				POBJ_LAYOUT_NAME(data_store), 0)) == NULL) {
 			perror("failed to open pool\n");
 			return 1;
 		}

--- a/src/examples/libpmemobj/map/kv_server.c
+++ b/src/examples/libpmemobj/map/kv_server.c
@@ -437,14 +437,14 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		pop = pmemobj_create(path, POBJ_LAYOUT_NAME(kv_server),
-				KV_SIZE, 0666);
+				KV_SIZE, 0666, 0);
 		if (pop == NULL) {
 			fprintf(stderr, "failed to create pool: %s\n",
 					pmemobj_errormsg());
 			return 1;
 		}
 	} else {
-		pop = pmemobj_open(path, POBJ_LAYOUT_NAME(kv_server));
+		pop = pmemobj_open(path, POBJ_LAYOUT_NAME(kv_server), 0);
 		if (pop == NULL) {
 			fprintf(stderr, "failed to open pool: %s\n",
 					pmemobj_errormsg());

--- a/src/examples/libpmemobj/map/mapcli.c
+++ b/src/examples/libpmemobj/map/mapcli.c
@@ -225,7 +225,7 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		pop = pmemobj_create(path, POBJ_LAYOUT_NAME(map),
-				PM_HASHSET_POOL_SIZE, S_IRUSR | S_IWUSR);
+				PM_HASHSET_POOL_SIZE, S_IRUSR | S_IWUSR, 0);
 		if (pop == NULL) {
 			fprintf(stderr, "failed to create pool: %s\n",
 					pmemobj_errormsg());
@@ -255,7 +255,7 @@ main(int argc, char *argv[])
 
 		map = D_RO(root)->map;
 	} else {
-		pop = pmemobj_open(path, POBJ_LAYOUT_NAME(map));
+		pop = pmemobj_open(path, POBJ_LAYOUT_NAME(map), 0);
 		if (pop == NULL) {
 			fprintf(stderr, "failed to open pool: %s\n",
 					pmemobj_errormsg());

--- a/src/examples/libpmemobj/pi.c
+++ b/src/examples/libpmemobj/pi.c
@@ -192,12 +192,13 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(pi),
-			PMEMOBJ_MIN_POOL, S_IRWXU)) == NULL) {
+			PMEMOBJ_MIN_POOL, S_IRWXU, 0)) == NULL) {
 			printf("failed to create pool\n");
 			return 1;
 		}
 	} else {
-		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(pi))) == NULL) {
+		pop = pmemobj_open(path, POBJ_LAYOUT_NAME(pi), 0);
+		if (pop == NULL) {
 			printf("failed to open pool\n");
 			return 1;
 		}

--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
@@ -114,7 +114,7 @@ pmemblk_map(PMEMobjpool *pop, size_t bsize, size_t fsize)
 PMEMblkpool *
 pmemblk_open(const char *path, size_t bsize)
 {
-	PMEMobjpool *pop = pmemobj_open(path, POBJ_LAYOUT_NAME(obj_pmemblk));
+	PMEMobjpool *pop = pmemobj_open(path, POBJ_LAYOUT_NAME(obj_pmemblk), 0);
 	if (pop == NULL)
 		return NULL;
 	struct stat buf;
@@ -140,7 +140,7 @@ pmemblk_create(const char *path, size_t bsize, size_t poolsize, mode_t mode)
 	}
 
 	PMEMobjpool *pop = pmemobj_create(path, POBJ_LAYOUT_NAME(obj_pmemblk),
-				poolsize, mode);
+				poolsize, mode, 0);
 	if (pop == NULL)
 		return NULL;
 
@@ -162,7 +162,7 @@ pmemblk_close(PMEMblkpool *pbp)
 int
 pmemblk_check(const char *path, size_t bsize)
 {
-	int ret = pmemobj_check(path, POBJ_LAYOUT_NAME(obj_pmemblk));
+	int ret = pmemobj_check(path, POBJ_LAYOUT_NAME(obj_pmemblk), 0);
 	if (ret)
 		return ret;
 

--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
@@ -237,7 +237,7 @@ pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno)
 		size_t block_off = blockno * D_RO(bp)->bsize;
 		uint8_t *dst = D_RW(D_RW(bp)->data) + block_off;
 		/* add the modified block to the undo log */
-		pmemobj_tx_add_range_direct(dst, D_RO(bp)->bsize);
+		pmemobj_tx_add_range_direct(dst, D_RO(bp)->bsize, 0);
 		memcpy(dst, buf, D_RO(bp)->bsize);
 	} TX_ONABORT {
 		retval = 1;
@@ -264,7 +264,7 @@ pmemblk_set_zero(PMEMblkpool *pbp, off_t blockno)
 		&D_RW(bp)->locks[blockno % MAX_THREADS], TX_LOCK_NONE) {
 		size_t block_off = blockno * D_RO(bp)->bsize;
 		uint8_t *dst = D_RW(D_RW(bp)->data) + block_off;
-		pmemobj_tx_add_range_direct(dst, D_RO(bp)->bsize);
+		pmemobj_tx_add_range_direct(dst, D_RO(bp)->bsize, 0);
 		memset(dst, 0, D_RO(bp)->bsize);
 	} TX_ONABORT {
 		retval = -1;

--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
@@ -193,7 +193,7 @@ pmemblk_nblock(PMEMblkpool *pbp)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)pbp;
 	return ((struct base *)pmemobj_direct(pmemobj_root(pop,
-					sizeof (struct base))))->nblocks;
+					sizeof (struct base), 0)))->nblocks;
 }
 
 /*

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
@@ -98,7 +98,7 @@ struct base {
 PMEMlogpool *
 pmemlog_open(const char *path)
 {
-	return (PMEMlogpool *)pmemobj_open(path, LAYOUT_NAME);
+	return (PMEMlogpool *)pmemobj_open(path, LAYOUT_NAME, 0);
 }
 
 /*
@@ -108,7 +108,7 @@ PMEMlogpool *
 pmemlog_create(const char *path, size_t poolsize, mode_t mode)
 {
 	return (PMEMlogpool *)pmemobj_create(path, LAYOUT_NAME,
-				poolsize, mode);
+				poolsize, mode, 0);
 }
 
 /*

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
@@ -153,7 +153,7 @@ pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count)
 
 	/* allocate the new node to be inserted */
 	PMEMoid log = pmemobj_tx_alloc(count + sizeof (struct log_hdr),
-				LOG_TYPE);
+				LOG_TYPE, 0);
 
 	struct log *logp = pmemobj_direct(log);
 	logp->hdr.size = count;
@@ -161,13 +161,13 @@ pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count)
 	logp->hdr.next = OID_NULL;
 
 	/* add the modified root object to the undo log */
-	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base));
+	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base), 0);
 	if (bp->tail.off == 0) {
 		/* update head */
 		bp->head = log;
 	} else {
 		/* add the modified tail entry to the undo log */
-		pmemobj_tx_add_range(bp->tail, 0, sizeof (struct log));
+		pmemobj_tx_add_range(bp->tail, 0, sizeof (struct log), 0);
 		((struct log *)pmemobj_direct(bp->tail))->hdr.next = log;
 	}
 
@@ -201,10 +201,10 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 	pmemobj_tx_begin(pop, env, TX_LOCK_RWLOCK, &bp->rwlock, TX_LOCK_NONE);
 
 	/* add the base object to the undo log - once for the transaction */
-	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base));
+	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base), 0);
 	/* add the tail entry once to the undo log, if it is set */
 	if (!OID_IS_NULL(bp->tail))
-		pmemobj_tx_add_range(bp->tail, 0, sizeof (struct log));
+		pmemobj_tx_add_range(bp->tail, 0, sizeof (struct log), 0);
 
 	/* append the data */
 	for (int i = 0; i < iovcnt; ++i) {
@@ -213,7 +213,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 
 		/* allocate the new node to be inserted */
 		PMEMoid log = pmemobj_tx_alloc(count + sizeof (struct log_hdr),
-				LOG_TYPE);
+				LOG_TYPE, 0);
 
 		struct log *logp = pmemobj_direct(log);
 		logp->hdr.size = count;
@@ -277,7 +277,7 @@ pmemlog_rewind(PMEMlogpool *plp)
 	/* begin a transaction, also acquiring the write lock for the log */
 	pmemobj_tx_begin(pop, env, TX_LOCK_RWLOCK, &bp->rwlock, TX_LOCK_NONE);
 	/* add the root object to the undo log */
-	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base));
+	pmemobj_tx_add_range(baseoid, 0, sizeof (struct base), 0);
 
 	/* free all log nodes */
 	while (bp->head.off != 0) {

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
@@ -137,7 +137,7 @@ int
 pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
-	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base));
+	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base), 0);
 	struct base *bp = pmemobj_direct(baseoid);
 
 	/* set the return point */
@@ -186,7 +186,7 @@ int
 pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
-	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base));
+	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base), 0);
 	struct base *bp = pmemobj_direct(baseoid);
 
 	/* set the return point */
@@ -244,7 +244,7 @@ pmemlog_tell(PMEMlogpool *plp)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
 	struct base *bp = pmemobj_direct(pmemobj_root(pop,
-				sizeof (struct base)));
+				sizeof (struct base), 0));
 
 	if (pmemobj_rwlock_rdlock(pop, &bp->rwlock) != 0)
 		return 0;
@@ -263,7 +263,7 @@ void
 pmemlog_rewind(PMEMlogpool *plp)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
-	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base));
+	PMEMoid baseoid = pmemobj_root(pop, sizeof (struct base), 0);
 	struct base *bp = pmemobj_direct(baseoid);
 
 	/* set the return point */
@@ -307,7 +307,7 @@ pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
 	struct base *bp = pmemobj_direct(pmemobj_root(pop,
-						sizeof (struct base)));
+						sizeof (struct base), 0));
 
 	if (pmemobj_rwlock_rdlock(pop, &bp->rwlock) != 0)
 		return;

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
@@ -93,7 +93,7 @@ pmemlog_open(const char *path)
 {
 
 	return (PMEMlogpool *)pmemobj_open(path,
-				POBJ_LAYOUT_NAME(obj_pmemlog_macros));
+				POBJ_LAYOUT_NAME(obj_pmemlog_macros), 0);
 }
 
 /*
@@ -104,7 +104,7 @@ pmemlog_create(const char *path, size_t poolsize, mode_t mode)
 {
 	return (PMEMlogpool *)pmemobj_create(path,
 				POBJ_LAYOUT_NAME(obj_pmemlog_macros),
-				poolsize, mode);
+				poolsize, mode, 0);
 }
 
 /*

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
@@ -100,7 +100,7 @@ PMEMlogpool *
 pmemlog_open(const char *path)
 {
 	return (PMEMlogpool *)pmemobj_open(path,
-				POBJ_LAYOUT_NAME(obj_pmemlog_minimal));
+				POBJ_LAYOUT_NAME(obj_pmemlog_minimal), 0);
 }
 
 /*
@@ -111,7 +111,7 @@ pmemlog_create(const char *path, size_t poolsize, mode_t mode)
 {
 	return (PMEMlogpool *)pmemobj_create(path,
 				POBJ_LAYOUT_NAME(obj_pmemlog_minimal),
-				poolsize, mode);
+				poolsize, mode, 0);
 }
 
 /*

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
@@ -147,7 +147,7 @@ pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count)
 	PMEMoid obj;
 	pmemobj_alloc(pop, &obj, obj_size,
 			0, create_log_entry,
-			&args);
+			&args, 0);
 
 	return 0;
 }
@@ -167,7 +167,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 		size_t obj_size = sizeof (size_t) + args.size;
 		/* alloc-construct to an internal list */
 		pmemobj_alloc(pop, NULL, obj_size,
-				0, create_log_entry, &args);
+				0, create_log_entry, &args, 0);
 	}
 
 	return 0;

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
@@ -126,7 +126,7 @@ PMEMlogpool *
 pmemlog_open(const char *path)
 {
 	PMEMobjpool *pop = pmemobj_open(path,
-				POBJ_LAYOUT_NAME(obj_pmemlog_simple));
+				POBJ_LAYOUT_NAME(obj_pmemlog_simple), 0);
 	assert(pop != NULL);
 	struct stat buf;
 	if (stat(path, &buf)) {
@@ -146,7 +146,7 @@ pmemlog_create(const char *path, size_t poolsize, mode_t mode)
 
 	PMEMobjpool *pop = pmemobj_create(path,
 				POBJ_LAYOUT_NAME(obj_pmemlog_simple),
-				poolsize, mode);
+				poolsize, mode, 0);
 	assert(pop != NULL);
 	struct stat buf;
 	if (stat(path, &buf)) {

--- a/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
+++ b/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
@@ -2174,7 +2174,7 @@ pmemobjfs_mkfs(const char *fname, size_t size, size_t bsize, mode_t mode)
 	objfs->block_size = bsize;
 
 	objfs->pop = pmemobj_create(fname, POBJ_LAYOUT_NAME(pmemobjfs),
-			size, mode);
+			size, mode, 0);
 	if (!objfs->pop) {
 		fprintf(stderr, "error: %s\n", pmemobj_errormsg());
 		ret = -1;
@@ -2441,7 +2441,7 @@ main(int argc, char *argv[])
 
 	int ret = 0;
 
-	objfs->pop = pmemobj_open(fname, POBJ_LAYOUT_NAME(pmemobjfs));
+	objfs->pop = pmemobj_open(fname, POBJ_LAYOUT_NAME(pmemobjfs), 0);
 	if (objfs->pop == NULL) {
 		perror("pmemobj_open");
 		ret = -1;

--- a/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
+++ b/src/examples/libpmemobj/pmemobjfs/pmemobjfs.c
@@ -122,20 +122,19 @@ for (entry = ((head)).first; !TOID_IS_NULL(entry) &&\
 		entry = next)
 
 #define	PDLL_INSERT_HEAD(head, entry, field) do {\
-	pmemobj_tx_add_range_direct(&head.first, sizeof (head.first));\
+	TX_ADD_DIRECT(&head.first);\
 	TX_ADD_FIELD(entry, field);\
 	D_RW(entry)->field.next = head.first;\
 	D_RW(entry)->field.prev =\
 		(typeof (D_RW(entry)->field.prev))OID_NULL;\
 	head.first = entry;\
 	if (TOID_IS_NULL(head.last)) {\
-		pmemobj_tx_add_range_direct(&head.last, sizeof (head.last));\
+		TX_ADD_DIRECT(&head.last);\
 		head.last = entry;\
 	}\
 	typeof (entry) next = D_RO(entry)->field.next;\
 	if (!TOID_IS_NULL(next)) {\
-		pmemobj_tx_add_range_direct(&D_RW(next)->field.prev,\
-				sizeof (D_RW(next)->field.prev));\
+		TX_ADD_DIRECT(&D_RW(next)->field.prev);\
 		D_RW(next)->field.prev = entry;\
 	}\
 } while (0)
@@ -143,31 +142,27 @@ for (entry = ((head)).first; !TOID_IS_NULL(entry) &&\
 #define	PDLL_REMOVE(head, entry, field) do {\
 	if (TOID_EQUALS(head.first, entry) &&\
 		TOID_EQUALS(head.last, entry)) {\
-		pmemobj_tx_add_range_direct(&head.first, sizeof (head.first));\
-		pmemobj_tx_add_range_direct(&head.last, sizeof (head.last));\
+		TX_ADD_DIRECT(&head.first);\
+		TX_ADD_DIRECT(&head.last);\
 		head.first = (typeof (D_RW(entry)->field.prev))OID_NULL;\
 		head.last = (typeof (D_RW(entry)->field.prev))OID_NULL;\
 	} else if (TOID_EQUALS(head.first, entry)) {\
 		typeof (entry) next = D_RW(entry)->field.next;\
-		pmemobj_tx_add_range_direct(&D_RW(next)->field.prev,\
-				sizeof (D_RW(next)->field.prev));\
-		pmemobj_tx_add_range_direct(&head.first, sizeof (head.first));\
+		TX_ADD_DIRECT(&D_RW(next)->field.prev);\
+		TX_ADD_DIRECT(&head.first);\
 		head.first = D_RO(entry)->field.next;\
 		D_RW(next)->field.prev.oid = OID_NULL;\
 	} else if (TOID_EQUALS(head.last, entry)) {\
 		typeof (entry) prev = D_RW(entry)->field.prev;\
-		pmemobj_tx_add_range_direct(&D_RW(prev)->field.next,\
-				sizeof (D_RW(prev)->field.next));\
-		pmemobj_tx_add_range_direct(&head.last, sizeof (head.last));\
+		TX_ADD_DIRECT(&D_RW(prev)->field.next);\
+		TX_ADD_DIRECT(&head.last);\
 		head.last = D_RO(entry)->field.prev;\
 		D_RW(prev)->field.next.oid = OID_NULL;\
 	} else {\
 		typeof (entry) prev = D_RW(entry)->field.prev;\
 		typeof (entry) next = D_RW(entry)->field.next;\
-		pmemobj_tx_add_range_direct(&D_RW(prev)->field.next,\
-				sizeof (D_RW(prev)->field.next));\
-		pmemobj_tx_add_range_direct(&D_RW(next)->field.prev,\
-				sizeof (D_RW(next)->field.prev));\
+		TX_ADD_DIRECT(&D_RW(prev)->field.next);\
+		TX_ADD_DIRECT(&D_RW(next)->field.prev);\
 		D_RW(prev)->field.next = D_RO(entry)->field.next;\
 		D_RW(next)->field.prev = D_RO(entry)->field.prev;\
 	}\

--- a/src/examples/libpmemobj/pminvaders/pminvaders.c
+++ b/src/examples/libpmemobj/pminvaders/pminvaders.c
@@ -385,7 +385,7 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(pminvaders),
-		    PMINVADERS_POOL_SIZE, S_IWUSR | S_IRUSR)) == NULL) {
+		    PMINVADERS_POOL_SIZE, S_IWUSR | S_IRUSR, 0)) == NULL) {
 			printf("failed to create pool\n");
 			return 1;
 		}
@@ -393,7 +393,7 @@ main(int argc, char *argv[])
 		/* create the player and initialize with a constructor */
 		POBJ_NEW(pop, NULL, struct player, create_player, NULL);
 	} else {
-		if ((pop = pmemobj_open(path, LAYOUT_NAME)) == NULL) {
+		if ((pop = pmemobj_open(path, LAYOUT_NAME, 0)) == NULL) {
 			printf("failed to open pool\n");
 			return 1;
 		}

--- a/src/examples/libpmemobj/pminvaders/pminvaders2.c
+++ b/src/examples/libpmemobj/pminvaders/pminvaders2.c
@@ -790,13 +790,13 @@ main(int argc, char *argv[])
 	if (access(argv[1], F_OK)) {
 		if ((pop = pmemobj_create(argv[1],
 				POBJ_LAYOUT_NAME(pminvaders2),
-				POOL_SIZE, S_IRUSR | S_IWUSR)) == NULL) {
+				POOL_SIZE, S_IRUSR | S_IWUSR, 0)) == NULL) {
 			fprintf(stderr, "%s", pmemobj_errormsg());
 			exit(1);
 		}
 	} else {
 		if ((pop = pmemobj_open(argv[1],
-				POBJ_LAYOUT_NAME(pminvaders2))) == NULL) {
+				POBJ_LAYOUT_NAME(pminvaders2), 0)) == NULL) {
 			fprintf(stderr, "%s", pmemobj_errormsg());
 			exit(1);
 		}

--- a/src/examples/libpmemobj/string_store/reader.c
+++ b/src/examples/libpmemobj/string_store/reader.c
@@ -54,7 +54,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root), 0);
 	struct my_root *rootp = pmemobj_direct(root);
 
 	if (rootp->len == strlen(rootp->buf))

--- a/src/examples/libpmemobj/string_store/reader.c
+++ b/src/examples/libpmemobj/string_store/reader.c
@@ -48,7 +48,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMobjpool *pop = pmemobj_open(argv[1], LAYOUT_NAME);
+	PMEMobjpool *pop = pmemobj_open(argv[1], LAYOUT_NAME, 0);
 	if (pop == NULL) {
 		perror("pmemobj_open");
 		return 1;

--- a/src/examples/libpmemobj/string_store/writer.c
+++ b/src/examples/libpmemobj/string_store/writer.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 	}
 
 	PMEMobjpool *pop = pmemobj_create(argv[1], LAYOUT_NAME,
-				PMEMOBJ_MIN_POOL, 0666);
+				PMEMOBJ_MIN_POOL, 0666, 0);
 
 	if (pop == NULL) {
 		perror("pmemobj_create");

--- a/src/examples/libpmemobj/string_store/writer.c
+++ b/src/examples/libpmemobj/string_store/writer.c
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root), 0);
 	struct my_root *rootp = pmemobj_direct(root);
 
 	char buf[MAX_BUF_LEN];

--- a/src/examples/libpmemobj/string_store_tx/reader.c
+++ b/src/examples/libpmemobj/string_store_tx/reader.c
@@ -54,7 +54,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root), 0);
 	struct my_root *rootp = pmemobj_direct(root);
 
 	printf("%s\n", rootp->buf);

--- a/src/examples/libpmemobj/string_store_tx/reader.c
+++ b/src/examples/libpmemobj/string_store_tx/reader.c
@@ -48,7 +48,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMobjpool *pop = pmemobj_open(argv[1], LAYOUT_NAME);
+	PMEMobjpool *pop = pmemobj_open(argv[1], LAYOUT_NAME, 0);
 	if (pop == NULL) {
 		perror("pmemobj_open");
 		return 1;

--- a/src/examples/libpmemobj/string_store_tx/writer.c
+++ b/src/examples/libpmemobj/string_store_tx/writer.c
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 	}
 
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range(root, 0, sizeof (struct my_root));
+		pmemobj_tx_add_range(root, 0, sizeof (struct my_root), 0);
 		memcpy(rootp->buf, buf, strlen(buf));
 	} TX_END
 

--- a/src/examples/libpmemobj/string_store_tx/writer.c
+++ b/src/examples/libpmemobj/string_store_tx/writer.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 	}
 
 	PMEMobjpool *pop = pmemobj_create(argv[1], LAYOUT_NAME,
-				PMEMOBJ_MIN_POOL, 0666);
+				PMEMOBJ_MIN_POOL, 0666, 0);
 
 	if (pop == NULL) {
 		perror("pmemobj_create");

--- a/src/examples/libpmemobj/string_store_tx/writer.c
+++ b/src/examples/libpmemobj/string_store_tx/writer.c
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct my_root), 0);
 	struct my_root *rootp = pmemobj_direct(root);
 
 	char buf[MAX_BUF_LEN];

--- a/src/examples/libpmemobj/string_store_tx_type/reader.c
+++ b/src/examples/libpmemobj/string_store_tx_type/reader.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 	}
 
 	PMEMobjpool *pop = pmemobj_open(argv[1],
-					POBJ_LAYOUT_NAME(string_store));
+					POBJ_LAYOUT_NAME(string_store), 0);
 	if (pop == NULL) {
 		perror("pmemobj_open");
 		return 1;

--- a/src/examples/libpmemobj/string_store_tx_type/writer.c
+++ b/src/examples/libpmemobj/string_store_tx_type/writer.c
@@ -49,7 +49,8 @@ main(int argc, char *argv[])
 	}
 
 	PMEMobjpool *pop = pmemobj_create(argv[1],
-			POBJ_LAYOUT_NAME(string_store), PMEMOBJ_MIN_POOL, 0666);
+			POBJ_LAYOUT_NAME(string_store), PMEMOBJ_MIN_POOL, 0666,
+			0);
 
 	if (pop == NULL) {
 		perror("pmemobj_create");

--- a/src/examples/libpmemobj/tree_map/btree_map.c
+++ b/src/examples/libpmemobj/tree_map/btree_map.c
@@ -642,7 +642,7 @@ btree_map_insert_new(PMEMobjpool *pop, TOID(struct btree_map) map,
 	int ret = 0;
 
 	TX_BEGIN(pop) {
-		PMEMoid n = pmemobj_tx_alloc(size, type_num);
+		PMEMoid n = pmemobj_tx_alloc(size, type_num, 0);
 		constructor(pop, pmemobj_direct(n), arg);
 		btree_map_insert(pop, map, key, n);
 	} TX_ONABORT {

--- a/src/examples/libpmemobj/tree_map/btree_map.c
+++ b/src/examples/libpmemobj/tree_map/btree_map.c
@@ -71,7 +71,7 @@ btree_map_new(PMEMobjpool *pop, TOID(struct btree_map) *map, void *arg)
 	int ret = 0;
 
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		*map = TX_ZNEW(struct btree_map);
 	} TX_ONABORT {
 		ret = 1;
@@ -120,7 +120,7 @@ btree_map_delete(PMEMobjpool *pop, TOID(struct btree_map) *map)
 	int ret = 0;
 	TX_BEGIN(pop) {
 		btree_map_clear(pop, *map);
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		TX_FREE(*map);
 		*map = TOID_NULL(struct btree_map);
 	} TX_ONABORT {

--- a/src/examples/libpmemobj/tree_map/ctree_map.c
+++ b/src/examples/libpmemobj/tree_map/ctree_map.c
@@ -76,7 +76,7 @@ ctree_map_new(PMEMobjpool *pop, TOID(struct ctree_map) *map, void *arg)
 	int ret = 0;
 
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		*map = TX_ZNEW(struct ctree_map);
 	} TX_ONABORT {
 		ret = 1;
@@ -127,7 +127,7 @@ ctree_map_delete(PMEMobjpool *pop, TOID(struct ctree_map) *map)
 	int ret = 0;
 	TX_BEGIN(pop) {
 		ctree_map_clear(pop, *map);
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		TX_FREE(*map);
 		*map = TOID_NULL(struct ctree_map);
 	} TX_ONABORT {
@@ -167,7 +167,7 @@ ctree_map_insert_leaf(struct tree_map_entry *p,
 	/* insert the found destination in the other slot */
 	D_RW(new_node)->entries[!d] = *p;
 
-	pmemobj_tx_add_range_direct(p, sizeof (*p));
+	TX_ADD_DIRECT(p);
 	p->key = 0;
 	p->slot = new_node.oid;
 }
@@ -216,7 +216,7 @@ ctree_map_insert(PMEMobjpool *pop, TOID(struct ctree_map) map,
 	struct tree_map_entry e = {key, value};
 	TX_BEGIN(pop) {
 		if (p->key == 0 || p->key == key) {
-			pmemobj_tx_add_range_direct(p, sizeof (*p));
+			TX_ADD_DIRECT(p);
 			*p = e;
 		} else {
 			ctree_map_insert_leaf(&D_RW(map)->root, e,
@@ -291,7 +291,7 @@ ctree_map_remove(PMEMobjpool *pop, TOID(struct ctree_map) map, uint64_t key)
 
 	if (parent == NULL) { /* root */
 		TX_BEGIN(pop) {
-			pmemobj_tx_add_range_direct(leaf, sizeof (*leaf));
+			TX_ADD_DIRECT(leaf);
 			leaf->key = 0;
 			leaf->slot = OID_NULL;
 		} TX_END
@@ -308,7 +308,7 @@ ctree_map_remove(PMEMobjpool *pop, TOID(struct ctree_map) map, uint64_t key)
 			struct tree_map_entry *dest = parent;
 			TOID(struct tree_map_node) node;
 			TOID_ASSIGN(node, parent->slot);
-			pmemobj_tx_add_range_direct(dest, sizeof (*dest));
+			TX_ADD_DIRECT(dest);
 			*dest = D_RW(node)->entries[
 				D_RO(node)->entries[0].key == leaf->key];
 

--- a/src/examples/libpmemobj/tree_map/ctree_map.c
+++ b/src/examples/libpmemobj/tree_map/ctree_map.c
@@ -184,7 +184,7 @@ ctree_map_insert_new(PMEMobjpool *pop, TOID(struct ctree_map) map,
 	int ret = 0;
 
 	TX_BEGIN(pop) {
-		PMEMoid n = pmemobj_tx_alloc(size, type_num);
+		PMEMoid n = pmemobj_tx_alloc(size, type_num, 0);
 		constructor(pop, pmemobj_direct(n), arg);
 		ctree_map_insert(pop, map, key, n);
 	} TX_ONABORT {

--- a/src/examples/libpmemobj/tree_map/rbtree_map.c
+++ b/src/examples/libpmemobj/tree_map/rbtree_map.c
@@ -102,7 +102,7 @@ rbtree_map_new(PMEMobjpool *pop, TOID(struct rbtree_map) *map, void *arg)
 {
 	int ret = 0;
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		*map = TX_ZNEW(struct rbtree_map);
 
 		TOID(struct tree_map_node) s = TX_ZNEW(struct tree_map_node);
@@ -174,7 +174,7 @@ rbtree_map_delete(PMEMobjpool *pop, TOID(struct rbtree_map) *map)
 	int ret = 0;
 	TX_BEGIN(pop) {
 		rbtree_map_clear(pop, *map);
-		pmemobj_tx_add_range_direct(map, sizeof (*map));
+		TX_ADD_DIRECT(map);
 		TX_FREE(*map);
 		*map = TOID_NULL(struct rbtree_map);
 	} TX_ONABORT {
@@ -230,7 +230,7 @@ rbtree_map_insert_bst(TOID(struct rbtree_map) map, TOID(struct tree_map_node) n)
 
 	TX_SET(n, parent, parent);
 
-	pmemobj_tx_add_range_direct(dst, sizeof (*dst));
+	TX_ADD_DIRECT(dst);
 	*dst = n;
 }
 

--- a/src/examples/libpmemobj/tree_map/rbtree_map.c
+++ b/src/examples/libpmemobj/tree_map/rbtree_map.c
@@ -525,7 +525,7 @@ rbtree_map_insert_new(PMEMobjpool *pop, TOID(struct rbtree_map) map,
 	int ret = 0;
 
 	TX_BEGIN(pop) {
-		PMEMoid n = pmemobj_tx_alloc(size, type_num);
+		PMEMoid n = pmemobj_tx_alloc(size, type_num, 0);
 		constructor(pop, pmemobj_direct(n), arg);
 		rbtree_map_insert(pop, map, key, n);
 	} TX_ONABORT {

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -361,31 +361,31 @@ typedef int (*pmemobj_constr)(PMEMobjpool *pop, void *ptr, void *arg);
  * memory reserved for the object is automatically reclaimed.
  */
 int pmemobj_alloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
-	uint64_t type_num, pmemobj_constr constructor, void *arg);
+	uint64_t type_num, pmemobj_constr constructor, void *arg, int flags);
 
 /*
  * Allocates a new zeroed object from the pool.
  */
 int pmemobj_zalloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
-	uint64_t type_num);
+	uint64_t type_num, int flags);
 
 /*
  * Resizes an existing object.
  */
 int pmemobj_realloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
-	uint64_t type_num);
+	uint64_t type_num, int flags);
 
 /*
  * Resizes an existing object, if extended new space is zeroed.
  */
 int pmemobj_zrealloc(PMEMobjpool *pop, PMEMoid *oidp, size_t size,
-	uint64_t type_num);
+	uint64_t type_num, int flags);
 
 /*
  * Allocates a new object with duplicate of the string s.
  */
 int pmemobj_strdup(PMEMobjpool *pop, PMEMoid *oidp, const char *s,
-	uint64_t type_num);
+	uint64_t type_num, int flags);
 
 /*
  * Frees an existing object.
@@ -414,14 +414,14 @@ uint64_t pmemobj_type_num(PMEMoid oid);
  *
  * This function is thread-safe.
  */
-PMEMoid pmemobj_root(PMEMobjpool *pop, size_t size);
+PMEMoid pmemobj_root(PMEMobjpool *pop, size_t size, int flags);
 
 /*
  * Same as above, but calls the constructor function when the object is first
  * created and on all subsequent reallocations.
  */
 PMEMoid pmemobj_root_construct(PMEMobjpool *pop, size_t size,
-	pmemobj_constr constructor, void *arg);
+	pmemobj_constr constructor, void *arg, int flags);
 
 /*
  * Returns the size in bytes of the root object. Always equal to the requested
@@ -507,37 +507,38 @@ _pobj_ret; })
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
 pmemobj_alloc((pop), _pobj_oidp, sizeof (t), TOID_TYPE_NUM(t), (constr),\
-		(arg)); })
+		(arg), 0); })
 
 #define	POBJ_ALLOC(pop, o, t, size, constr, arg) (\
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
-pmemobj_alloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t), (constr), (arg)); })
+pmemobj_alloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t), (constr), (arg), 0);\
+})
 
 #define	POBJ_ZNEW(pop, o, t) (\
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
-pmemobj_zalloc((pop), _pobj_oidp, sizeof (t), TOID_TYPE_NUM(t)); })
+pmemobj_zalloc((pop), _pobj_oidp, sizeof (t), TOID_TYPE_NUM(t), 0); })
 
 #define	POBJ_ZALLOC(pop, o, t, size) (\
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
-pmemobj_zalloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t)); })
+pmemobj_zalloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t), 0); })
 
 #define	POBJ_REALLOC(pop, o, t, size) (\
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
-pmemobj_realloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t)); })
+pmemobj_realloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM(t), 0); })
 
 #define	POBJ_ZREALLOC(pop, o, t, size) (\
 { TOID(t) *_pobj_tmp = (o);\
 PMEMoid *_pobj_oidp = _pobj_tmp ? &_pobj_tmp->oid : NULL;\
-pmemobj_zrealloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM_OF(*(o))); })
+pmemobj_zrealloc((pop), _pobj_oidp, (size), TOID_TYPE_NUM_OF(*(o)), 0); })
 
 #define	POBJ_FREE(o) pmemobj_free((PMEMoid *)(o))
 
 #define	POBJ_ROOT(pop, t) (\
-{ TOID(t) _pobj_ret = (TOID(t))pmemobj_root((pop), sizeof (t));\
+{ TOID(t) _pobj_ret = (TOID(t))pmemobj_root((pop), sizeof (t), 0);\
 _pobj_ret; })
 
 /*

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -87,11 +87,11 @@ const char *pmemobj_check_version(
 /*
  * Pool management...
  */
-PMEMobjpool *pmemobj_open(const char *path, const char *layout);
+PMEMobjpool *pmemobj_open(const char *path, const char *layout, int flags);
 PMEMobjpool *pmemobj_create(const char *path, const char *layout,
-	size_t poolsize, mode_t mode);
+	size_t poolsize, mode_t mode, int flags);
 void pmemobj_close(PMEMobjpool *pop);
-int pmemobj_check(const char *path, const char *layout);
+int pmemobj_check(const char *path, const char *layout, int flags);
 
 /*
  * Passing NULL to pmemobj_set_funcs() tells libpmemobj to continue to use the

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -908,7 +908,7 @@ _POBJ_TX_BEGIN(pop, ##__VA_ARGS__)
  *
  * This function must be called during TX_STAGE_WORK.
  */
-int pmemobj_tx_add_range(PMEMoid oid, uint64_t off, size_t size);
+int pmemobj_tx_add_range(PMEMoid oid, uint64_t off, size_t size, int flags);
 
 /*
  * Takes a "snapshot" of the given memory region and saves it in the undo log.
@@ -922,7 +922,7 @@ int pmemobj_tx_add_range(PMEMoid oid, uint64_t off, size_t size);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-int pmemobj_tx_add_range_direct(const void *ptr, size_t size);
+int pmemobj_tx_add_range_direct(const void *ptr, size_t size, int flags);
 
 /*
  * Transactionally allocates a new object.
@@ -932,7 +932,7 @@ int pmemobj_tx_add_range_direct(const void *ptr, size_t size);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-PMEMoid pmemobj_tx_alloc(size_t size, uint64_t type_num);
+PMEMoid pmemobj_tx_alloc(size_t size, uint64_t type_num, int flags);
 
 /*
  * Transactionally allocates new zeroed object.
@@ -942,7 +942,7 @@ PMEMoid pmemobj_tx_alloc(size_t size, uint64_t type_num);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-PMEMoid pmemobj_tx_zalloc(size_t size, uint64_t type_num);
+PMEMoid pmemobj_tx_zalloc(size_t size, uint64_t type_num, int flags);
 
 /*
  * Transactionally resizes an existing object.
@@ -952,7 +952,8 @@ PMEMoid pmemobj_tx_zalloc(size_t size, uint64_t type_num);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-PMEMoid pmemobj_tx_realloc(PMEMoid oid, size_t size, uint64_t type_num);
+PMEMoid pmemobj_tx_realloc(PMEMoid oid, size_t size, uint64_t type_num,
+		int flags);
 
 /*
  * Transactionally resizes an existing object, if extended new space is zeroed.
@@ -962,7 +963,8 @@ PMEMoid pmemobj_tx_realloc(PMEMoid oid, size_t size, uint64_t type_num);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-PMEMoid pmemobj_tx_zrealloc(PMEMoid oid, size_t size, uint64_t type_num);
+PMEMoid pmemobj_tx_zrealloc(PMEMoid oid, size_t size, uint64_t type_num,
+		int flags);
 
 /*
  * Transactionally allocates a new object with duplicate of the string s.
@@ -972,7 +974,7 @@ PMEMoid pmemobj_tx_zrealloc(PMEMoid oid, size_t size, uint64_t type_num);
  *
  * This function must be called during TX_STAGE_WORK.
  */
-PMEMoid pmemobj_tx_strdup(const char *s, uint64_t type_num);
+PMEMoid pmemobj_tx_strdup(const char *s, uint64_t type_num, int flags);
 
 /*
  * Transactionally frees an existing object.
@@ -985,46 +987,46 @@ PMEMoid pmemobj_tx_strdup(const char *s, uint64_t type_num);
 int pmemobj_tx_free(PMEMoid oid);
 
 #define	TX_ADD(o)\
-pmemobj_tx_add_range((o).oid, 0, sizeof (*(o)._type))
+pmemobj_tx_add_range((o).oid, 0, sizeof (*(o)._type), 0)
 
 #define	TX_ADD_FIELD(o, field)\
 pmemobj_tx_add_range((o).oid, offsetof(__typeof__ (*(o)._type), field),\
-		sizeof (D_RO(o)->field))
+		sizeof (D_RO(o)->field), 0)
 
 #define	TX_ADD_DIRECT(p)\
-pmemobj_tx_add_range_direct(p, sizeof (*p))
+pmemobj_tx_add_range_direct(p, sizeof (*p), 0)
 
 #define	TX_ADD_FIELD_DIRECT(p, field)\
-pmemobj_tx_add_range_direct(&(p)->field, sizeof ((p)->field))
+pmemobj_tx_add_range_direct(&(p)->field, sizeof ((p)->field), 0)
 
 #define	TX_NEW(t) (\
 { TOID(t) _pobj_ret = (TOID(t))pmemobj_tx_alloc(sizeof (t),\
-TOID_TYPE_NUM(t)); _pobj_ret; })
+TOID_TYPE_NUM(t), 0); _pobj_ret; })
 
 #define	TX_ALLOC(t, size) (\
 { TOID(t) _pobj_ret = (TOID(t))pmemobj_tx_alloc((size),\
-TOID_TYPE_NUM(t)); _pobj_ret; })
+TOID_TYPE_NUM(t), 0); _pobj_ret; })
 
 #define	TX_ZNEW(t) (\
 { TOID(t) _pobj_ret = (TOID(t))pmemobj_tx_zalloc(sizeof (t),\
-TOID_TYPE_NUM(t)); _pobj_ret; })
+TOID_TYPE_NUM(t), 0); _pobj_ret; })
 
 #define	TX_ZALLOC(t, size) (\
 { TOID(t) _pobj_ret = (TOID(t))pmemobj_tx_zalloc((size),\
-TOID_TYPE_NUM(t)); _pobj_ret; })
+TOID_TYPE_NUM(t), 0); _pobj_ret; })
 
 #define	TX_REALLOC(o, size) (\
 { __typeof__(o) _pobj_ret =\
 (__typeof__(o))pmemobj_tx_realloc((o).oid, (size),\
-TOID_TYPE_NUM_OF(o)); _pobj_ret; })
+TOID_TYPE_NUM_OF(o), 0); _pobj_ret; })
 
 #define	TX_ZREALLOC(o, size) (\
 { __typeof__(o) _pobj_ret =\
 (__typeof__(o))pmemobj_tx_zrealloc((o).oid, (size),\
-TOID_TYPE_NUM_OF(o)); _pobj_ret; })
+TOID_TYPE_NUM_OF(o), 0); _pobj_ret; })
 
 #define	TX_STRDUP(s, type_num)\
-pmemobj_tx_strdup(s, type_num)
+pmemobj_tx_strdup(s, type_num, 0)
 
 #define	TX_FREE(o)\
 pmemobj_tx_free((o).oid)
@@ -1042,14 +1044,14 @@ pmemobj_tx_free((o).oid)
 static inline void *
 TX_MEMCPY(void *dest, const void *src, size_t num)
 {
-	pmemobj_tx_add_range_direct(dest, num);
+	pmemobj_tx_add_range_direct(dest, num, 0);
 	return memcpy(dest, src, num);
 }
 
 static inline void *
 TX_MEMSET(void *dest, int c, size_t num)
 {
-	pmemobj_tx_add_range_direct(dest, num);
+	pmemobj_tx_add_range_direct(dest, num, 0);
 	return memset(dest, c, num);
 }
 

--- a/src/include/libpmemobj/detail/common.hpp
+++ b/src/include/libpmemobj/detail/common.hpp
@@ -62,7 +62,7 @@ namespace detail {
 		if (pmemobj_tx_stage() != TX_STAGE_WORK)
 			return;
 
-		if (pmemobj_tx_add_range_direct(that, sizeof (*that)))
+		if (TX_ADD_DIRECT(that))
 			throw transaction_error("Could not add an object to the"
 					" transaction.");
 	}

--- a/src/include/libpmemobj/make_persistent.hpp
+++ b/src/include/libpmemobj/make_persistent.hpp
@@ -71,7 +71,7 @@ namespace obj {
 				"memory outside of transaction scope");
 
 		persistent_ptr<T> ptr = pmemobj_tx_alloc(sizeof (T),
-			detail::type_num<T>());
+			detail::type_num<T>(), 0);
 
 		if (ptr == nullptr)
 			throw transaction_alloc_error("failed to allocate "

--- a/src/include/libpmemobj/make_persistent_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_atomic.hpp
@@ -71,7 +71,7 @@ namespace obj {
 		auto ret = pmemobj_alloc(pool.get_handle(), ptr.raw_ptr(),
 			sizeof (T), detail::type_num<T>(),
 			&detail::obj_constructor<T, Args...>,
-			static_cast<void*>(&arg_pack));
+			static_cast<void*>(&arg_pack), 0);
 
 		if (ret != 0)
 			throw std::bad_alloc();

--- a/src/include/libpmemobj/pool.hpp
+++ b/src/include/libpmemobj/pool.hpp
@@ -95,16 +95,18 @@ namespace obj
 		 *	pool or a pool set.
 		 * @param layout Unique identifier of the pool as specified at
 		 *	pool creation time.
+		 * @param flags
 		 *
 		 * @return handle to the opened pool.
 		 *
 		 * @throw nvml::pool_error when an error during opening occurs.
 		 */
 		static pool_base open(const std::string &path,
-				const std::string &layout)
+				const std::string &layout,
+				int flags = 0)
 		{
 			pmemobjpool *pop = pmemobj_open(path.c_str(),
-					layout.c_str());
+					layout.c_str(), flags);
 			if (pop == nullptr)
 				throw pool_error("Failed opening pool");
 
@@ -122,6 +124,7 @@ namespace obj
 		 * @param size Size of the pool in bytes. If zero and the file
 		 *	exists the pool is created in-place.
 		 * @param mode File mode for the new file.
+		 * @param flags
 		 *
 		 * @return handle to the created pool.
 		 *
@@ -130,10 +133,11 @@ namespace obj
 		static pool_base create(const std::string &path,
 				const std::string &layout,
 				std::size_t size = PMEMOBJ_MIN_POOL,
-				mode_t mode = S_IWUSR | S_IRUSR)
+				mode_t mode = S_IWUSR | S_IRUSR,
+				int flags = 0)
 		{
 			pmemobjpool *pop = pmemobj_create(path.c_str(),
-					layout.c_str(), size, mode);
+					layout.c_str(), size, mode, flags);
 			if (pop == nullptr)
 				throw pool_error("Failed creating pool");
 
@@ -147,13 +151,16 @@ namespace obj
 		 *	pool or a pool set.
 		 * @param layout Unique identifier of the pool as specified at
 		 *	pool creation time.
+		 * @param flags
 		 *
 		 * @return -1 on error, 1 if file is consistent, 0 otherwise.
 		 */
 		static int check(const std::string &path,
-				const std::string &layout) noexcept
+				const std::string &layout,
+				int flags = 0) noexcept
 		{
-			return pmemobj_check(path.c_str(), layout.c_str());
+			return pmemobj_check(path.c_str(), layout.c_str(),
+					flags);
 		}
 
 		/**

--- a/src/include/libpmemobj/pool.hpp
+++ b/src/include/libpmemobj/pool.hpp
@@ -370,7 +370,7 @@ namespace obj
 		persistent_ptr<T> get_root() noexcept
 		{
 			persistent_ptr<T> root = pmemobj_root(this->pop,
-					sizeof (T));
+					sizeof (T), 0);
 			return root;
 		}
 

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -89,9 +89,7 @@ libpmemobj.so {
 		pmemobj_tx_add_range;
 		pmemobj_tx_add_range_direct;
 		pmemobj_tx_alloc;
-		pmemobj_tx_zalloc;
 		pmemobj_tx_realloc;
-		pmemobj_tx_zrealloc;
 		pmemobj_tx_strdup;
 		pmemobj_tx_free;
 		pmemobj_memcpy_persist;

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -63,9 +63,7 @@ libpmemobj.so {
 		pmemobj_pool_by_ptr;
 		pmemobj_direct;
 		pmemobj_alloc;
-		pmemobj_zalloc;
 		pmemobj_realloc;
-		pmemobj_zrealloc;
 		pmemobj_strdup;
 		pmemobj_free;
 		pmemobj_alloc_usable_size;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -669,7 +669,7 @@ pmemobj_runtime_init(PMEMobjpool *pop, int rdonly, int boot)
  */
 PMEMobjpool *
 pmemobj_create(const char *path, const char *layout, size_t poolsize,
-		mode_t mode)
+		mode_t mode, int flags)
 {
 	LOG(3, "path %s layout %s poolsize %zu mode %o",
 			path, layout, poolsize, mode);
@@ -677,6 +677,12 @@ pmemobj_create(const char *path, const char *layout, size_t poolsize,
 	/* check length of layout */
 	if (layout && (strlen(layout) >= PMEMOBJ_MAX_LAYOUT)) {
 		ERR("Layout too long");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (flags) {
+		ERR("unsupported flags %x", flags);
 		errno = EINVAL;
 		return NULL;
 	}
@@ -917,9 +923,15 @@ err:
  * pmemobj_open -- open a transactional memory pool
  */
 PMEMobjpool *
-pmemobj_open(const char *path, const char *layout)
+pmemobj_open(const char *path, const char *layout, int flags)
 {
 	LOG(3, "path %s layout %s", path, layout);
+
+	if (flags) {
+		ERR("unsupported flags %x", flags);
+		errno = EINVAL;
+		return NULL;
+	}
 
 	return pmemobj_open_common(path, layout, Open_cow, 1);
 }
@@ -978,9 +990,15 @@ pmemobj_close(PMEMobjpool *pop)
  * pmemobj_check -- transactional memory pool consistency check
  */
 int
-pmemobj_check(const char *path, const char *layout)
+pmemobj_check(const char *path, const char *layout, int flags)
 {
 	LOG(3, "path %s layout %s", path, layout);
+
+	if (flags) {
+		ERR("unsupported flags %x", flags);
+		errno = EINVAL;
+		return -1;
+	}
 
 	PMEMobjpool *pop = pmemobj_open_common(path, layout, 1, 0);
 	if (pop == NULL)

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -81,6 +81,7 @@ struct lane_tx_runtime {
 
 struct tx_alloc_args {
 	type_num_t type_num;
+	int flags;
 };
 
 struct tx_alloc_copy_args {
@@ -88,6 +89,7 @@ struct tx_alloc_copy_args {
 	size_t size;
 	const void *ptr;
 	size_t copy_size;
+	int flags;
 };
 
 struct tx_add_range_args {
@@ -160,41 +162,8 @@ constructor_tx_alloc(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 	/* do not report changes to the new object */
 	VALGRIND_ADD_TO_TX(ptr, usable_size);
 
-	return 0;
-}
-
-/*
- * constructor_tx_zalloc -- (internal) constructor for zalloc
- */
-static int
-constructor_tx_zalloc(PMEMobjpool *pop, void *ptr,
-	size_t usable_size, void *arg)
-{
-	LOG(3, NULL);
-
-	ASSERTne(ptr, NULL);
-	ASSERTne(arg, NULL);
-
-	struct tx_alloc_args *args = arg;
-
-	struct oob_header *oobh = OOB_HEADER_FROM_PTR(ptr);
-
-	/* temporarily add the OOB header */
-	VALGRIND_ADD_TO_TX(oobh, OBJ_OOB_SIZE);
-
-	/*
-	 * no need to flush and persist because this
-	 * will be done in pre-commit phase
-	 */
-	oobh->type_num = args->type_num;
-	oobh->size = 0;
-
-	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
-
-	/* do not report changes to the new object */
-	VALGRIND_ADD_TO_TX(ptr, usable_size);
-
-	memset(ptr, 0, usable_size);
+	if (args->flags & PMEMOBJ_FLAG_ZERO)
+		memset(ptr, 0, usable_size);
 
 	return 0;
 }
@@ -270,46 +239,16 @@ constructor_tx_copy(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
 
 	/* do not report changes made to the copy */
-	VALGRIND_ADD_TO_TX(ptr, args->size);
+	int zero = (args->flags & PMEMOBJ_FLAG_ZERO) &&
+			usable_size > args->copy_size;
+	if (zero)
+		VALGRIND_ADD_TO_TX(ptr, usable_size);
+	else
+		VALGRIND_ADD_TO_TX(ptr, args->size);
 
 	memcpy(ptr, args->ptr, args->copy_size);
 
-	return 0;
-}
-
-/*
- * constructor_tx_copy_zero -- (internal) copy constructor which zeroes
- * the non-copied area
- */
-static int
-constructor_tx_copy_zero(PMEMobjpool *pop, void *ptr,
-	size_t usable_size, void *arg)
-{
-	LOG(3, NULL);
-
-	ASSERTne(ptr, NULL);
-	ASSERTne(arg, NULL);
-
-	struct tx_alloc_copy_args *args = arg;
-	struct oob_header *oobh = OOB_HEADER_FROM_PTR(ptr);
-
-	/* temporarily add the OOB header */
-	VALGRIND_ADD_TO_TX(oobh, OBJ_OOB_SIZE);
-
-	/*
-	 * no need to flush and persist because this
-	 * will be done in pre-commit phase
-	 */
-	oobh->type_num = args->type_num;
-	oobh->size = 0;
-
-	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
-
-	/* do not report changes made to the copy */
-	VALGRIND_ADD_TO_TX(ptr, usable_size);
-
-	memcpy(ptr, args->ptr, args->copy_size);
-	if (usable_size > args->copy_size) {
+	if (zero) {
 		void *zero_ptr = (void *)((uintptr_t)ptr + args->copy_size);
 		size_t zero_size = usable_size - args->copy_size;
 		memset(zero_ptr, 0, zero_size);
@@ -822,7 +761,8 @@ release_and_free_tx_locks(struct lane_tx_runtime *lane)
  * tx_alloc_common -- (internal) common function for alloc and zalloc
  */
 static PMEMoid
-tx_alloc_common(size_t size, type_num_t type_num, pmalloc_constr constructor)
+tx_alloc_common(size_t size, type_num_t type_num, pmalloc_constr constructor,
+		int flags)
 {
 	LOG(3, NULL);
 
@@ -839,6 +779,7 @@ tx_alloc_common(size_t size, type_num_t type_num, pmalloc_constr constructor)
 
 	struct tx_alloc_args args = {
 		.type_num = type_num,
+		.flags = flags,
 	};
 
 	/* allocate object to undo log */
@@ -862,7 +803,7 @@ err_oom:
  */
 static PMEMoid
 tx_alloc_copy_common(size_t size, type_num_t type_num, const void *ptr,
-	size_t copy_size, pmalloc_constr constructor)
+	size_t copy_size, pmalloc_constr constructor, int flags)
 {
 	LOG(3, NULL);
 
@@ -882,6 +823,7 @@ tx_alloc_copy_common(size_t size, type_num_t type_num, const void *ptr,
 		.size = size,
 		.ptr = ptr,
 		.copy_size = copy_size,
+		.flags = flags,
 	};
 
 	/* allocate object to undo log */
@@ -898,71 +840,6 @@ tx_alloc_copy_common(size_t size, type_num_t type_num, const void *ptr,
 err_oom:
 	ERR("out of memory");
 	return pmemobj_tx_abort_null(ENOMEM);
-}
-
-/*
- * tx_realloc_common -- (internal) common function for tx realloc
- */
-static PMEMoid
-tx_realloc_common(PMEMoid oid, size_t size, uint64_t type_num,
-	pmalloc_constr constructor_alloc,
-	pmalloc_constr constructor_realloc,
-	int flags)
-{
-	LOG(3, NULL);
-
-	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
-		ERR("requested size too large");
-		return pmemobj_tx_abort_null(ENOMEM);
-	}
-
-	if (flags) {
-		ERR("unsupported flags %x", flags);
-		return pmemobj_tx_abort_null(EINVAL);
-	}
-
-	struct lane_tx_runtime *lane =
-		(struct lane_tx_runtime *)tx.section->runtime;
-
-	/* if oid is NULL just alloc */
-	if (OBJ_OID_IS_NULL(oid))
-		return tx_alloc_common(size, (type_num_t)type_num,
-				constructor_alloc);
-
-	ASSERT(OBJ_OID_IS_VALID(lane->pop, oid));
-
-	/* if size is 0 just free */
-	if (size == 0) {
-		if (pmemobj_tx_free(oid)) {
-			ERR("pmemobj_tx_free failed");
-			return oid;
-		} else {
-			return OID_NULL;
-		}
-	}
-
-	/* oid is not NULL and size is not 0 so do realloc by alloc and free */
-	void *ptr = OBJ_OFF_TO_PTR(lane->pop, oid.off);
-	size_t old_size = pmalloc_usable_size(lane->pop,
-			oid.off) - OBJ_OOB_SIZE;
-
-	size_t copy_size = old_size < size ? old_size : size;
-
-	PMEMoid new_obj = tx_alloc_copy_common(size, (type_num_t)type_num,
-			ptr, copy_size, constructor_realloc);
-
-	if (!OBJ_OID_IS_NULL(new_obj)) {
-		if (pmemobj_tx_free(oid)) {
-			ERR("pmemobj_tx_free failed");
-			struct lane_tx_layout *layout =
-				(struct lane_tx_layout *)tx.section->layout;
-			list_remove_free_oob(lane->pop, &layout->undo_alloc,
-					&new_obj);
-			return OID_NULL;
-		}
-	}
-
-	return new_obj;
 }
 
 /*
@@ -1526,38 +1403,13 @@ pmemobj_tx_alloc(size_t size, uint64_t type_num, int flags)
 		return pmemobj_tx_abort_null(EINVAL);
 	}
 
-	if (flags) {
-		ERR("unsupported flags %x", flags);
+	if (flags & ~PMEMOBJ_FLAG_ZERO) {
+		ERR("unsupported flags %x", flags & ~PMEMOBJ_FLAG_ZERO);
 		return pmemobj_tx_abort_null(EINVAL);
 	}
 
 	return tx_alloc_common(size, (type_num_t)type_num,
-			constructor_tx_alloc);
-}
-
-/*
- * pmemobj_tx_zalloc -- allocates a new zeroed object
- */
-PMEMoid
-pmemobj_tx_zalloc(size_t size, uint64_t type_num, int flags)
-{
-	LOG(3, NULL);
-
-	ASSERT_IN_TX();
-	ASSERT_TX_STAGE_WORK();
-
-	if (size == 0) {
-		ERR("allocation with size 0");
-		return pmemobj_tx_abort_null(EINVAL);
-	}
-
-	if (flags) {
-		ERR("unsupported flags %x", flags);
-		return pmemobj_tx_abort_null(EINVAL);
-	}
-
-	return tx_alloc_common(size, (type_num_t)type_num,
-			constructor_tx_zalloc);
+			constructor_tx_alloc, flags);
 }
 
 /*
@@ -1571,24 +1423,58 @@ pmemobj_tx_realloc(PMEMoid oid, size_t size, uint64_t type_num, int flags)
 	ASSERT_IN_TX();
 	ASSERT_TX_STAGE_WORK();
 
-	return tx_realloc_common(oid, size, type_num,
-			constructor_tx_alloc, constructor_tx_copy, flags);
-}
+	if (size > PMEMOBJ_MAX_ALLOC_SIZE) {
+		ERR("requested size too large");
+		return pmemobj_tx_abort_null(ENOMEM);
+	}
 
+	if (flags & ~PMEMOBJ_FLAG_ZERO) {
+		ERR("unsupported flags %x", flags & ~PMEMOBJ_FLAG_ZERO);
+		return pmemobj_tx_abort_null(EINVAL);
+	}
 
-/*
- * pmemobj_zrealloc -- resizes an existing object, any new space is zeroed.
- */
-PMEMoid
-pmemobj_tx_zrealloc(PMEMoid oid, size_t size, uint64_t type_num, int flags)
-{
-	LOG(3, NULL);
+	struct lane_tx_runtime *lane =
+		(struct lane_tx_runtime *)tx.section->runtime;
 
-	ASSERT_IN_TX();
-	ASSERT_TX_STAGE_WORK();
+	/* if oid is NULL just alloc */
+	if (OBJ_OID_IS_NULL(oid))
+		return tx_alloc_common(size, (type_num_t)type_num,
+				constructor_tx_alloc, flags);
 
-	return tx_realloc_common(oid, size, type_num,
-			constructor_tx_zalloc, constructor_tx_copy_zero, flags);
+	ASSERT(OBJ_OID_IS_VALID(lane->pop, oid));
+
+	/* if size is 0 just free */
+	if (size == 0) {
+		if (pmemobj_tx_free(oid)) {
+			ERR("pmemobj_tx_free failed");
+			return oid;
+		} else {
+			return OID_NULL;
+		}
+	}
+
+	/* oid is not NULL and size is not 0 so do realloc by alloc and free */
+	void *ptr = OBJ_OFF_TO_PTR(lane->pop, oid.off);
+	size_t old_size = pmalloc_usable_size(lane->pop,
+			oid.off) - OBJ_OOB_SIZE;
+
+	size_t copy_size = old_size < size ? old_size : size;
+
+	PMEMoid new_obj = tx_alloc_copy_common(size, (type_num_t)type_num,
+			ptr, copy_size, constructor_tx_copy, flags);
+
+	if (!OBJ_OID_IS_NULL(new_obj)) {
+		if (pmemobj_tx_free(oid)) {
+			ERR("pmemobj_tx_free failed");
+			struct lane_tx_layout *layout =
+				(struct lane_tx_layout *)tx.section->layout;
+			list_remove_free_oob(lane->pop, &layout->undo_alloc,
+					&new_obj);
+			return OID_NULL;
+		}
+	}
+
+	return new_obj;
 }
 
 /*
@@ -1616,12 +1502,13 @@ pmemobj_tx_strdup(const char *s, uint64_t type_num, int flags)
 
 	if (len == 0)
 		return tx_alloc_common(sizeof (char), (type_num_t)type_num,
-				constructor_tx_zalloc);
+				constructor_tx_alloc,
+				flags | PMEMOBJ_FLAG_ZERO);
 
 	size_t size = (len + 1) * sizeof (char);
 
 	return tx_alloc_copy_common(size, (type_num_t)type_num, s, size,
-			constructor_tx_copy);
+			constructor_tx_copy, flags);
 }
 
 /*

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -159,7 +159,8 @@ test_alloc_api(PMEMobjpool *pop)
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
-	err = pmemobj_zalloc(pop, NULL, SIZE_MAX, 0, 0);
+	err = pmemobj_alloc(pop, NULL, SIZE_MAX, 0, NULL, NULL,
+			PMEMOBJ_FLAG_ZERO);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
@@ -168,7 +169,8 @@ test_alloc_api(PMEMobjpool *pop)
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
-	err = pmemobj_zalloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, 0);
+	err = pmemobj_alloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, NULL,
+			NULL, PMEMOBJ_FLAG_ZERO);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 }

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -155,20 +155,20 @@ test_alloc_api(PMEMobjpool *pop)
 
 	int err = 0;
 
-	err = pmemobj_alloc(pop, NULL, SIZE_MAX, 0, NULL, NULL);
+	err = pmemobj_alloc(pop, NULL, SIZE_MAX, 0, NULL, NULL, 0);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
-	err = pmemobj_zalloc(pop, NULL, SIZE_MAX, 0);
+	err = pmemobj_zalloc(pop, NULL, SIZE_MAX, 0, 0);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
 	err = pmemobj_alloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, NULL,
-		NULL);
+		NULL, 0);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 
-	err = pmemobj_zalloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0);
+	err = pmemobj_zalloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, 0);
 	ASSERTeq(err, -1);
 	ASSERTeq(errno, ENOMEM);
 }
@@ -179,41 +179,41 @@ test_realloc_api(PMEMobjpool *pop)
 	PMEMoid oid = OID_NULL;
 	int ret;
 
-	ret = pmemobj_alloc(pop, &oid, 128, 0, NULL, NULL);
+	ret = pmemobj_alloc(pop, &oid, 128, 0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("alloc: %u, size: %zu", 128,
 			pmemobj_alloc_usable_size(oid));
 
 	/* grow */
-	ret = pmemobj_realloc(pop, &oid, 655360, 0);
+	ret = pmemobj_realloc(pop, &oid, 655360, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 128, 655360,
 			pmemobj_alloc_usable_size(oid));
 
 	/* shrink */
-	ret = pmemobj_realloc(pop, &oid, 1, 0);
+	ret = pmemobj_realloc(pop, &oid, 1, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 655360, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	/* free */
-	ret = pmemobj_realloc(pop, &oid, 0, 0);
+	ret = pmemobj_realloc(pop, &oid, 0, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(OID_IS_NULL(oid));
 	OUT("free");
 
 	/* alloc */
-	ret = pmemobj_realloc(pop, &oid, 777, 0);
+	ret = pmemobj_realloc(pop, &oid, 777, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 0, 777,
 			pmemobj_alloc_usable_size(oid));
 
 	/* shrink */
-	ret = pmemobj_realloc(pop, &oid, 1, 0);
+	ret = pmemobj_realloc(pop, &oid, 1, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 777, 1,
@@ -224,14 +224,14 @@ test_realloc_api(PMEMobjpool *pop)
 	OUT("free");
 
 	/* alloc */
-	ret = pmemobj_realloc(pop, &oid, 1, 0);
+	ret = pmemobj_realloc(pop, &oid, 1, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 0, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	/* do nothing */
-	ret = pmemobj_realloc(pop, &oid, 1, 0);
+	ret = pmemobj_realloc(pop, &oid, 1, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 	OUT("realloc: %u => %u, size: %zu", 1, 1,
@@ -242,21 +242,21 @@ test_realloc_api(PMEMobjpool *pop)
 	OUT("free");
 
 	/* do nothing */
-	ret = pmemobj_realloc(pop, &oid, 0, 0);
+	ret = pmemobj_realloc(pop, &oid, 0, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(OID_IS_NULL(oid));
 
 	/* alloc */
-	ret = pmemobj_realloc(pop, &oid, 1, 0);
+	ret = pmemobj_realloc(pop, &oid, 1, 0, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!OID_IS_NULL(oid));
 
 	/* grow beyond reasonable size */
-	ret = pmemobj_realloc(pop, &oid, SIZE_MAX, 0);
+	ret = pmemobj_realloc(pop, &oid, SIZE_MAX, 0, 0);
 	ASSERTeq(ret, -1);
 	ASSERTeq(errno, ENOMEM);
 
-	ret = pmemobj_realloc(pop, &oid, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0);
+	ret = pmemobj_realloc(pop, &oid, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, 0);
 	ASSERTeq(ret, -1);
 	ASSERTeq(errno, ENOMEM);
 
@@ -410,7 +410,7 @@ static void
 test_tx_api(PMEMobjpool *pop)
 {
 	TOID(struct dummy_root) root;
-	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct dummy_root)));
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct dummy_root), 0));
 
 	int *vstate = NULL; /* volatile state */
 

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -541,7 +541,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(basic),
-			0, S_IWUSR | S_IRUSR)) == NULL)
+			0, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	test_alloc_api(pop);

--- a/src/test/obj_check/obj_check.c
+++ b/src/test/obj_check/obj_check.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 
 	const char *path = argv[1];
 
-	int ret = pmemobj_check(path, NULL);
+	int ret = pmemobj_check(path, NULL, 0);
 
 	switch (ret) {
 	case 1:

--- a/src/test/obj_constructor/obj_constructor.c
+++ b/src/test/obj_constructor/obj_constructor.c
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 	 */
 	int allocs = 0;
 	while (pmemobj_alloc(pop, NULL, sizeof (struct node), 1,
-			NULL, NULL) == 0)
+			NULL, NULL, 0) == 0)
 		allocs++;
 
 	ASSERTne(allocs, 0);
@@ -105,26 +105,26 @@ main(int argc, char *argv[])
 
 	errno = 0;
 	root.oid = pmemobj_root_construct(pop, sizeof (struct root),
-			root_constr_cancel, NULL);
+			root_constr_cancel, NULL, 0);
 	ASSERT(TOID_IS_NULL(root));
 	ASSERTeq(errno, ECANCELED);
 
 	errno = 0;
 	ret = pmemobj_alloc(pop, NULL, sizeof (struct node), 1,
-			node_constr_cancel, NULL);
+			node_constr_cancel, NULL, 0);
 	ASSERTeq(ret, -1);
 	ASSERTeq(errno, ECANCELED);
 
 	/* the same number of allocations should be possible. */
 	while (pmemobj_alloc(pop, NULL, sizeof (struct node), 1,
-			NULL, NULL) == 0)
+			NULL, NULL, 0) == 0)
 		allocs--;
 	ASSERTeq(allocs, 0);
 	POBJ_FOREACH_SAFE(pop, oid, next)
 		pmemobj_free(&oid);
 
 	root.oid = pmemobj_root_construct(pop, sizeof (struct root),
-			NULL, NULL);
+			NULL, NULL, 0);
 	ASSERT(!TOID_IS_NULL(root));
 
 	errno = 0;

--- a/src/test/obj_constructor/obj_constructor.c
+++ b/src/test/obj_constructor/obj_constructor.c
@@ -84,7 +84,7 @@ main(int argc, char *argv[])
 	TOID(struct node) node;
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(constr),
-			0, S_IWUSR | S_IRUSR)) == NULL)
+			0, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	/*

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
@@ -118,7 +118,7 @@ test_make_args(pool<struct root> &pop)
 	TX_BEGIN(pop.get_handle()) {
 		ASSERT(r->pfoo == nullptr);
 
-		pmemobj_tx_add_range_direct(&r->pfoo, sizeof(r->pfoo));
+		TX_ADD_DIRECT(&r->pfoo);
 		r->pfoo = make_persistent<foo>(2);
 		r->pfoo->check_foo(2, 2);
 

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -71,7 +71,7 @@ struct root {
  */
 persistent_ptr<root> init_foobar(pmemobjpool *pop)
 {
-	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
+	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root), 0);
 		TX_BEGIN(pop) {
 			ASSERT(r->bar_ptr == nullptr);
 			ASSERT(r->foo_ptr == nullptr);
@@ -97,7 +97,7 @@ persistent_ptr<root> init_foobar(pmemobjpool *pop)
  */
 void cleanup_foobar(pmemobjpool *pop)
 {
-	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
+	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root), 0);
 
 	TX_BEGIN(pop) {
 		ASSERT(r->bar_ptr != nullptr);

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -76,8 +76,8 @@ persistent_ptr<root> init_foobar(pmemobjpool *pop)
 			ASSERT(r->bar_ptr == nullptr);
 			ASSERT(r->foo_ptr == nullptr);
 
-			r->bar_ptr = pmemobj_tx_alloc(sizeof (bar), 0);
-			r->foo_ptr = pmemobj_tx_alloc(sizeof (foo), 0);
+			r->bar_ptr = pmemobj_tx_alloc(sizeof (bar), 0, 0);
+			r->foo_ptr = pmemobj_tx_alloc(sizeof (foo), 0, 0);
 
 			r->bar_ptr->pdouble = 1.0;
 			r->bar_ptr->pfloat = 2.0;

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -303,7 +303,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
-			S_IWUSR | S_IRUSR)) == NULL)
+			S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	arithmetic_test(pop);

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -159,7 +159,7 @@ test_ptr_transactional(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		ASSERT(r->pfoo == nullptr);
 
-		r->pfoo = pmemobj_tx_alloc(sizeof (foo), 0);
+		r->pfoo = pmemobj_tx_alloc(sizeof (foo), 0, 0);
 
 	} TX_ONABORT {
 		ASSERT(0);
@@ -221,7 +221,7 @@ test_ptr_array(PMEMobjpool *pop)
 	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
 
 	TX_BEGIN(pop) {
-		r->parr = pmemobj_tx_zalloc(sizeof (int) * TEST_ARR_SIZE, 0);
+		r->parr = pmemobj_tx_zalloc(sizeof (int) * TEST_ARR_SIZE, 0, 0);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -130,7 +130,7 @@ test_ptr_atomic(PMEMobjpool *pop)
 	persistent_ptr<foo> pfoo;
 
 	ret = pmemobj_alloc(pop, pfoo.raw_ptr(), sizeof (foo),
-		0, NULL, NULL);
+		0, NULL, NULL, 0);
 
 	ASSERTeq(ret, 0);
 	ASSERTne(pfoo.get(), NULL);
@@ -154,7 +154,7 @@ test_ptr_atomic(PMEMobjpool *pop)
 void
 test_ptr_transactional(PMEMobjpool *pop)
 {
-	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
+	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root), 0);
 
 	TX_BEGIN(pop) {
 		ASSERT(r->pfoo == nullptr);
@@ -209,7 +209,7 @@ test_ptr_array(PMEMobjpool *pop)
 	persistent_ptr<p<int>[]> parr_vsize;
 	ret = pmemobj_alloc(pop, parr_vsize.raw_ptr(),
 		sizeof (int) * TEST_ARR_SIZE,
-		0, NULL, NULL);
+		0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 
 	for (int i = 0; i < TEST_ARR_SIZE; ++i)
@@ -218,7 +218,7 @@ test_ptr_array(PMEMobjpool *pop)
 	for (int i = 0; i < TEST_ARR_SIZE; ++i)
 		ASSERTeq(parr_vsize[i], i);
 
-	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
+	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root), 0);
 
 	TX_BEGIN(pop) {
 		r->parr = pmemobj_tx_alloc(sizeof (int) * TEST_ARR_SIZE, 0,

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -221,7 +221,8 @@ test_ptr_array(PMEMobjpool *pop)
 	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
 
 	TX_BEGIN(pop) {
-		r->parr = pmemobj_tx_zalloc(sizeof (int) * TEST_ARR_SIZE, 0, 0);
+		r->parr = pmemobj_tx_alloc(sizeof (int) * TEST_ARR_SIZE, 0,
+				PMEMOBJ_FLAG_ZERO);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -256,7 +256,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop = NULL;
 
-	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	test_ptr_operators_null();

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
@@ -62,7 +62,7 @@ prepare_array(PMEMobjpool *pop)
 	persistent_ptr<T> parr_vsize;
 	ret = pmemobj_alloc(pop, parr_vsize.raw_ptr(),
 		sizeof (T) * TEST_ARR_SIZE,
-		0, NULL, NULL);
+		0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 
 	T *parray = parr_vsize.get();

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
@@ -200,7 +200,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
-			S_IWUSR | S_IRUSR)) == NULL)
+			S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	test_arith(pop);

--- a/src/test/obj_debug/obj_debug.c
+++ b/src/test/obj_debug/obj_debug.c
@@ -185,7 +185,8 @@ test_double_free(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	PMEMoid oid, oid2;
-	int err = pmemobj_zalloc(pop, &oid, 100, 0, 0);
+	int err = pmemobj_alloc(pop, &oid, 100, 0,  NULL, NULL,
+			PMEMOBJ_FLAG_ZERO);
 	ASSERTeq(err, 0);
 	ASSERT(!OID_IS_NULL(oid));
 

--- a/src/test/obj_debug/obj_debug.c
+++ b/src/test/obj_debug/obj_debug.c
@@ -87,7 +87,7 @@ test_FOREACH(const char *path)
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
-	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root), 0));
 	POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->lhead, next,
 			sizeof (struct tobj), NULL, NULL);
 
@@ -126,7 +126,7 @@ test_lists(const char *path)
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
-	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
+	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root), 0));
 
 	COMMANDS_LISTS();
 	TX_BEGIN(pop) {
@@ -167,7 +167,7 @@ test_alloc_construct(const char *path)
 		struct int3_s args = { 1, 2, 3 };
 		PMEMoid allocation;
 		pmemobj_alloc(pop, &allocation, sizeof (allocation), 1,
-				int3_constructor, &args);
+				int3_constructor, &args, 0);
 	} TX_ONABORT {
 		ASSERT(0);
 	} TX_END
@@ -185,7 +185,7 @@ test_double_free(const char *path)
 		FATAL("!pmemobj_create: %s", path);
 
 	PMEMoid oid, oid2;
-	int err = pmemobj_zalloc(pop, &oid, 100, 0);
+	int err = pmemobj_zalloc(pop, &oid, 100, 0, 0);
 	ASSERTeq(err, 0);
 	ASSERT(!OID_IS_NULL(oid));
 

--- a/src/test/obj_debug/obj_debug.c
+++ b/src/test/obj_debug/obj_debug.c
@@ -84,7 +84,7 @@ test_FOREACH(const char *path)
 	} while (0)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
@@ -123,7 +123,7 @@ test_lists(const char *path)
 	} while (0)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
@@ -160,7 +160,7 @@ test_alloc_construct(const char *path)
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	TX_BEGIN(pop) {
@@ -181,7 +181,7 @@ test_double_free(const char *path)
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	PMEMoid oid, oid2;

--- a/src/test/obj_direct/obj_direct.c
+++ b/src/test/obj_direct/obj_direct.c
@@ -105,11 +105,11 @@ main(int argc, char *argv[])
 		ASSERTeq((char *)pmemobj_direct(oids[i]) - off,
 			(char *)pops[i]);
 
-		r = pmemobj_alloc(pops[i], &tmpoids[i], 100, 1, NULL, NULL);
+		r = pmemobj_alloc(pops[i], &tmpoids[i], 100, 1, NULL, NULL, 0);
 		ASSERTeq(r, 0);
 	}
 
-	r = pmemobj_alloc(pops[0], &thread_oid, 100, 2, NULL, NULL);
+	r = pmemobj_alloc(pops[0], &thread_oid, 100, 2, NULL, NULL, 0);
 	ASSERTeq(r, 0);
 	ASSERTne(pmemobj_direct(thread_oid), NULL);
 

--- a/src/test/obj_direct/obj_direct.c
+++ b/src/test/obj_direct/obj_direct.c
@@ -84,7 +84,7 @@ main(int argc, char *argv[])
 	for (int i = 0; i < npools; ++i) {
 		snprintf(path, MAX_PATH_LEN, "%s/testfile%d", dir, i);
 		pops[i] = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-				S_IWUSR | S_IRUSR);
+				S_IWUSR | S_IRUSR, 0);
 
 		if (pops[i] == NULL)
 			FATAL("!pmemobj_create");

--- a/src/test/obj_first_next/obj_first_next.c
+++ b/src/test/obj_first_next/obj_first_next.c
@@ -275,7 +275,7 @@ test_internal_object_mask(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		/* trigger creation of a range cache */
-		pmemobj_tx_add_range(root, 0, 8);
+		pmemobj_tx_add_range(root, 0, 8, 0);
 	} TX_END
 
 	PMEMoid oid;

--- a/src/test/obj_first_next/obj_first_next.c
+++ b/src/test/obj_first_next/obj_first_next.c
@@ -298,7 +298,7 @@ main(int argc, char *argv[])
 
 	const char *path = argv[1];
 	if ((pop = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-						S_IWUSR | S_IRUSR)) == NULL)
+						S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	for (int i = 2; i < argc; i++) {

--- a/src/test/obj_first_next/obj_first_next.c
+++ b/src/test/obj_first_next/obj_first_next.c
@@ -271,7 +271,7 @@ static void
 test_internal_object_mask(PMEMobjpool *pop)
 {
 	/* allocate root object */
-	PMEMoid root = pmemobj_root(pop, sizeof (struct type));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct type), 0);
 
 	TX_BEGIN(pop) {
 		/* trigger creation of a range cache */
@@ -279,7 +279,7 @@ test_internal_object_mask(PMEMobjpool *pop)
 	} TX_END
 
 	PMEMoid oid;
-	pmemobj_alloc(pop, &oid, sizeof (struct type), 0, NULL, NULL);
+	pmemobj_alloc(pop, &oid, sizeof (struct type), 0, NULL, NULL, 0);
 	ASSERT(!OID_IS_NULL(oid));
 
 	/* verify that there's no root object nor range cache anywhere */

--- a/src/test/obj_heap_state/obj_heap_state.c
+++ b/src/test/obj_heap_state/obj_heap_state.c
@@ -70,14 +70,14 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			0, S_IWUSR | S_IRUSR)) == NULL)
+			0, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	pmemobj_root(pop, ROOT_SIZE); /* just to trigger allocation */
 
 	pmemobj_close(pop);
 
-	pop = pmemobj_open(path, LAYOUT_NAME);
+	pop = pmemobj_open(path, LAYOUT_NAME, 0);
 	ASSERTne(pop, NULL);
 
 	for (int i = 0; i < ALLOCS; ++i) {

--- a/src/test/obj_heap_state/obj_heap_state.c
+++ b/src/test/obj_heap_state/obj_heap_state.c
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
 			0, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
-	pmemobj_root(pop, ROOT_SIZE); /* just to trigger allocation */
+	pmemobj_root(pop, ROOT_SIZE, 0); /* just to trigger allocation */
 
 	pmemobj_close(pop);
 
@@ -83,7 +83,7 @@ main(int argc, char *argv[])
 	for (int i = 0; i < ALLOCS; ++i) {
 		PMEMoid oid;
 		pmemobj_alloc(pop, &oid, ALLOC_SIZE, 0,
-				test_constructor, NULL);
+				test_constructor, NULL, 0);
 		OUT("%d %lu", i, oid.off);
 	}
 

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -863,7 +863,7 @@ do_insert(PMEMobjpool *pop, const char *arg)
 
 	PMEMoid it;
 	pmemobj_alloc(pop, &it,
-			sizeof (struct oob_item), 0, NULL, NULL);
+			sizeof (struct oob_item), 0, NULL, NULL, 0);
 
 	if (list_insert(pop,
 		offsetof(struct item, next),

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -1028,7 +1028,7 @@ main(int argc, char *argv[])
 	util_init(); /* to initialize On_valgrind flag */
 
 	UT_COMPILE_ERROR_ON(OOB_OFF != 48);
-	PMEMobjpool *pop = pmemobj_open(path, NULL);
+	PMEMobjpool *pop = pmemobj_open(path, NULL, 0);
 	ASSERTne(pop, NULL);
 
 	ASSERT(!TOID_IS_NULL(List));

--- a/src/test/obj_list_macro/obj_list_macro.c
+++ b/src/test/obj_list_macro/obj_list_macro.c
@@ -366,7 +366,7 @@ main(int argc, char *argv[])
 	const char *path = argv[1];
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-						S_IWUSR | S_IRUSR)) == NULL)
+						S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	POBJ_ZNEW(pop, &List, struct list);

--- a/src/test/obj_many_size_allocs/obj_many_size_allocs.c
+++ b/src/test/obj_many_size_allocs/obj_many_size_allocs.c
@@ -64,13 +64,13 @@ test_allocs(PMEMobjpool *pop, const char *path)
 {
 	PMEMoid oid[TEST_ALLOC_SIZE];
 
-	if (pmemobj_alloc(pop, &oid[0], 0, 0, NULL, NULL) == 0)
+	if (pmemobj_alloc(pop, &oid[0], 0, 0, NULL, NULL, 0) == 0)
 		FATAL("pmemobj_alloc(0) succeeded");
 
 	for (int i = 1; i < TEST_ALLOC_SIZE; ++i) {
 		struct cargs args = { i };
 		if (pmemobj_alloc(pop, &oid[i], i, 0,
-				test_constructor, &args) != 0)
+				test_constructor, &args, 0) != 0)
 			FATAL("!pmemobj_alloc");
 		ASSERT(!OID_IS_NULL(oid[i]));
 	}
@@ -94,11 +94,11 @@ test_lazy_load(PMEMobjpool *pop, const char *path)
 {
 	PMEMoid oid[3];
 
-	int ret = pmemobj_alloc(pop, &oid[0], LAZY_LOAD_SIZE, 0, NULL, NULL);
+	int ret = pmemobj_alloc(pop, &oid[0], LAZY_LOAD_SIZE, 0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
-	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_SIZE, 0, NULL, NULL);
+	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_SIZE, 0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
-	ret = pmemobj_alloc(pop, &oid[2], LAZY_LOAD_SIZE, 0, NULL, NULL);
+	ret = pmemobj_alloc(pop, &oid[2], LAZY_LOAD_SIZE, 0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 
 	pmemobj_close(pop);
@@ -106,7 +106,7 @@ test_lazy_load(PMEMobjpool *pop, const char *path)
 
 	pmemobj_free(&oid[1]);
 
-	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_BIG_SIZE, 0, NULL, NULL);
+	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_BIG_SIZE, 0, NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 }
 

--- a/src/test/obj_many_size_allocs/obj_many_size_allocs.c
+++ b/src/test/obj_many_size_allocs/obj_many_size_allocs.c
@@ -77,9 +77,9 @@ test_allocs(PMEMobjpool *pop, const char *path)
 
 	pmemobj_close(pop);
 
-	ASSERT(pmemobj_check(path, LAYOUT_NAME) == 1);
+	ASSERT(pmemobj_check(path, LAYOUT_NAME, 0) == 1);
 
-	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
+	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME, 0)) != NULL);
 
 	for (int i = 1; i < TEST_ALLOC_SIZE; ++i) {
 		pmemobj_free(&oid[i]);
@@ -102,7 +102,7 @@ test_lazy_load(PMEMobjpool *pop, const char *path)
 	ASSERTeq(ret, 0);
 
 	pmemobj_close(pop);
-	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
+	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME, 0)) != NULL);
 
 	pmemobj_free(&oid[1]);
 
@@ -124,7 +124,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			0, S_IWUSR | S_IRUSR)) == NULL)
+			0, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	test_lazy_load(pop, path);

--- a/src/test/obj_memcheck/obj_memcheck.c
+++ b/src/test/obj_memcheck/obj_memcheck.c
@@ -76,7 +76,7 @@ test_everything(const char *path)
 	PMEMobjpool *pop = NULL;
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(mc),
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	struct root *rt = D_RW(POBJ_ROOT(pop, struct root));

--- a/src/test/obj_out_of_memory/obj_out_of_memory.c
+++ b/src/test/obj_out_of_memory/obj_out_of_memory.c
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 		const char *path = argv[i];
 
 		PMEMobjpool *pop = pmemobj_create(path, LAYOUT_NAME, 0,
-					S_IWUSR | S_IRUSR);
+					S_IWUSR | S_IRUSR, 0);
 		if (pop == NULL)
 			FATAL("!pmemobj_create: %s", path);
 
@@ -100,7 +100,7 @@ main(int argc, char *argv[])
 
 		pmemobj_close(pop);
 
-		ASSERTeq(pmemobj_check(path, LAYOUT_NAME), 1);
+		ASSERTeq(pmemobj_check(path, LAYOUT_NAME, 0), 1);
 
 		/*
 		 * To prevent subsequent opens from receiving exactly the same
@@ -110,7 +110,7 @@ main(int argc, char *argv[])
 		 */
 		void *heap_touch = MALLOC(1);
 
-		ASSERTne(pop = pmemobj_open(path, LAYOUT_NAME), NULL);
+		ASSERTne(pop = pmemobj_open(path, LAYOUT_NAME, 0), NULL);
 
 		test_free(pop);
 

--- a/src/test/obj_out_of_memory/obj_out_of_memory.c
+++ b/src/test/obj_out_of_memory/obj_out_of_memory.c
@@ -60,7 +60,7 @@ test_alloc(PMEMobjpool *pop, size_t size)
 	while (1) {
 		struct cargs args = { size };
 		if (pmemobj_alloc(pop, NULL, size, 0,
-				test_constructor, &args) != 0)
+				test_constructor, &args, 0) != 0)
 			break;
 		cnt++;
 	}

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -140,7 +140,7 @@ main(int argc, char *argv[])
 	struct foo *f = pmemobj_direct(root);
 
 	TX_BEGIN(pop) {
-		f->bar = pmemobj_tx_alloc(sizeof (struct foo), 0);
+		f->bar = pmemobj_tx_alloc(sizeof (struct foo), 0, 0);
 		ASSERT(!OID_IS_NULL(f->bar));
 	} TX_END
 	print_reset_counters("tx_alloc");

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
 	print_reset_counters("tx_free");
 
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range_direct(&f->val, sizeof (f->val));
+		TX_ADD_DIRECT(&f->val);
 	} TX_END
 	print_reset_counters("tx_add");
 

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(path, "persist_count",
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	OUT("persist\t;msync\t;flush\t;drain\t;task");

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -122,15 +122,16 @@ main(int argc, char *argv[])
 	print_reset_counters("pool_create");
 
 	/* allocate one structure to create a run */
-	pmemobj_alloc(pop, NULL, sizeof (struct foo), 0, NULL, NULL);
+	pmemobj_alloc(pop, NULL, sizeof (struct foo), 0, NULL, NULL, 0);
 	reset_counters();
 
-	PMEMoid root = pmemobj_root(pop, sizeof (struct foo));
+	PMEMoid root = pmemobj_root(pop, sizeof (struct foo), 0);
 	ASSERT(!OID_IS_NULL(root));
 	print_reset_counters("root_alloc");
 
 	PMEMoid oid;
-	int ret = pmemobj_alloc(pop, &oid, sizeof (struct foo), 0, NULL, NULL);
+	int ret = pmemobj_alloc(pop, &oid, sizeof (struct foo), 0, NULL, NULL,
+			0);
 	ASSERTeq(ret, 0);
 	print_reset_counters("atomic_alloc");
 

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -178,9 +178,9 @@ main(int argc, char *argv[])
 
 	if (access(argv[1], F_OK) != 0) {
 		pop = pmemobj_create(argv[1], "TEST",
-		THREADS * OPS_PER_THREAD * ALLOC_SIZE * FRAGMENTATION, 0666);
+		THREADS * OPS_PER_THREAD * ALLOC_SIZE * FRAGMENTATION, 0666, 0);
 	} else {
-		if ((pop = pmemobj_open(argv[1], "TEST")) == NULL) {
+		if ((pop = pmemobj_open(argv[1], "TEST", 0)) == NULL) {
 			printf("failed to open pool\n");
 			return 1;
 		}

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -146,7 +146,7 @@ alloc_free_worker(void *arg)
 	PMEMoid oid;
 	for (int i = 0; i < OPS_PER_THREAD; ++i) {
 		int err = pmemobj_alloc(a->pop, &oid, ALLOC_SIZE,
-				0, NULL, NULL);
+				0, NULL, NULL, 0);
 		ASSERTeq(err, 0);
 		pmemobj_free(&oid);
 	}
@@ -189,7 +189,7 @@ main(int argc, char *argv[])
 	if (pop == NULL)
 		FATAL("!pmemobj_create");
 
-	PMEMoid oid = pmemobj_root(pop, sizeof (struct root));
+	PMEMoid oid = pmemobj_root(pop, sizeof (struct root), 0);
 	struct root *r = pmemobj_direct(oid);
 	ASSERTne(r, NULL);
 

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -132,7 +132,7 @@ tx_worker(void *arg)
 	 */
 	TX_BEGIN(a->pop) {
 		for (;;) /* this is NOT an infinite loop */
-			pmemobj_tx_alloc(ALLOC_SIZE, a->idx);
+			pmemobj_tx_alloc(ALLOC_SIZE, a->idx, 0);
 	} TX_END
 
 	return NULL;

--- a/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
+++ b/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
@@ -49,7 +49,7 @@ static void *
 oom_worker(void *arg)
 {
 	allocated = 0;
-	while (pmemobj_alloc(pop, NULL, TEST_ALLOC_SIZE, 0, NULL, NULL) == 0)
+	while (pmemobj_alloc(pop, NULL, TEST_ALLOC_SIZE, 0, NULL, NULL, 0) == 0)
 		allocated++;
 
 	PMEMoid iter, iter2;

--- a/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
+++ b/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
 	const char *path = argv[1];
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
 	pthread_t t;

--- a/src/test/obj_pool/obj_pool.c
+++ b/src/test/obj_pool/obj_pool.c
@@ -49,7 +49,7 @@ static void
 pool_create(const char *path, const char *layout, size_t poolsize,
 	unsigned mode)
 {
-	PMEMobjpool *pop = pmemobj_create(path, layout, poolsize, mode);
+	PMEMobjpool *pop = pmemobj_create(path, layout, poolsize, mode, 0);
 
 	if (pop == NULL)
 		OUT("!%s: pmemobj_create", path);
@@ -63,7 +63,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 
 		pmemobj_close(pop);
 
-		int result = pmemobj_check(path, layout);
+		int result = pmemobj_check(path, layout, 0);
 
 		if (result < 0)
 			OUT("!%s: pmemobj_check", path);
@@ -75,7 +75,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 static void
 pool_open(const char *path, const char *layout)
 {
-	PMEMobjpool *pop = pmemobj_open(path, layout);
+	PMEMobjpool *pop = pmemobj_open(path, layout, 0);
 	if (pop == NULL)
 		OUT("!%s: pmemobj_open", path);
 	else {

--- a/src/test/obj_pool_lock/obj_pool_lock.c
+++ b/src/test/obj_pool_lock/obj_pool_lock.c
@@ -43,11 +43,11 @@ static void
 test_reopen(const char *path)
 {
 	PMEMobjpool *pop1 = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
-			S_IWUSR | S_IRUSR);
+			S_IWUSR | S_IRUSR, 0);
 	if (!pop1)
 		FATAL("!create");
 
-	PMEMobjpool *pop2 = pmemobj_open(path, LAYOUT);
+	PMEMobjpool *pop2 = pmemobj_open(path, LAYOUT, 0);
 	if (pop2)
 		FATAL("pmemobj_open should not succeed");
 
@@ -56,7 +56,7 @@ test_reopen(const char *path)
 
 	pmemobj_close(pop1);
 
-	pop2 = pmemobj_open(path, LAYOUT);
+	pop2 = pmemobj_open(path, LAYOUT, 0);
 	if (!pop2)
 		FATAL("pmemobj_open should succeed after close");
 
@@ -81,7 +81,7 @@ test_open_in_different_process(const char *path, int sleep)
 		while (access(path, R_OK))
 			usleep(100 * 1000);
 
-		pop = pmemobj_open(path, LAYOUT);
+		pop = pmemobj_open(path, LAYOUT, 0);
 		if (pop)
 			FATAL("pmemobj_open after fork should not succeed");
 
@@ -92,7 +92,8 @@ test_open_in_different_process(const char *path, int sleep)
 		exit(0);
 	}
 
-	pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
+	pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR,
+			0);
 	if (!pop)
 		FATAL("!create");
 

--- a/src/test/obj_pool_lookup/obj_pool_lookup.c
+++ b/src/test/obj_pool_lookup/obj_pool_lookup.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 	for (int i = 0; i < npools; ++i) {
 		snprintf(path, MAX_PATH_LEN, "%s/testfile%d", dir, i);
 		pops[i] = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-				S_IWUSR | S_IRUSR);
+				S_IWUSR | S_IRUSR, 0);
 
 		/*
 		 * Reserve a page after the pool for address checks, if it

--- a/src/test/obj_pool_lookup/obj_pool_lookup.c
+++ b/src/test/obj_pool_lookup/obj_pool_lookup.c
@@ -80,7 +80,8 @@ main(int argc, char *argv[])
 	PMEMoid oids[npools];
 
 	for (int i = 0; i < npools; ++i) {
-		r = pmemobj_alloc(pops[i], &oids[i], ALLOC_SIZE, 1, NULL, NULL);
+		r = pmemobj_alloc(pops[i], &oids[i], ALLOC_SIZE, 1, NULL, NULL,
+				0);
 		ASSERTeq(r, 0);
 	}
 

--- a/src/test/obj_realloc/TEST0
+++ b/src/test/obj_realloc/TEST0
@@ -32,8 +32,7 @@
 #
 
 #
-# src/test/obj_realloc/TEST0 -- unit test for pmemobj_realloc and
-# pmemobj_zrealloc
+# src/test/obj_realloc/TEST0 -- unit test for pmemobj_realloc
 #
 export UNITTEST_NAME=obj_realloc/TEST0
 export UNITTEST_NUM=0

--- a/src/test/obj_realloc/TEST1
+++ b/src/test/obj_realloc/TEST1
@@ -32,8 +32,7 @@
 #
 
 #
-# src/test/obj_realloc/TEST1 -- unit test for pmemobj_realloc and
-# pmemobj_zrealloc
+# src/test/obj_realloc/TEST1 -- unit test for pmemobj_realloc
 #
 export UNITTEST_NAME=obj_realloc/TEST1
 export UNITTEST_NUM=1

--- a/src/test/obj_realloc/obj_realloc.c
+++ b/src/test/obj_realloc/obj_realloc.c
@@ -82,7 +82,7 @@ test_alloc(PMEMobjpool *pop, size_t size)
 	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 
 	int ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid, size,
-			TOID_TYPE_NUM(struct object));
+			TOID_TYPE_NUM(struct object), 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
 	ASSERT(pmemobj_alloc_usable_size(D_RO(root)->obj.oid) >= size);
@@ -98,7 +98,7 @@ test_free(PMEMobjpool *pop)
 	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
 
 	int ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid, 0,
-			TOID_TYPE_NUM(struct object));
+			TOID_TYPE_NUM(struct object), 0);
 	ASSERTeq(ret, 0);
 	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 }
@@ -130,10 +130,10 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 	int ret;
 	if (zrealloc)
 		ret = pmemobj_zalloc(pop, &D_RW(root)->obj.oid,
-			size_from, type_from);
+			size_from, type_from, 0);
 	else
 		ret = pmemobj_alloc(pop, &D_RW(root)->obj.oid,
-			size_from, type_from, NULL, NULL);
+			size_from, type_from, NULL, NULL, 0);
 
 	ASSERTeq(ret, 0);
 	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
@@ -157,10 +157,10 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 
 	if (zrealloc) {
 		ret = pmemobj_zrealloc(pop, &D_RW(root)->obj.oid,
-				size_to, type_to);
+				size_to, type_to, 0);
 	} else {
 		ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid,
-				size_to, type_to);
+				size_to, type_to, 0);
 	}
 
 	ASSERTeq(ret, 0);

--- a/src/test/obj_realloc/obj_realloc.c
+++ b/src/test/obj_realloc/obj_realloc.c
@@ -222,7 +222,7 @@ main(int argc, char *argv[])
 	if (argc < 2)
 		FATAL("usage: %s file [check_integrity]", argv[0]);
 
-	PMEMobjpool *pop = pmemobj_open(argv[1], POBJ_LAYOUT_NAME(realloc));
+	PMEMobjpool *pop = pmemobj_open(argv[1], POBJ_LAYOUT_NAME(realloc), 0);
 	if (!pop)
 		FATAL("!pmemobj_open");
 

--- a/src/test/obj_realloc/obj_realloc.c
+++ b/src/test/obj_realloc/obj_realloc.c
@@ -31,7 +31,7 @@
  */
 
 /*
- * obj_realloc.c -- unit test for pmemobj_realloc and pmemobj_zrealloc
+ * obj_realloc.c -- unit test for pmemobj_realloc
  */
 #include <sys/param.h>
 #include <string.h>
@@ -129,8 +129,8 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 
 	int ret;
 	if (zrealloc)
-		ret = pmemobj_zalloc(pop, &D_RW(root)->obj.oid,
-			size_from, type_from, 0);
+		ret = pmemobj_alloc(pop, &D_RW(root)->obj.oid,
+			size_from, type_from, NULL, NULL, PMEMOBJ_FLAG_ZERO);
 	else
 		ret = pmemobj_alloc(pop, &D_RW(root)->obj.oid,
 			size_from, type_from, NULL, NULL, 0);
@@ -156,8 +156,8 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 	}
 
 	if (zrealloc) {
-		ret = pmemobj_zrealloc(pop, &D_RW(root)->obj.oid,
-				size_to, type_to, 0);
+		ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid,
+				size_to, type_to, PMEMOBJ_FLAG_ZERO);
 	} else {
 		ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid,
 				size_to, type_to, 0);

--- a/src/test/obj_recovery/obj_recovery.c
+++ b/src/test/obj_recovery/obj_recovery.c
@@ -77,11 +77,11 @@ main(int argc, char *argv[])
 
 	if (!exists) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(recovery),
-			0, S_IWUSR | S_IRUSR)) == NULL) {
+			0, S_IWUSR | S_IRUSR, 0)) == NULL) {
 			FATAL("failed to create pool\n");
 		}
 	} else {
-		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(recovery)))
+		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(recovery), 0))
 						== NULL) {
 			FATAL("failed to open pool\n");
 		}
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	ASSERT(pmemobj_check(path, POBJ_LAYOUT_NAME(recovery)));
+	ASSERT(pmemobj_check(path, POBJ_LAYOUT_NAME(recovery), 0));
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_recreate/obj_recreate.c
+++ b/src/test/obj_recreate/obj_recreate.c
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop = NULL;
 
 	/* create pool 2*N */
-	pop = pmemobj_create(path, LAYOUT_NAME, 2 * N, S_IWUSR | S_IRUSR);
+	pop = pmemobj_create(path, LAYOUT_NAME, 2 * N, S_IWUSR | S_IRUSR, 0);
 	if (pop == NULL)
 		FATAL("!pmemobj_create: %s", path);
 
@@ -93,7 +93,7 @@ main(int argc, char *argv[])
 	CLOSE(fd);
 
 	/* create pool on existing file */
-	pop = pmemobj_create(path, LAYOUT_NAME, 0, S_IWUSR | S_IRUSR);
+	pop = pmemobj_create(path, LAYOUT_NAME, 0, S_IWUSR | S_IRUSR, 0);
 	if (pop == NULL)
 		FATAL("!pmemobj_create: %s", path);
 

--- a/src/test/obj_recreate/obj_recreate.c
+++ b/src/test/obj_recreate/obj_recreate.c
@@ -71,7 +71,8 @@ main(int argc, char *argv[])
 		FATAL("!pmemobj_create: %s", path);
 
 	/* allocate 1.5*N */
-	TOID(struct root) root = (TOID(struct root))pmemobj_root(pop, 1.5 * N);
+	TOID(struct root) root = (TOID(struct root))pmemobj_root(pop, 1.5 * N,
+			0);
 
 	/* use root object for something */
 	POBJ_NEW(pop, &D_RW(root)->foo, struct foo, NULL, NULL);
@@ -98,7 +99,7 @@ main(int argc, char *argv[])
 		FATAL("!pmemobj_create: %s", path);
 
 	/* try to allocate 0.7*N */
-	root = (TOID(struct root))pmemobj_root(pop, 0.5 * N);
+	root = (TOID(struct root))pmemobj_root(pop, 0.5 * N, 0);
 
 	if (TOID_IS_NULL(root))
 		FATAL("couldn't allocate root object");

--- a/src/test/obj_strdup/obj_strdup.c
+++ b/src/test/obj_strdup/obj_strdup.c
@@ -127,7 +127,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_strdup(pop);

--- a/src/test/obj_strdup/obj_strdup.c
+++ b/src/test/obj_strdup/obj_strdup.c
@@ -63,7 +63,7 @@ static void
 do_strdup(PMEMobjpool *pop)
 {
 	TOID(char) str = TOID_NULL(char);
-	pmemobj_strdup(pop, &str.oid, TEST_STR_1, TYPE_SIMPLE);
+	pmemobj_strdup(pop, &str.oid, TEST_STR_1, TYPE_SIMPLE, 0);
 	ASSERT(!TOID_IS_NULL(str));
 	ASSERTeq(strcmp(D_RO(str), TEST_STR_1), 0);
 }
@@ -75,7 +75,7 @@ static void
 do_strdup_null(PMEMobjpool *pop)
 {
 	TOID(char) str = TOID_NULL(char);
-	pmemobj_strdup(pop, &str.oid, NULL, TYPE_NULL);
+	pmemobj_strdup(pop, &str.oid, NULL, TYPE_NULL, 0);
 	ASSERT(TOID_IS_NULL(str));
 }
 
@@ -87,7 +87,7 @@ do_alloc(PMEMobjpool *pop, const char *s, unsigned type_num)
 {
 	TOID(char) str;
 	POBJ_ZNEW(pop, &str, char);
-	pmemobj_strdup(pop, &str.oid, s, type_num);
+	pmemobj_strdup(pop, &str.oid, s, type_num, 0);
 	ASSERT(!TOID_IS_NULL(str));
 	ASSERTeq(strcmp(D_RO(str), s), 0);
 	return str;
@@ -101,7 +101,7 @@ do_strdup_alloc(PMEMobjpool *pop)
 {
 	TOID(char) str1 = do_alloc(pop, TEST_STR_1, TYPE_SIMPLE_ALLOC_1);
 	TOID(char) str2 = do_alloc(pop, TEST_STR_2, TYPE_SIMPLE_ALLOC_2);
-	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_SIMPLE_ALLOC);
+	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_SIMPLE_ALLOC, 0);
 	ASSERTeq(strcmp(D_RO(str1), D_RO(str2)), 0);
 }
 
@@ -113,7 +113,7 @@ do_strdup_null_alloc(PMEMobjpool *pop)
 {
 	TOID(char) str1 = do_alloc(pop, TEST_STR_1, TYPE_NULL_ALLOC_1);
 	TOID(char) str2 = TOID_NULL(char);
-	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_NULL_ALLOC);
+	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_NULL_ALLOC, 0);
 	ASSERT(!TOID_IS_NULL(str1));
 }
 

--- a/src/test/obj_toid/obj_toid.c
+++ b/src/test/obj_toid/obj_toid.c
@@ -67,7 +67,7 @@ do_toid_no_valid(PMEMobjpool *pop)
 {
 	TOID(struct obj) obj;
 	int ret = pmemobj_alloc(pop, &obj.oid, sizeof (struct obj), TEST_NUM,
-								NULL, NULL);
+								NULL, NULL, 0);
 	ASSERTeq(ret, 0);
 	ASSERT(!TOID_VALID(obj));
 	POBJ_FREE(&obj);

--- a/src/test/obj_toid/obj_toid.c
+++ b/src/test/obj_toid/obj_toid.c
@@ -97,7 +97,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_toid_valid(pop);

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -525,7 +525,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_add_range_commit(pop);

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -80,7 +80,7 @@ do_tx_zalloc(PMEMobjpool *pop, int type_num)
 	PMEMoid ret = OID_NULL;
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num);
+		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num, 0);
 	} TX_END
 
 	return ret;
@@ -99,12 +99,12 @@ do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 		ASSERT(!TOID_IS_NULL(obj));
 
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
@@ -133,12 +133,12 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
 		ASSERT(!TOID_IS_NULL(obj));
 
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
@@ -167,12 +167,12 @@ do_tx_add_range_twice_commit(PMEMobjpool *pop)
 	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
@@ -197,12 +197,12 @@ do_tx_add_range_twice_abort(PMEMobjpool *pop)
 	ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
@@ -229,14 +229,14 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
-					DATA_OFF, DATA_SIZE);
+					DATA_OFF, DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -271,14 +271,14 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
-					DATA_OFF, DATA_SIZE);
+					DATA_OFF, DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -312,14 +312,14 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 	TOID_ASSIGN(obj2, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
-					DATA_OFF, DATA_SIZE);
+					DATA_OFF, DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -349,7 +349,7 @@ do_tx_add_range_abort(PMEMobjpool *pop)
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
@@ -373,7 +373,7 @@ do_tx_add_range_commit(PMEMobjpool *pop)
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
+		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
@@ -424,13 +424,13 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 	 * --++++++++--
 	 */
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range(obj.oid, 0, 4);
+		pmemobj_tx_add_range(obj.oid, 0, 4, 0);
 		memset(D_RW(obj)->data + 0, 1, 4);
 
-		pmemobj_tx_add_range(obj.oid, 8, 4);
+		pmemobj_tx_add_range(obj.oid, 8, 4, 0);
 		memset(D_RW(obj)->data + 8, 2, 4);
 
-		pmemobj_tx_add_range(obj.oid, 2, 8);
+		pmemobj_tx_add_range(obj.oid, 2, 8, 0);
 		memset(D_RW(obj)->data + 2, 3, 8);
 
 		TX_ADD(obj);
@@ -448,13 +448,13 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 	 * ----++++----
 	 */
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range(obj.oid, 0, 4);
+		pmemobj_tx_add_range(obj.oid, 0, 4, 0);
 		memset(D_RW(obj)->data + 0, 1, 4);
 
-		pmemobj_tx_add_range(obj.oid, 8, 4);
+		pmemobj_tx_add_range(obj.oid, 8, 4, 0);
 		memset(D_RW(obj)->data + 8, 2, 4);
 
-		pmemobj_tx_add_range(obj.oid, 4, 4);
+		pmemobj_tx_add_range(obj.oid, 4, 4, 0);
 		memset(D_RW(obj)->data + 4, 3, 4);
 
 		TX_ADD(obj);
@@ -472,16 +472,16 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 	 * --++++++++--
 	 */
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range(obj.oid, 0, 4);
+		pmemobj_tx_add_range(obj.oid, 0, 4, 0);
 		memset(D_RW(obj)->data + 0, 1, 4);
 
-		pmemobj_tx_add_range(obj.oid, 5, 2);
+		pmemobj_tx_add_range(obj.oid, 5, 2, 0);
 		memset(D_RW(obj)->data + 5, 2, 2);
 
-		pmemobj_tx_add_range(obj.oid, 8, 4);
+		pmemobj_tx_add_range(obj.oid, 8, 4, 0);
 		memset(D_RW(obj)->data + 8, 3, 4);
 
-		pmemobj_tx_add_range(obj.oid, 2, 8);
+		pmemobj_tx_add_range(obj.oid, 2, 8, 0);
 		memset(D_RW(obj)->data + 2, 4, 8);
 
 		TX_ADD(obj);
@@ -499,10 +499,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 	 * ++++
 	 */
 	TX_BEGIN(pop) {
-		pmemobj_tx_add_range(obj.oid, 0, 4);
+		pmemobj_tx_add_range(obj.oid, 0, 4, 0);
 		memset(D_RW(obj)->data, 1, 4);
 
-		pmemobj_tx_add_range(obj.oid, 0, 4);
+		pmemobj_tx_add_range(obj.oid, 0, 4, 0);
 		memset(D_RW(obj)->data, 2, 4);
 
 		pmemobj_tx_abort(-1);

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -80,7 +80,8 @@ do_tx_zalloc(PMEMobjpool *pop, int type_num)
 	PMEMoid ret = OID_NULL;
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num, 0);
+		ret = pmemobj_tx_alloc(sizeof (struct object), type_num,
+				PMEMOBJ_FLAG_ZERO);
 	} TX_END
 
 	return ret;

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -73,7 +73,8 @@ do_tx_zalloc(PMEMobjpool *pop, int type_num)
 	PMEMoid ret = OID_NULL;
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num, 0);
+		ret = pmemobj_tx_alloc(sizeof (struct object), type_num,
+				PMEMOBJ_FLAG_ZERO);
 	} TX_END
 
 	return ret;

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -73,7 +73,7 @@ do_tx_zalloc(PMEMobjpool *pop, int type_num)
 	PMEMoid ret = OID_NULL;
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num);
+		ret = pmemobj_tx_zalloc(sizeof (struct object), type_num, 0);
 	} TX_END
 
 	return ret;
@@ -94,13 +94,12 @@ do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF,
-				DATA_SIZE);
+		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF, DATA_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
@@ -131,13 +130,12 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
-		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF,
-				DATA_SIZE);
+		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF, DATA_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
@@ -168,13 +166,13 @@ do_tx_add_range_twice_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
@@ -201,13 +199,13 @@ do_tx_add_range_twice_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
@@ -236,7 +234,7 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -244,7 +242,7 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
-					DATA_SIZE);
+					DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -281,7 +279,7 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -289,7 +287,7 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
-					DATA_SIZE);
+					DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -325,7 +323,7 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -333,7 +331,7 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
-					DATA_SIZE);
+					DATA_SIZE, 0);
 			ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
@@ -365,7 +363,7 @@ do_tx_add_range_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
@@ -391,7 +389,7 @@ do_tx_add_range_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
-				VALUE_SIZE);
+				VALUE_SIZE, 0);
 		ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -477,7 +477,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-			S_IWUSR | S_IRUSR)) == NULL)
+			S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_add_range_commit(pop);

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -500,7 +500,7 @@ do_tx_root(PMEMobjpool *pop)
 {
 	size_t root_size = 24;
 	TX_BEGIN(pop) {
-		PMEMoid root = pmemobj_root(pop, root_size);
+		PMEMoid root = pmemobj_root(pop, root_size, 0);
 		ASSERT(!OID_IS_NULL(root));
 		ASSERT(util_is_zeroed(pmemobj_direct(root),
 				root_size));

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -521,7 +521,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, 0,
-				S_IWUSR | S_IRUSR)) == NULL)
+				S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_root(pop);

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -31,7 +31,7 @@
  */
 
 /*
- * obj_tx_alloc.c -- unit test for pmemobj_tx_alloc and pmemobj_tx_zalloc
+ * obj_tx_alloc.c -- unit test for pmemobj_tx_alloc
  */
 #include <assert.h>
 #include <sys/param.h>
@@ -129,9 +129,10 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
-			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
+			TOID_ASSIGN(obj2, pmemobj_tx_alloc(
 					sizeof (struct object),
-					TYPE_ABORT_AFTER_NESTED2, 0));
+					TYPE_ABORT_AFTER_NESTED2,
+					PMEMOBJ_FLAG_ZERO));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -185,9 +186,9 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
-			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
+			TOID_ASSIGN(obj2, pmemobj_tx_alloc(
 					sizeof (struct object),
-					TYPE_ABORT_NESTED2, 0));
+					TYPE_ABORT_NESTED2, PMEMOBJ_FLAG_ZERO));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -239,9 +240,10 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
-			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
+			TOID_ASSIGN(obj2, pmemobj_tx_alloc(
 					sizeof (struct object),
-					TYPE_COMMIT_NESTED2, 0));
+					TYPE_COMMIT_NESTED2,
+					PMEMOBJ_FLAG_ZERO));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -392,8 +394,8 @@ do_tx_zalloc_abort(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
-				TYPE_ZEROED_ABORT, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
+				TYPE_ZEROED_ABORT, PMEMOBJ_FLAG_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 
@@ -420,7 +422,8 @@ do_tx_zalloc_zerolen(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zalloc(0, TYPE_ZEROED_ABORT, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(0, TYPE_ZEROED_ABORT,
+				PMEMOBJ_FLAG_ZERO));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -443,8 +446,8 @@ do_tx_zalloc_huge(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zalloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
-				TYPE_ZEROED_ABORT, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
+				TYPE_ZEROED_ABORT, PMEMOBJ_FLAG_ZERO));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -467,8 +470,8 @@ do_tx_zalloc_commit(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
-				TYPE_ZEROED_COMMIT, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
+				TYPE_ZEROED_COMMIT, PMEMOBJ_FLAG_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -123,7 +123,7 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
-				TYPE_ABORT_AFTER_NESTED1));
+				TYPE_ABORT_AFTER_NESTED1, 0));
 		ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -131,7 +131,7 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
-					TYPE_ABORT_AFTER_NESTED2));
+					TYPE_ABORT_AFTER_NESTED2, 0));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -179,7 +179,7 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
-				TYPE_ABORT_NESTED1));
+				TYPE_ABORT_NESTED1, 0));
 		ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -187,7 +187,7 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
-					TYPE_ABORT_NESTED2));
+					TYPE_ABORT_NESTED2, 0));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -233,7 +233,7 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
-				TYPE_COMMIT_NESTED1));
+				TYPE_COMMIT_NESTED1, 0));
 		ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
@@ -241,7 +241,7 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 		TX_BEGIN(pop) {
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
-					TYPE_COMMIT_NESTED2));
+					TYPE_COMMIT_NESTED2, 0));
 			ASSERT(!TOID_IS_NULL(obj2));
 			ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
@@ -290,7 +290,7 @@ do_tx_alloc_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
-				TYPE_ABORT));
+				TYPE_ABORT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 
 		D_RW(obj)->value = TEST_VALUE_1;
@@ -316,7 +316,7 @@ do_tx_alloc_zerolen(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_alloc(0, TYPE_ABORT));
+		TOID_ASSIGN(obj, pmemobj_tx_alloc(0, TYPE_ABORT, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -340,7 +340,7 @@ do_tx_alloc_huge(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
-				TYPE_ABORT));
+				TYPE_ABORT, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -364,7 +364,7 @@ do_tx_alloc_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
-				TYPE_COMMIT));
+				TYPE_COMMIT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 
 		D_RW(obj)->value = TEST_VALUE_1;
@@ -393,7 +393,7 @@ do_tx_zalloc_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
-				TYPE_ZEROED_ABORT));
+				TYPE_ZEROED_ABORT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 
@@ -420,7 +420,7 @@ do_tx_zalloc_zerolen(PMEMobjpool *pop)
 {
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zalloc(0, TYPE_ZEROED_ABORT));
+		TOID_ASSIGN(obj, pmemobj_tx_zalloc(0, TYPE_ZEROED_ABORT, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -444,7 +444,7 @@ do_tx_zalloc_huge(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
-				TYPE_ZEROED_ABORT));
+				TYPE_ZEROED_ABORT, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -468,7 +468,7 @@ do_tx_zalloc_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
-				TYPE_ZEROED_COMMIT));
+				TYPE_ZEROED_COMMIT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 

--- a/src/test/obj_tx_flow/obj_tx_flow.c
+++ b/src/test/obj_tx_flow/obj_tx_flow.c
@@ -268,7 +268,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	TOID(struct test_obj) obj;

--- a/src/test/obj_tx_free/obj_tx_free.c
+++ b/src/test/obj_tx_free/obj_tx_free.c
@@ -359,7 +359,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_free_wrong_uuid(pop);

--- a/src/test/obj_tx_free/obj_tx_free.c
+++ b/src/test/obj_tx_free/obj_tx_free.c
@@ -77,7 +77,7 @@ do_tx_alloc(PMEMobjpool *pop, int type_num)
 	PMEMoid ret = OID_NULL;
 
 	TX_BEGIN(pop) {
-		ret = pmemobj_tx_alloc(sizeof (struct object), type_num);
+		ret = pmemobj_tx_alloc(sizeof (struct object), type_num, 0);
 	} TX_END
 
 	return ret;
@@ -286,7 +286,7 @@ do_tx_free_alloc_abort(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(
-				sizeof (struct object), TYPE_FREE_ALLOC));
+				sizeof (struct object), TYPE_FREE_ALLOC, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
 		ASSERTeq(ret, 0);
@@ -311,7 +311,7 @@ do_tx_free_alloc_commit(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(
-				sizeof (struct object), TYPE_FREE_ALLOC));
+				sizeof (struct object), TYPE_FREE_ALLOC, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
 		ASSERTeq(ret, 0);

--- a/src/test/obj_tx_invalid/obj_tx_invalid.c
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.c
@@ -116,31 +116,31 @@ main(int argc, char *argv[])
 	}
 
 	else if (strcmp(argv[2], "zalloc") == 0)
-		pmemobj_tx_zalloc(10, 1, 0);
+		pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 	else if (strcmp(argv[2], "zalloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_zalloc(10, 1, 0);
+			pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_zalloc(10, 1, 0);
+			pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_zalloc(10, 1, 0);
+			pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_zalloc(10, 1, 0);
+			pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_zalloc(10, 1, 0);
+		pmemobj_tx_alloc(10, 1, PMEMOBJ_FLAG_ZERO);
 	}
 
 	else if (strcmp(argv[2], "strdup") == 0)
@@ -200,31 +200,31 @@ main(int argc, char *argv[])
 	}
 
 	else if (strcmp(argv[2], "zrealloc") == 0)
-		pmemobj_tx_zrealloc(oid, 10, 1, 0);
+		pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 	else if (strcmp(argv[2], "zrealloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_zrealloc(oid, 10, 1, 0);
+			pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_zrealloc(oid, 10, 1, 0);
+			pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_zrealloc(oid, 10, 1, 0);
+			pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_zrealloc(oid, 10, 1, 0);
+			pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_zrealloc(oid, 10, 1, 0);
+		pmemobj_tx_realloc(oid, 10, 1, PMEMOBJ_FLAG_ZERO);
 	}
 
 	else if (strcmp(argv[2], "free") == 0)

--- a/src/test/obj_tx_invalid/obj_tx_invalid.c
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.c
@@ -88,143 +88,143 @@ main(int argc, char *argv[])
 	}
 
 	if (strcmp(argv[2], "alloc") == 0)
-		pmemobj_tx_alloc(10, 1);
+		pmemobj_tx_alloc(10, 1, 0);
 	else if (strcmp(argv[2], "alloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_alloc(10, 1);
+			pmemobj_tx_alloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "alloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_alloc(10, 1);
+			pmemobj_tx_alloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "alloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_alloc(10, 1);
+			pmemobj_tx_alloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "alloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_alloc(10, 1);
+			pmemobj_tx_alloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "alloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_alloc(10, 1);
+		pmemobj_tx_alloc(10, 1, 0);
 	}
 
 	else if (strcmp(argv[2], "zalloc") == 0)
-		pmemobj_tx_zalloc(10, 1);
+		pmemobj_tx_zalloc(10, 1, 0);
 	else if (strcmp(argv[2], "zalloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_zalloc(10, 1);
+			pmemobj_tx_zalloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_zalloc(10, 1);
+			pmemobj_tx_zalloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_zalloc(10, 1);
+			pmemobj_tx_zalloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_zalloc(10, 1);
+			pmemobj_tx_zalloc(10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zalloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_zalloc(10, 1);
+		pmemobj_tx_zalloc(10, 1, 0);
 	}
 
 	else if (strcmp(argv[2], "strdup") == 0)
-		pmemobj_tx_strdup("aaa", 1);
+		pmemobj_tx_strdup("aaa", 1, 0);
 	else if (strcmp(argv[2], "strdup-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_strdup("aaa", 1);
+			pmemobj_tx_strdup("aaa", 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "strdup-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_strdup("aaa", 1);
+			pmemobj_tx_strdup("aaa", 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "strdup-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_strdup("aaa", 1);
+			pmemobj_tx_strdup("aaa", 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "strdup-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_strdup("aaa", 1);
+			pmemobj_tx_strdup("aaa", 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "strdup-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_strdup("aaa", 1);
+		pmemobj_tx_strdup("aaa", 1, 0);
 	}
 
 	else if (strcmp(argv[2], "realloc") == 0)
-		pmemobj_tx_realloc(oid, 10, 1);
+		pmemobj_tx_realloc(oid, 10, 1, 0);
 	else if (strcmp(argv[2], "realloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_realloc(oid, 10, 1);
+			pmemobj_tx_realloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "realloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_realloc(oid, 10, 1);
+			pmemobj_tx_realloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "realloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_realloc(oid, 10, 1);
+			pmemobj_tx_realloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "realloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_realloc(oid, 10, 1);
+			pmemobj_tx_realloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "realloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_realloc(oid, 10, 1);
+		pmemobj_tx_realloc(oid, 10, 1, 0);
 	}
 
 	else if (strcmp(argv[2], "zrealloc") == 0)
-		pmemobj_tx_zrealloc(oid, 10, 1);
+		pmemobj_tx_zrealloc(oid, 10, 1, 0);
 	else if (strcmp(argv[2], "zrealloc-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_zrealloc(oid, 10, 1);
+			pmemobj_tx_zrealloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_zrealloc(oid, 10, 1);
+			pmemobj_tx_zrealloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_zrealloc(oid, 10, 1);
+			pmemobj_tx_zrealloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_zrealloc(oid, 10, 1);
+			pmemobj_tx_zrealloc(oid, 10, 1, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "zrealloc-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_zrealloc(oid, 10, 1);
+		pmemobj_tx_zrealloc(oid, 10, 1, 0);
 	}
 
 	else if (strcmp(argv[2], "free") == 0)
@@ -256,59 +256,59 @@ main(int argc, char *argv[])
 	}
 
 	else if (strcmp(argv[2], "add_range") == 0)
-		pmemobj_tx_add_range(oid, 0, 10);
+		pmemobj_tx_add_range(oid, 0, 10, 0);
 	else if (strcmp(argv[2], "add_range-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_add_range(oid, 0, 10);
+			pmemobj_tx_add_range(oid, 0, 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_add_range(oid, 0, 10);
+			pmemobj_tx_add_range(oid, 0, 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_add_range(oid, 0, 10);
+			pmemobj_tx_add_range(oid, 0, 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_add_range(oid, 0, 10);
+			pmemobj_tx_add_range(oid, 0, 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_add_range(oid, 0, 10);
+		pmemobj_tx_add_range(oid, 0, 10, 0);
 	}
 
 	else if (strcmp(argv[2], "add_range_direct") == 0)
-		pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+		pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 	else if (strcmp(argv[2], "add_range_direct-in-work") == 0) {
 		TX_BEGIN(pop) {
-			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range_direct-in-abort") == 0) {
 		TX_BEGIN(pop) {
 			pmemobj_tx_abort(ENOMEM);
 		} TX_ONABORT {
-			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range_direct-in-commit") == 0) {
 		TX_BEGIN(pop) {
 		} TX_ONCOMMIT {
-			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range_direct-in-finally") == 0) {
 		TX_BEGIN(pop) {
 		} TX_FINALLY {
-			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+			pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 		} TX_END
 	} else if (strcmp(argv[2], "add_range_direct-after-tx") == 0) {
 		TX_BEGIN(pop) {
 		} TX_END
-		pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10);
+		pmemobj_tx_add_range_direct(pmemobj_direct(oid), 10, 0);
 	}
 
 	else if (strcmp(argv[2], "abort") == 0)

--- a/src/test/obj_tx_invalid/obj_tx_invalid.c
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.c
@@ -68,11 +68,11 @@ main(int argc, char *argv[])
 
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(tx_invalid),
-			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL) {
+			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL) {
 			FATAL("!pmemobj_create %s", path);
 		}
 	} else {
-		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(tx_invalid)))
+		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(tx_invalid), 0))
 						== NULL) {
 			FATAL("!pmemobj_open %s", path);
 		}

--- a/src/test/obj_tx_invalid/obj_tx_invalid.c
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.c
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 	PMEMoid oid = pmemobj_first(pop);
 
 	if (OID_IS_NULL(oid)) {
-		if (pmemobj_alloc(pop, &oid, 10, 1, NULL, NULL))
+		if (pmemobj_alloc(pop, &oid, 10, 1, NULL, NULL, 0))
 			FATAL("!pmemobj_alloc");
 	} else {
 		ASSERTeq(pmemobj_type_num(oid), 1);

--- a/src/test/obj_tx_locks/obj_tx_locks.c
+++ b/src/test/obj_tx_locks/obj_tx_locks.c
@@ -189,7 +189,7 @@ main(int argc, char *argv[])
 		FATAL("usage: %s <file> [m]", argv[0]);
 
 	if ((test_obj.pop = pmemobj_create(argv[1], LAYOUT_NAME,
-	    PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
+	    PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	int multithread = 0;

--- a/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
+++ b/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
@@ -131,7 +131,7 @@ main(int argc, char *argv[])
 		FATAL("usage: %s <file>", argv[0]);
 
 	pop = pmemobj_create(argv[1], LAYOUT_NAME,
-			PMEMOBJ_MIN_POOL * 4, S_IWUSR | S_IRUSR);
+			PMEMOBJ_MIN_POOL * 4, S_IWUSR | S_IRUSR, 0);
 	if (pop == NULL)
 		FATAL("!pmemobj_create");
 

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -31,7 +31,7 @@
  */
 
 /*
- * obj_tx_realloc.c -- unit test for pmemobj_tx_realloc and pmemobj_tx_zrealloc
+ * obj_tx_realloc.c -- unit test for pmemobj_tx_realloc
  */
 #include <sys/param.h>
 #include <string.h>
@@ -227,8 +227,8 @@ do_tx_zrealloc_commit(PMEMobjpool *pop)
 	size_t new_size = 2 * old_size;
 
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			new_size, TYPE_COMMIT_ZERO, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
+			new_size, TYPE_COMMIT_ZERO, PMEMOBJ_FLAG_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
@@ -293,8 +293,8 @@ do_tx_zrealloc_abort(PMEMobjpool *pop)
 	size_t new_size = 2 * old_size;
 
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			new_size, TYPE_ABORT_ZERO, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
+			new_size, TYPE_ABORT_ZERO, PMEMOBJ_FLAG_ZERO));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
@@ -354,8 +354,9 @@ do_tx_zrealloc_huge(PMEMobjpool *pop)
 	size_t new_size = 2 * old_size;
 
 	TX_BEGIN(pop) {
-		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			PMEMOBJ_MAX_ALLOC_SIZE + 1, TYPE_ABORT_ZERO_HUGE, 0));
+		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
+			PMEMOBJ_MAX_ALLOC_SIZE + 1, TYPE_ABORT_ZERO_HUGE,
+			PMEMOBJ_FLAG_ZERO));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -440,13 +440,13 @@ static void
 do_tx_root_realloc(PMEMobjpool *pop)
 {
 	TX_BEGIN(pop) {
-		PMEMoid root = pmemobj_root(pop, sizeof (struct object));
+		PMEMoid root = pmemobj_root(pop, sizeof (struct object), 0);
 		ASSERT(!OID_IS_NULL(root));
 		ASSERT(util_is_zeroed(pmemobj_direct(root),
 				sizeof (struct object)));
 		ASSERTeq(sizeof (struct object), pmemobj_root_size(pop));
 
-		root = pmemobj_root(pop, 2 * sizeof (struct object));
+		root = pmemobj_root(pop, 2 * sizeof (struct object), 0);
 		ASSERT(!OID_IS_NULL(root));
 		ASSERT(util_is_zeroed(pmemobj_direct(root),
 				2 * sizeof (struct object)));

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -86,7 +86,7 @@ do_tx_alloc(PMEMobjpool *pop, int type_num, size_t value)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(
-				sizeof (struct object), type_num));
+				sizeof (struct object), type_num, 0));
 		if (!TOID_IS_NULL(obj)) {
 			D_RW(obj)->value = value;
 		}
@@ -107,7 +107,7 @@ do_tx_realloc_commit(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
-			new_size, TYPE_COMMIT));
+			new_size, TYPE_COMMIT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	} TX_ONABORT {
@@ -135,7 +135,7 @@ do_tx_realloc_abort(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
-			new_size, TYPE_ABORT));
+			new_size, TYPE_ABORT, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 
@@ -165,7 +165,7 @@ do_tx_realloc_huge(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
-			new_size, TYPE_ABORT_HUGE));
+			new_size, TYPE_ABORT_HUGE, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -228,7 +228,7 @@ do_tx_zrealloc_commit(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			new_size, TYPE_COMMIT_ZERO));
+			new_size, TYPE_COMMIT_ZERO, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
@@ -294,7 +294,7 @@ do_tx_zrealloc_abort(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			new_size, TYPE_ABORT_ZERO));
+			new_size, TYPE_ABORT_ZERO, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
@@ -355,7 +355,7 @@ do_tx_zrealloc_huge(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
-			PMEMOBJ_MAX_ALLOC_SIZE + 1, TYPE_ABORT_ZERO_HUGE));
+			PMEMOBJ_MAX_ALLOC_SIZE + 1, TYPE_ABORT_ZERO_HUGE, 0));
 		ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
 		ASSERT(0);
@@ -386,7 +386,7 @@ do_tx_realloc_alloc_commit(PMEMobjpool *pop)
 		ASSERT(!TOID_IS_NULL(obj));
 		new_size = 2 * pmemobj_alloc_usable_size(obj.oid);
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
-			new_size, TYPE_COMMIT_ALLOC));
+			new_size, TYPE_COMMIT_ALLOC, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	} TX_ONABORT {
@@ -418,7 +418,7 @@ do_tx_realloc_alloc_abort(PMEMobjpool *pop)
 		ASSERT(!TOID_IS_NULL(obj));
 		new_size = 2 * pmemobj_alloc_usable_size(obj.oid);
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
-			new_size, TYPE_ABORT_ALLOC));
+			new_size, TYPE_ABORT_ALLOC, 0));
 		ASSERT(!TOID_IS_NULL(obj));
 		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -466,7 +466,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, 0,
-				S_IWUSR | S_IRUSR)) == NULL)
+				S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	do_tx_root_realloc(pop);

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -72,7 +72,7 @@ static unsigned counter;
 static void
 tx_strdup(TOID(char) *str, const char *s, unsigned type_num)
 {
-	TOID_ASSIGN(*str, pmemobj_tx_strdup(s, type_num));
+	TOID_ASSIGN(*str, pmemobj_tx_strdup(s, type_num, 0));
 }
 
 /*

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -294,7 +294,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
-	    S_IWUSR | S_IRUSR)) == NULL)
+	    S_IWUSR | S_IRUSR, 0)) == NULL)
 		FATAL("!pmemobj_create");
 
 	for (counter = 0; counter < MAX_FUNC; counter++) {

--- a/src/test/out_err_mt/out_err_mt.c
+++ b/src/test/out_err_mt/out_err_mt.c
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
 		FATAL("usage: %s filename1 filename2 filename3 dir", argv[0]);
 
 	PMEMobjpool *pop = pmemobj_create(argv[1], "test",
-		PMEMOBJ_MIN_POOL, 0666);
+		PMEMOBJ_MIN_POOL, 0666, 0);
 	PMEMlogpool *plp = pmemlog_create(argv[2],
 		PMEMLOG_MIN_POOL, 0666);
 	PMEMblkpool *pbp = pmemblk_create(argv[3],

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -63,8 +63,6 @@ pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_type_num
-pmemobj_zalloc
-pmemobj_zrealloc
 $(*)nondebug/libpmemobj.so:
 _pobj_cache_invalidate
 _pobj_cached_pool
@@ -129,8 +127,6 @@ pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_type_num
-pmemobj_zalloc
-pmemobj_zrealloc
 $(*)debug/libpmemobj.a:
 _pobj_cache_invalidate
 _pobj_cached_pool
@@ -195,8 +191,6 @@ pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_type_num
-pmemobj_zalloc
-pmemobj_zrealloc
 $(*)nondebug/libpmemobj.a:
 _pobj_cache_invalidate
 _pobj_cached_pool
@@ -261,5 +255,3 @@ pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
 pmemobj_type_num
-pmemobj_zalloc
-pmemobj_zrealloc

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -62,8 +62,6 @@ pmemobj_tx_process
 pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
-pmemobj_tx_zalloc
-pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
@@ -130,8 +128,6 @@ pmemobj_tx_process
 pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
-pmemobj_tx_zalloc
-pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
@@ -198,8 +194,6 @@ pmemobj_tx_process
 pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
-pmemobj_tx_zalloc
-pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc
@@ -266,8 +260,6 @@ pmemobj_tx_process
 pmemobj_tx_realloc
 pmemobj_tx_stage
 pmemobj_tx_strdup
-pmemobj_tx_zalloc
-pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_zalloc
 pmemobj_zrealloc

--- a/src/test/set_funcs/set_funcs.c
+++ b/src/test/set_funcs/set_funcs.c
@@ -172,7 +172,7 @@ test_obj(const char *path)
 	memset(cnt, 0, sizeof (cnt));
 
 	PMEMobjpool *pop =
-			pmemobj_create(path, NULL, PMEMOBJ_MIN_POOL, 0600);
+			pmemobj_create(path, NULL, PMEMOBJ_MIN_POOL, 0600, 0);
 
 	PMEMoid oid;
 

--- a/src/test/set_funcs/set_funcs.c
+++ b/src/test/set_funcs/set_funcs.c
@@ -176,10 +176,10 @@ test_obj(const char *path)
 
 	PMEMoid oid;
 
-	if (pmemobj_alloc(pop, &oid, 10, 0, NULL, NULL))
+	if (pmemobj_alloc(pop, &oid, 10, 0, NULL, NULL, 0))
 		FATAL("!alloc");
 
-	if (pmemobj_realloc(pop, &oid, 100, 0))
+	if (pmemobj_realloc(pop, &oid, 100, 0, 0))
 		FATAL("!realloc");
 
 	pmemobj_free(&oid);

--- a/src/test/tools/pmemalloc/pmemalloc.c
+++ b/src/test/tools/pmemalloc/pmemalloc.c
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
 	char *file = argv[optind];
 
 	PMEMobjpool *pop;
-	if ((pop = pmemobj_open(file, NULL)) == NULL) {
+	if ((pop = pmemobj_open(file, NULL, 0)) == NULL) {
 		fprintf(stderr, "pmemobj_open: %s\n", pmemobj_errormsg());
 		return -1;
 	}

--- a/src/test/tools/pmemalloc/pmemalloc.c
+++ b/src/test/tools/pmemalloc/pmemalloc.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
 	if (size) {
 		PMEMoid oid;
 		TX_BEGIN(pop) {
-			oid = pmemobj_tx_alloc(size, type_num);
+			oid = pmemobj_tx_alloc(size, type_num, 0);
 			if (exit_at == 'a')
 				exit(1);
 		} TX_END
@@ -138,7 +138,7 @@ main(int argc, char *argv[])
 
 		if (do_set) {
 			TX_BEGIN(pop) {
-				pmemobj_tx_add_range(oid, 0, size);
+				pmemobj_tx_add_range(oid, 0, size, 0);
 				if (exit_at == 's')
 					exit(1);
 			} TX_END

--- a/src/test/tools/pmemalloc/pmemalloc.c
+++ b/src/test/tools/pmemalloc/pmemalloc.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	}
 
 	if (root_size) {
-		PMEMoid oid = pmemobj_root(pop, root_size);
+		PMEMoid oid = pmemobj_root(pop, root_size, 0);
 		if (OID_IS_NULL(oid)) {
 			fprintf(stderr, "pmemobj_root: %s\n",
 					pmemobj_errormsg());

--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -409,7 +409,7 @@ pocli_pmemobj_root(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	PMEMoid root = pmemobj_root(ctx->pop, size);
+	PMEMoid root = pmemobj_root(ctx->pop, size, 0);
 
 	if (OID_IS_NULL(root))
 		return pocli_err(ctx, POCLI_ERR_CMD, "pmemobj_root failed\n");
@@ -470,7 +470,7 @@ pocli_pmemobj_zalloc(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	int r = pmemobj_zalloc(ctx->pop, oidp, size, type_num);
+	int r = pmemobj_zalloc(ctx->pop, oidp, size, type_num, 0);
 
 	pocli_printf(ctx, "%s(%s, %llu, %u): %d\n",
 		args->argv[0], args->argv[1], size, type_num, r);
@@ -512,7 +512,7 @@ pocli_pmemobj_zrealloc(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	int r = pmemobj_zrealloc(ctx->pop, oidp, size, type_num);
+	int r = pmemobj_zrealloc(ctx->pop, oidp, size, type_num, 0);
 
 	pocli_printf(ctx, "%s(%s, %llu, %u): %d\n",
 		args->argv[0], args->argv[1], size, type_num, r);
@@ -801,7 +801,7 @@ pocli_alloc(FILE *input, const char *fname, const struct pocli_cmd *cmds,
 
 	size_t root_size = pmemobj_root_size(pcli->ctx.pop);
 	if (root_size)
-		pcli->ctx.root = pmemobj_root(pcli->ctx.pop, root_size);
+		pcli->ctx.root = pmemobj_root(pcli->ctx.pop, root_size, 0);
 
 	pcli->inbuf_len = inbuf_len;
 	pcli->inbuf = malloc(inbuf_len);

--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -793,7 +793,7 @@ pocli_alloc(FILE *input, const char *fname, const struct pocli_cmd *cmds,
 	pcli->ctx.pocli = pcli;
 	pcli->ctx.err = stderr;
 	pcli->ctx.out = stdout;
-	pcli->ctx.pop = pmemobj_open(fname, NULL);
+	pcli->ctx.pop = pmemobj_open(fname, NULL, 0);
 	if (!pcli->ctx.pop) {
 		fprintf(stderr, "%s: %s\n", fname, pmemobj_errormsg());
 		goto err_free_pcli;

--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -470,7 +470,8 @@ pocli_pmemobj_zalloc(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	int r = pmemobj_zalloc(ctx->pop, oidp, size, type_num, 0);
+	int r = pmemobj_alloc(ctx->pop, oidp, size, type_num, NULL, NULL,
+			PMEMOBJ_FLAG_ZERO);
 
 	pocli_printf(ctx, "%s(%s, %llu, %u): %d\n",
 		args->argv[0], args->argv[1], size, type_num, r);
@@ -512,7 +513,8 @@ pocli_pmemobj_zrealloc(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	int r = pmemobj_zrealloc(ctx->pop, oidp, size, type_num, 0);
+	int r = pmemobj_realloc(ctx->pop, oidp, size, type_num,
+			PMEMOBJ_FLAG_ZERO);
 
 	pocli_printf(ctx, "%s(%s, %llu, %u): %d\n",
 		args->argv[0], args->argv[1], size, type_num, r);

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -176,7 +176,7 @@ pmempool_create_obj(struct pmempool_create *pcp)
 	outv(1, "Creating pmem obj pool with layout '%s'\n",
 			pcp->layout ? pcp->layout : "");
 	PMEMobjpool *pop = pmemobj_create(pcp->fname, pcp->layout,
-			pcp->params.size, pcp->params.mode);
+			pcp->params.size, pcp->params.mode, 0);
 	if (!pop) {
 		outv_err("'%s' -- %s\n", pcp->fname, pmemobj_errormsg());
 		return -1;


### PR DESCRIPTION
For now there's only flag used by those APIs: PMEMOBJ_FLAG_ZERO.

I'm going to propose several API extensions that will add new flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/700)
<!-- Reviewable:end -->
