### PR TITLE
A bunch of patches required to compile NVML on Windows

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -353,7 +353,7 @@ out_common(const char *file, int line, const char *func, int level,
 	const char *errstr = "";
 
 	if (file) {
-		char *f = rindex(file, '/');
+		char *f = strrchr(file, '/');
 		if (f)
 			file = f + 1;
 		ret = out_snprintf(&buf[cc], MAXPRINT - cc,
@@ -429,7 +429,7 @@ out_error(const char *file, int line, const char *func,
 		cc = 0;
 
 		if (file) {
-			char *f = rindex(file, '/');
+			char *f = strrchr(file, '/');
 			if (f)
 				file = f + 1;
 			ret = out_snprintf(&buf[cc], MAXPRINT,

--- a/src/common/out.c
+++ b/src/common/out.c
@@ -199,7 +199,7 @@ out_init(const char *log_prefix, const char *log_level_var,
 		size_t cc = strlen(log_file);
 
 		/* reserve more than enough space for a PID + '\0' */
-		char log_file_pid[cc + 30];
+		char *log_file_pid = alloca(cc + 30);
 
 		if (cc > 0 && log_file[cc - 1] == '-') {
 			snprintf(log_file_pid, cc + 30, "%s%d",

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1655,22 +1655,22 @@ int
 util_parse_size(const char *str, size_t *sizep)
 {
 	const struct suff suffixes[] = {
-		{ "B", 1 },
-		{ "K", 1UL << 10 },		/* JEDEC */
-		{ "M", 1UL << 20 },
-		{ "G", 1UL << 30 },
-		{ "T", 1UL << 40 },
-		{ "P", 1UL << 50 },
-		{ "KiB", 1UL << 10 },		/* IEC */
-		{ "MiB", 1UL << 20 },
-		{ "GiB", 1UL << 30 },
-		{ "TiB", 1UL << 40 },
-		{ "PiB", 1UL << 50 },
-		{ "kB", 1000UL },		/* SI */
-		{ "MB", 1000UL * 1000 },
-		{ "GB", 1000UL * 1000 * 1000 },
-		{ "TB", 1000UL * 1000 * 1000 * 1000 },
-		{ "PB", 1000UL * 1000 * 1000 * 1000 * 1000 }
+		{ "B", 1ULL },
+		{ "K", 1ULL << 10 },		/* JEDEC */
+		{ "M", 1ULL << 20 },
+		{ "G", 1ULL << 30 },
+		{ "T", 1ULL << 40 },
+		{ "P", 1ULL << 50 },
+		{ "KiB", 1ULL << 10 },		/* IEC */
+		{ "MiB", 1ULL << 20 },
+		{ "GiB", 1ULL << 30 },
+		{ "TiB", 1ULL << 40 },
+		{ "PiB", 1ULL << 50 },
+		{ "kB", 1000ULL },		/* SI */
+		{ "MB", 1000ULL * 1000 },
+		{ "GB", 1000ULL * 1000 * 1000 },
+		{ "TB", 1000ULL * 1000 * 1000 * 1000 },
+		{ "PB", 1000ULL * 1000 * 1000 * 1000 * 1000 }
 	};
 
 	int res = -1;
@@ -1678,7 +1678,7 @@ util_parse_size(const char *str, size_t *sizep)
 	size_t size = 0;
 	char unit[4] = {0};
 
-	int ret = sscanf(str, "%lu%4s", &size, unit);
+	int ret = sscanf(str, "%zu%4s", &size, unit);
 	if (ret == 1) {
 		res = 0;
 	} else if (ret == 2) {

--- a/src/examples/libpmemobj/tree_map/ctree_map.c
+++ b/src/examples/libpmemobj/tree_map/ctree_map.c
@@ -40,7 +40,7 @@
 
 #include "ctree_map.h"
 
-#define	BIT_IS_SET(n, i) (!!((n) & (1L << (i))))
+#define	BIT_IS_SET(n, i) (!!((n) & (1ULL << (i))))
 
 TOID_DECLARE(struct tree_map_node, CTREE_MAP_TYPE_OFFSET + 1);
 

--- a/src/include/libpmemobj.h
+++ b/src/include/libpmemobj.h
@@ -223,7 +223,7 @@ _toid_##t##_toid(PMEMoid _oid) : oid(_oid)\
  * Declaration of typed OID
  */
 #define	_TOID_DECLARE(t, i)\
-typedef uint8_t _toid_##t##_toid_type_num[(i)];\
+typedef uint8_t _toid_##t##_toid_type_num[(i) + 1];\
 TOID(t)\
 {\
 	_TOID_CONSTR(t)\
@@ -245,12 +245,12 @@ TOID(t)\
 /*
  * Type number of specified type
  */
-#define	TOID_TYPE_NUM(t) (sizeof (_toid_##t##_toid_type_num))
+#define	TOID_TYPE_NUM(t) (sizeof (_toid_##t##_toid_type_num) - 1)
 
 /*
  * Type number of object read from typed OID
  */
-#define	TOID_TYPE_NUM_OF(o) (sizeof (*(o)._type_num))
+#define	TOID_TYPE_NUM_OF(o) (sizeof (*(o)._type_num) - 1)
 
 /*
  * NULL check
@@ -272,13 +272,13 @@ TOID(t)\
  * Begin of layout declaration
  */
 #define	POBJ_LAYOUT_BEGIN(name)\
-typedef uint8_t _pobj_layout_##name##_ref[__COUNTER__]
+typedef uint8_t _pobj_layout_##name##_ref[__COUNTER__ + 1]
 
 /*
  * End of layout declaration
  */
 #define	POBJ_LAYOUT_END(name)\
-typedef char _pobj_layout_##name##_cnt[__COUNTER__ -\
+typedef char _pobj_layout_##name##_cnt[__COUNTER__ + 1 -\
 1 - _POBJ_LAYOUT_REF(name)];
 
 /*
@@ -290,7 +290,7 @@ typedef char _pobj_layout_##name##_cnt[__COUNTER__ -\
  * Declaration of typed OID inside layout declaration
  */
 #define	POBJ_LAYOUT_TOID(name, t)\
-TOID_DECLARE(t, (__COUNTER__ - _POBJ_LAYOUT_REF(name)));
+TOID_DECLARE(t, (__COUNTER__ + 1 - _POBJ_LAYOUT_REF(name)));
 
 /*
  * Declaration of typed OID of root inside layout declaration

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -203,7 +203,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <xmmintrin.h>
+#include <emmintrin.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/libpmemobj/ctree.c
+++ b/src/libpmemobj/ctree.c
@@ -49,7 +49,7 @@
 #include "sys_util.h"
 #include "ctree.h"
 
-#define	BIT_IS_SET(n, i) (!!((n) & (((uint64_t)1) << (i))))
+#define	BIT_IS_SET(n, i) (!!((n) & (1ULL << (i))))
 
 /* internal nodes have LSB of the pointer set, leafs do not */
 #define	NODE_IS_INTERNAL(node) (BIT_IS_SET((uintptr_t)(node), 0))
@@ -82,8 +82,9 @@ static unsigned
 find_crit_bit(uint64_t lhs, uint64_t rhs)
 {
 	/* __builtin_clzll is undefined for 0 */
-	ASSERTne(lhs ^ rhs, 0);
-	return 64 - (unsigned)__builtin_clzll(lhs ^ rhs) - 1;
+	uint64_t val = lhs ^ rhs;
+	ASSERTne(val, 0);
+	return 64 - (unsigned)__builtin_clzll(val) - 1;
 }
 
 /*

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -246,7 +246,7 @@ heap_chunk_init(PMEMobjpool *pop, struct chunk_header *hdr,
 static void
 heap_zone_init(PMEMobjpool *pop, uint32_t zone_id)
 {
-	struct zone *z = &pop->heap->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, zone_id);
 	uint32_t size_idx = get_zone_size_idx(zone_id, pop->heap->max_zone,
 			pop->heap_size);
 
@@ -415,7 +415,7 @@ heap_create_run(PMEMobjpool *pop, struct bucket *b,
 	uint32_t chunk_id, uint32_t zone_id)
 {
 	struct pmalloc_heap *h = pop->heap;
-	struct zone *z = &h->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(h->layout, zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[chunk_id];
 	struct chunk_run *run = (struct chunk_run *)&z->chunks[chunk_id];
 
@@ -438,7 +438,7 @@ heap_reuse_run(PMEMobjpool *pop, struct bucket *b,
 	util_mutex_lock(heap_get_run_lock(pop, chunk_id));
 
 	struct pmalloc_heap *h = pop->heap;
-	struct zone *z = &h->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(h->layout, zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[chunk_id];
 	struct chunk_run *run = (struct chunk_run *)&z->chunks[chunk_id];
 
@@ -515,7 +515,7 @@ heap_populate_buckets(PMEMobjpool *pop)
 		return ENOMEM;
 
 	uint32_t zone_id = h->zones_exhausted++;
-	struct zone *z = &h->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(h->layout, zone_id);
 
 	/* ignore zone and chunk headers */
 	VALGRIND_ADD_TO_GLOBAL_TX_IGNORE(z, sizeof (z->header) +
@@ -694,7 +694,7 @@ heap_get_chunk_bucket(PMEMobjpool *pop, uint32_t chunk_id, uint32_t zone_id)
 	if (zone_id >= pop->heap->zones_exhausted)
 		return NULL;
 
-	struct zone *z = &pop->heap->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, zone_id);
 
 	ASSERT(chunk_id < z->header.size_idx);
 	struct chunk_header *hdr = &z->chunk_headers[chunk_id];
@@ -972,7 +972,7 @@ heap_resize_chunk(PMEMobjpool *pop,
 {
 	uint32_t new_chunk_id = chunk_id + new_size_idx;
 
-	struct zone *z = &pop->heap->layout->zones[zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, zone_id);
 	struct chunk_header *old_hdr = &z->chunk_headers[chunk_id];
 	struct chunk_header *new_hdr = &z->chunk_headers[new_chunk_id];
 
@@ -1083,7 +1083,7 @@ void
 heap_prep_block_header_operation(PMEMobjpool *pop, struct memory_block m,
 	enum heap_op op, struct operation_context *ctx)
 {
-	struct zone *z = &pop->heap->layout->zones[m.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	if (hdr->type != CHUNK_TYPE_RUN) {
@@ -1121,7 +1121,7 @@ heap_prep_block_header_operation(PMEMobjpool *pop, struct memory_block m,
 void *
 heap_get_block_data(PMEMobjpool *pop, struct memory_block m)
 {
-	struct zone *z = &pop->heap->layout->zones[m.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	void *data = &z->chunks[m.chunk_id].data;
@@ -1141,7 +1141,7 @@ heap_get_block_data(PMEMobjpool *pop, struct memory_block m)
 int
 heap_block_is_allocated(PMEMobjpool *pop, struct memory_block m)
 {
-	struct zone *z = &pop->heap->layout->zones[m.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	if (hdr->type == CHUNK_TYPE_USED)
@@ -1253,7 +1253,7 @@ int heap_get_adjacent_free_block(PMEMobjpool *pop, struct bucket *b,
 	if (b == NULL)
 		return EINVAL;
 
-	struct zone *z = &pop->heap->layout->zones[cnt.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, cnt.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[cnt.chunk_id];
 	m->zone_id = cnt.zone_id;
 
@@ -1274,8 +1274,8 @@ int heap_get_adjacent_free_block(PMEMobjpool *pop, struct bucket *b,
 void
 heap_lock_if_run(PMEMobjpool *pop, struct memory_block m)
 {
-	struct chunk_header *hdr =
-		&pop->heap->layout->zones[m.zone_id].chunk_headers[m.chunk_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
+	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	if (hdr->type == CHUNK_TYPE_RUN)
 		util_mutex_lock(heap_get_run_lock(pop, m.chunk_id));
@@ -1287,8 +1287,8 @@ heap_lock_if_run(PMEMobjpool *pop, struct memory_block m)
 void
 heap_unlock_if_run(PMEMobjpool *pop, struct memory_block m)
 {
-	struct chunk_header *hdr =
-		&pop->heap->layout->zones[m.zone_id].chunk_headers[m.chunk_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
+	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	if (hdr->type == CHUNK_TYPE_RUN) {
 		pthread_mutex_t *mutex = heap_get_run_lock(pop, m.chunk_id);
@@ -1395,7 +1395,7 @@ void
 heap_degrade_run_if_empty(PMEMobjpool *pop, struct bucket *b,
 	struct memory_block m)
 {
-	struct zone *z = &pop->heap->layout->zones[m.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 	ASSERT(hdr->type == CHUNK_TYPE_RUN);
 
@@ -1462,7 +1462,7 @@ out:
 size_t
 heap_get_chunk_block_size(PMEMobjpool *pop, struct memory_block m)
 {
-	struct zone *z = &pop->heap->layout->zones[m.zone_id];
+	struct zone *z = ZID_TO_ZONE(pop->heap->layout, m.zone_id);
 	struct chunk_header *hdr = &z->chunk_headers[m.chunk_id];
 
 	if (hdr->type == CHUNK_TYPE_USED || hdr->type == CHUNK_TYPE_FREE) {
@@ -1492,7 +1492,7 @@ heap_vg_boot(PMEMobjpool *pop)
 	/* mark unused part of the last zone as not accessible */
 	struct pmalloc_heap *h = pop->heap;
 	ASSERT(h->max_zone > 0);
-	struct zone *last_zone = &h->layout->zones[h->max_zone - 1];
+	struct zone *last_zone = ZID_TO_ZONE(h->layout, h->max_zone - 1);
 	void *unused = &last_zone->chunks[last_zone->header.size_idx];
 	VALGRIND_DO_MAKE_MEM_NOACCESS(pop, unused,
 			(void *)pop + pop->size - unused);
@@ -1627,7 +1627,7 @@ heap_vg_open(PMEMobjpool *pop)
 	unsigned zones = heap_max_zone(pop->heap_size);
 
 	for (unsigned i = 0; i < zones; ++i) {
-		struct zone *z = &layout->zones[i];
+		struct zone *z = ZID_TO_ZONE(layout, i);
 		uint32_t chunks;
 
 		VALGRIND_DO_MAKE_MEM_DEFINED(pop, &z->header,
@@ -1689,21 +1689,20 @@ heap_init(PMEMobjpool *pop)
 
 	unsigned zones = heap_max_zone(pop->heap_size);
 	for (unsigned i = 0; i < zones; ++i) {
-		memset(&layout->zones[i].header, 0,
-				sizeof (layout->zones[i].header));
+		memset(&ZID_TO_ZONE(layout, i)->header, 0,
+				sizeof (struct zone_header));
+		memset(&ZID_TO_ZONE(layout, i)->chunk_headers, 0,
+				sizeof (struct chunk_header));
 
-		memset(&layout->zones[i].chunk_headers, 0,
-				sizeof (layout->zones[i].chunk_headers));
-
-		pmem_msync(&layout->zones[i].header,
-			sizeof (layout->zones[i].header));
-		pmem_msync(&layout->zones[i].chunk_headers,
-			sizeof (layout->zones[i].chunk_headers));
+		pmem_msync(&ZID_TO_ZONE(layout, i)->header,
+				sizeof (struct zone_header));
+		pmem_msync(&ZID_TO_ZONE(layout, i)->chunk_headers,
+				sizeof (struct zone_header));
 
 		/* only explicitly allocated chunks should be accessible */
 		VALGRIND_DO_MAKE_MEM_NOACCESS(pop,
-			&layout->zones[i].chunk_headers,
-			sizeof (layout->zones[i].chunk_headers));
+			&ZID_TO_ZONE(layout, i)->chunk_headers,
+			sizeof (struct chunk_header));
 	}
 
 	return 0;
@@ -1862,7 +1861,7 @@ heap_check(PMEMobjpool *pop)
 		return -1;
 
 	for (unsigned i = 0; i < heap_max_zone(layout->header.size); ++i) {
-		if (heap_verify_zone(&layout->zones[i]))
+		if (heap_verify_zone(ZID_TO_ZONE(layout, i)))
 			return -1;
 	}
 
@@ -1972,6 +1971,6 @@ heap_foreach_object(PMEMobjpool *pop, object_callback cb, void *arg,
 	for (unsigned i = start.zone_id;
 		i < heap_max_zone(layout->header.size); ++i)
 		if (heap_zone_foreach_object(pop, cb, arg,
-			&layout->zones[i], start) != 0)
+				ZID_TO_ZONE(layout, i), start) != 0)
 			break;
 }

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -361,7 +361,7 @@ heap_process_run_metadata(PMEMobjpool *pop, struct bucket *b,
 			heap_run_insert(pop, b, chunk_id, zone_id,
 				BITS_PER_VALUE, block_off);
 			continue;
-		} else if (v == ~(uint64_t)0) {
+		} else if (v == UINT64_MAX) {
 			continue;
 		}
 
@@ -470,7 +470,7 @@ static int
 heap_run_is_empty(struct chunk_run *run)
 {
 	for (int i = 0; i < MAX_BITMAP_VALUES; ++i)
-		if (run->bitmap[i] != ~(uint64_t)0)
+		if (run->bitmap[i] != UINT64_MAX)
 			return 0;
 
 	return 1;

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -309,7 +309,7 @@ heap_run_insert(PMEMobjpool *pop, struct bucket *b, uint32_t chunk_id,
 	ASSERT(size_idx <= BITS_PER_VALUE);
 	ASSERT(block_off + size_idx <= r->bitmap_nallocs);
 
-	unsigned unit_max = r->unit_max;
+	uint32_t unit_max = r->unit_max;
 	struct memory_block m = {chunk_id, zone_id,
 		unit_max - (block_off % unit_max), block_off};
 

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -56,7 +56,7 @@
 #define	MIN_RUN_SIZE 128
 
 #define	ZID_TO_ZONE(layoutp, zone_id)\
-	((struct zone *)((uintptr_t)(((struct heap_layout *)(layoutp))->zones)\
+	((struct zone *)((uintptr_t)&(((struct heap_layout *)(layoutp))->zone0)\
 					+ ZONE_MAX_SIZE * (zone_id)))
 
 enum chunk_flags {
@@ -116,7 +116,7 @@ struct heap_header {
 
 struct heap_layout {
 	struct heap_header header;
-	struct zone zones[];
+	struct zone zone0;	/* first element of zones array */
 };
 
 struct allocation_header {

--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -43,8 +43,8 @@
 #define	HEAP_SIGNATURE_LEN 16
 #define	HEAP_SIGNATURE "MEMORY_HEAP_HDR\0"
 #define	ZONE_HEADER_MAGIC 0xC3F0A2D2
-#define	ZONE_MIN_SIZE (sizeof (struct zone) - (MAX_CHUNK - 1) * CHUNKSIZE)
-#define	ZONE_MAX_SIZE (sizeof (struct zone))
+#define	ZONE_MIN_SIZE (sizeof (struct zone) + sizeof (struct chunk))
+#define	ZONE_MAX_SIZE (sizeof (struct zone) + sizeof (struct chunk) * MAX_CHUNK)
 #define	HEAP_MIN_SIZE (sizeof (struct heap_layout) + ZONE_MIN_SIZE)
 #define	REDO_LOG_SIZE 4
 #define	BITS_PER_VALUE 64U
@@ -54,6 +54,10 @@
 #define	RUN_BITMAP_SIZE (BITS_PER_VALUE * MAX_BITMAP_VALUES)
 #define	RUNSIZE (CHUNKSIZE - RUN_METASIZE)
 #define	MIN_RUN_SIZE 128
+
+#define	ZID_TO_ZONE(layoutp, zone_id)\
+	((struct zone *)((uintptr_t)(((struct heap_layout *)(layoutp))->zones)\
+					+ ZONE_MAX_SIZE * (zone_id)))
 
 enum chunk_flags {
 	CHUNK_FLAG_ZEROED	=	0x0001,
@@ -96,7 +100,7 @@ struct zone_header {
 struct zone {
 	struct zone_header header;
 	struct chunk_header chunk_headers[MAX_CHUNK];
-	struct chunk chunks[MAX_CHUNK];
+	struct chunk chunks[];
 };
 
 struct heap_header {

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -84,15 +84,6 @@
 #define	OBJ_PTR_IS_VALID(pop, ptr)\
 	OBJ_OFF_IS_VALID(pop, OBJ_PTR_TO_OFF(pop, ptr))
 
-#define	OBJ_OID_IS_VALID(pop, oid) (\
-	{\
-		PMEMoid o = (oid);\
-		OBJ_OID_IS_NULL(o) ||\
-		(o.pool_uuid_lo == (pop)->uuid_lo &&\
-		o.off >= (pop)->heap_offset &&\
-		o.off < (pop)->heap_offset + (pop)->heap_size);\
-	})
-
 #define	OOB_HEADER_FROM_OFF(pop, off)\
 	((struct oob_header *)((uintptr_t)(pop) + (off) - OBJ_OOB_SIZE))
 
@@ -267,6 +258,18 @@ pmemobj_get_uuid_lo(PMEMobjpool *pop)
 	}
 
 	return uuid_lo;
+}
+
+/*
+ * OBJ_OID_IS_VALID -- (internal) checks if 'oid' is valid
+ */
+static inline int
+OBJ_OID_IS_VALID(PMEMobjpool *pop, PMEMoid oid)
+{
+	return OBJ_OID_IS_NULL(oid) ||
+		(oid.pool_uuid_lo == pop->uuid_lo &&
+		    oid.off >= pop->heap_offset &&
+		    oid.off < pop->heap_offset + pop->heap_size);
 }
 
 void obj_init(void);

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -1117,7 +1117,7 @@ pmemspoil_process_heap(struct pmemspoil *psp, struct pmemspoil_list *pfp,
 		PROCESS_FIELD(hdr, reserved, char);
 		PROCESS_FIELD(hdr, checksum, uint64_t);
 
-		PROCESS(zone, &hlayout->zones[PROCESS_INDEX],
+		PROCESS(zone, ZID_TO_ZONE(hlayout, PROCESS_INDEX),
 			util_heap_max_zone(psp->size));
 
 	} PROCESS_END

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -841,7 +841,7 @@ info_obj_zones_chunks(struct pmem_info *pip)
 		err(1, "Cannot allocate memory for zone stats");
 
 	for (size_t i = 0; i < maxzone; i++) {
-		struct zone *zone = &layout->zones[i];
+		struct zone *zone = ZID_TO_ZONE(layout, i);
 
 		if (util_ranges_contain(&pip->args.obj.zone_ranges, i)) {
 			int vvv = pip->args.obj.vheap &&


### PR DESCRIPTION
There is no Windows-specific code in these patches yet.
It's just to address some incompatibilities between gcc/clang and MSFT C compiler and to make further   work on NVML for Windows easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/702)
<!-- Reviewable:end -->
