### PR TITLE
tests: add prefix to macros from unittest.h

### DIFF
--- a/src/test/arch_flags/arch_flags.c
+++ b/src/test/arch_flags/arch_flags.c
@@ -42,7 +42,7 @@
 
 #define	ELF_FILE_NAME "/proc/self/exe"
 #define	FATAL_USAGE()\
-FATAL("usage: arch_flags <file>:<err>:<alignemnt_desc>:<reserved> <file>")
+UT_FATAL("usage: arch_flags <file>:<err>:<alignemnt_desc>:<reserved> <file>")
 #define	ARCH_FLAGS_LOG_PREFIX "arch_flags"
 #define	ARCH_FLAGS_LOG_LEVEL_VAR "ARCH_FLAGS_LOG_LEVEL"
 #define	ARCH_FLAGS_LOG_FILE_VAR "ARCH_FLAGS_LOG_FILE"
@@ -141,7 +141,7 @@ read_arch_flags(char *arg, struct arch_flags *arch_flags)
 	Open_ret = error;
 
 	ret = util_get_arch_flags(arch_flags);
-	OUT("get  : %d", ret);
+	UT_OUT("get  : %d", ret);
 
 	if (ret)
 		return 1;
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
 			Open_path = arg2;
 			Open_ret = 0;
 			ret = util_check_arch_flags(&arch_flags);
-			OUT("check: %d", ret);
+			UT_OUT("check: %d", ret);
 		}
 	}
 

--- a/src/test/blk_nblock/blk_nblock.c
+++ b/src/test/blk_nblock/blk_nblock.c
@@ -45,36 +45,38 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_nblock");
 
 	if (argc < 2)
-		FATAL("usage: %s bsize:file...", argv[0]);
+		UT_FATAL("usage: %s bsize:file...", argv[0]);
 
 	/* map each file argument with the given map type */
 	for (int arg = 1; arg < argc; arg++) {
 		char *fname;
 		size_t bsize = strtoul(argv[arg], &fname, 0);
 		if (*fname != ':')
-			FATAL("usage: %s bsize:file...", argv[0]);
+			UT_FATAL("usage: %s bsize:file...", argv[0]);
 		fname++;
 
 		PMEMblkpool *handle;
 		handle = pmemblk_create(fname, bsize, 0, S_IWUSR | S_IRUSR);
 		if (handle == NULL) {
-			OUT("!%s: pmemblk_create", fname);
+			UT_OUT("!%s: pmemblk_create", fname);
 		} else {
-			OUT("%s: block size %zu usable blocks: %zu",
+			UT_OUT("%s: block size %zu usable blocks: %zu",
 					fname, bsize, pmemblk_nblock(handle));
-			ASSERTeq(pmemblk_bsize(handle), bsize);
+			UT_ASSERTeq(pmemblk_bsize(handle), bsize);
 			pmemblk_close(handle);
 			int result = pmemblk_check(fname, bsize);
 			if (result < 0)
-				OUT("!%s: pmemblk_check", fname);
+				UT_OUT("!%s: pmemblk_check", fname);
 			else if (result == 0)
-				OUT("%s: pmemblk_check: not consistent", fname);
+				UT_OUT("%s: pmemblk_check: not consistent",
+						fname);
 			else {
-				ASSERTeq(pmemblk_check(fname, bsize + 1), -1);
-				ASSERTeq(pmemblk_check(fname, 0), 1);
+				UT_ASSERTeq(pmemblk_check(fname, bsize + 1),
+						-1);
+				UT_ASSERTeq(pmemblk_check(fname, 0), 1);
 
 				handle = pmemblk_open(fname, 0);
-				ASSERTeq(pmemblk_bsize(handle), bsize);
+				UT_ASSERTeq(pmemblk_bsize(handle), bsize);
 				pmemblk_close(handle);
 			}
 		}

--- a/src/test/blk_non_zero/blk_non_zero.c
+++ b/src/test/blk_non_zero/blk_non_zero.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_non_zero");
 
 	if (argc < 5)
-		FATAL("usage: %s bsize file func [file_size] op:lba...",
+		UT_FATAL("usage: %s bsize file func [file_size] op:lba...",
 				argv[0]);
 
 	int read_arg = 1;
@@ -131,28 +131,28 @@ main(int argc, char *argv[])
 			handle = pmemblk_create(path, Bsize, fsize,
 					S_IRUSR | S_IWUSR);
 			if (handle == NULL)
-				FATAL("!%s: pmemblk_create", path);
+				UT_FATAL("!%s: pmemblk_create", path);
 			break;
 		}
 		case 'o':
 			handle = pmemblk_open(path, Bsize);
 			if (handle == NULL)
-				FATAL("!%s: pmemblk_open", path);
+				UT_FATAL("!%s: pmemblk_open", path);
 			break;
 		default:
-			FATAL("unrecognized command %s", argv[read_arg - 1]);
+			UT_FATAL("unrecognized command %s", argv[read_arg - 1]);
 	}
 
-	OUT("%s block size %zu usable blocks %zu",
+	UT_OUT("%s block size %zu usable blocks %zu",
 			argv[1], Bsize, pmemblk_nblock(handle));
 
-	OUT("is zeroed:\t%d", is_zeroed(path));
+	UT_OUT("is zeroed:\t%d", is_zeroed(path));
 
 	/* map each file argument with the given map type */
 	for (; read_arg < argc; read_arg++) {
 		if (strchr("rwze", argv[read_arg][0]) == NULL ||
 				argv[read_arg][1] != ':')
-			FATAL("op must be r: or w: or z: or e:");
+			UT_FATAL("op must be r: or w: or z: or e:");
 		off_t lba = strtoul(&argv[read_arg][2], NULL, 0);
 
 		unsigned char buf[Bsize];
@@ -160,31 +160,33 @@ main(int argc, char *argv[])
 		switch (argv[read_arg][0]) {
 		case 'r':
 			if (pmemblk_read(handle, buf, lba) < 0)
-				OUT("!read      lba %zu", lba);
+				UT_OUT("!read      lba %zu", lba);
 			else
-				OUT("read      lba %zu: %s", lba, ident(buf));
+				UT_OUT("read      lba %zu: %s", lba,
+						ident(buf));
 			break;
 
 		case 'w':
 			construct(buf);
 			if (pmemblk_write(handle, buf, lba) < 0)
-				OUT("!write     lba %zu", lba);
+				UT_OUT("!write     lba %zu", lba);
 			else
-				OUT("write     lba %zu: %s", lba, ident(buf));
+				UT_OUT("write     lba %zu: %s", lba,
+						ident(buf));
 			break;
 
 		case 'z':
 			if (pmemblk_set_zero(handle, lba) < 0)
-				OUT("!set_zero  lba %zu", lba);
+				UT_OUT("!set_zero  lba %zu", lba);
 			else
-				OUT("set_zero  lba %zu", lba);
+				UT_OUT("set_zero  lba %zu", lba);
 			break;
 
 		case 'e':
 			if (pmemblk_set_error(handle, lba) < 0)
-				OUT("!set_error lba %zu", lba);
+				UT_OUT("!set_error lba %zu", lba);
 			else
-				OUT("set_error lba %zu", lba);
+				UT_OUT("set_error lba %zu", lba);
 			break;
 		}
 	}
@@ -193,9 +195,9 @@ main(int argc, char *argv[])
 
 	int result = pmemblk_check(path, Bsize);
 	if (result < 0)
-		OUT("!%s: pmemblk_check", path);
+		UT_OUT("!%s: pmemblk_check", path);
 	else if (result == 0)
-		OUT("%s: pmemblk_check: not consistent", path);
+		UT_OUT("%s: pmemblk_check: not consistent", path);
 
 	DONE(NULL);
 }

--- a/src/test/blk_pool/blk_pool.c
+++ b/src/test/blk_pool/blk_pool.c
@@ -51,12 +51,12 @@ pool_create(const char *path, size_t bsize, size_t poolsize, unsigned mode)
 	PMEMblkpool *pbp = pmemblk_create(path, bsize, poolsize, mode);
 
 	if (pbp == NULL)
-		OUT("!%s: pmemblk_create", path);
+		UT_OUT("!%s: pmemblk_create", path);
 	else {
 		struct stat stbuf;
 		STAT(path, &stbuf);
 
-		OUT("%s: file size %zu usable blocks %zu mode 0%o",
+		UT_OUT("%s: file size %zu usable blocks %zu mode 0%o",
 				path, stbuf.st_size,
 				pmemblk_nblock(pbp),
 				stbuf.st_mode & 0777);
@@ -66,11 +66,11 @@ pool_create(const char *path, size_t bsize, size_t poolsize, unsigned mode)
 		int result = pmemblk_check(path, bsize);
 
 		if (result < 0)
-			OUT("!%s: pmemblk_check", path);
+			UT_OUT("!%s: pmemblk_check", path);
 		else if (result == 0)
-			OUT("%s: pmemblk_check: not consistent", path);
+			UT_OUT("%s: pmemblk_check: not consistent", path);
 		else
-			ASSERTeq(pmemblk_check(path, bsize * 2), -1);
+			UT_ASSERTeq(pmemblk_check(path, bsize * 2), -1);
 	}
 }
 
@@ -79,9 +79,9 @@ pool_open(const char *path, size_t bsize)
 {
 	PMEMblkpool *pbp = pmemblk_open(path, bsize);
 	if (pbp == NULL)
-		OUT("!%s: pmemblk_open", path);
+		UT_OUT("!%s: pmemblk_open", path);
 	else {
-		OUT("%s: pmemblk_open: Success", path);
+		UT_OUT("%s: pmemblk_open: Success", path);
 		pmemblk_close(pbp);
 	}
 }
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_pool");
 
 	if (argc < 4)
-		FATAL("usage: %s op path bsize [poolsize mode]", argv[0]);
+		UT_FATAL("usage: %s op path bsize [poolsize mode]", argv[0]);
 
 	size_t bsize = strtoul(argv[3], NULL, 0);
 	size_t poolsize;
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 		break;
 
 	default:
-		FATAL("unknown operation");
+		UT_FATAL("unknown operation");
 	}
 
 	DONE(NULL);

--- a/src/test/blk_pool_lock/blk_pool_lock.c
+++ b/src/test/blk_pool_lock/blk_pool_lock.c
@@ -43,20 +43,20 @@ test_reopen(const char *path)
 	PMEMblkpool *blk1 = pmemblk_create(path, 4096, PMEMBLK_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	if (!blk1)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	PMEMblkpool *blk2 = pmemblk_open(path, 4096);
 	if (blk2)
-		FATAL("pmemblk_open should not succeed");
+		UT_FATAL("pmemblk_open should not succeed");
 
 	if (errno != EWOULDBLOCK)
-		FATAL("!pmemblk_open failed but for unexpected reason");
+		UT_FATAL("!pmemblk_open failed but for unexpected reason");
 
 	pmemblk_close(blk1);
 
 	blk2 = pmemblk_open(path, 4096);
 	if (!blk2)
-		FATAL("pmemobj_open should succeed after close");
+		UT_FATAL("pmemobj_open should succeed after close");
 
 	pmemblk_close(blk2);
 
@@ -70,7 +70,7 @@ test_open_in_different_process(const char *path, int sleep)
 	PMEMblkpool *blk;
 
 	if (pid < 0)
-		FATAL("fork failed");
+		UT_FATAL("fork failed");
 
 	if (pid == 0) {
 		/* child */
@@ -81,10 +81,10 @@ test_open_in_different_process(const char *path, int sleep)
 
 		blk = pmemblk_open(path, 4096);
 		if (blk)
-			FATAL("pmemblk_open after fork should not succeed");
+			UT_FATAL("pmemblk_open after fork should not succeed");
 
 		if (errno != EWOULDBLOCK)
-			FATAL("!pmemblk_open after fork failed but for "
+			UT_FATAL("!pmemblk_open after fork failed but for "
 				"unexpected reason");
 
 		exit(0);
@@ -92,15 +92,15 @@ test_open_in_different_process(const char *path, int sleep)
 
 	blk = pmemblk_create(path, 4096, PMEMBLK_MIN_POOL, S_IWUSR | S_IRUSR);
 	if (!blk)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	int status;
 
 	if (waitpid(pid, &status, 0) < 0)
-		FATAL("!waitpid failed");
+		UT_FATAL("!waitpid failed");
 
 	if (!WIFEXITED(status))
-		FATAL("child process failed");
+		UT_FATAL("child process failed");
 
 	pmemblk_close(blk);
 
@@ -113,7 +113,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_pool_lock");
 
 	if (argc < 2)
-		FATAL("usage: %s path", argv[0]);
+		UT_FATAL("usage: %s path", argv[0]);
 
 	test_reopen(argv[1]);
 

--- a/src/test/blk_rw/blk_rw.c
+++ b/src/test/blk_rw/blk_rw.c
@@ -86,7 +86,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_rw");
 
 	if (argc < 5)
-		FATAL("usage: %s bsize file func op:lba...", argv[0]);
+		UT_FATAL("usage: %s bsize file func op:lba...", argv[0]);
 
 	Bsize = strtoul(argv[1], NULL, 0);
 
@@ -98,22 +98,22 @@ main(int argc, char *argv[])
 			handle = pmemblk_create(path, Bsize, 0,
 					S_IWUSR | S_IRUSR);
 			if (handle == NULL)
-				FATAL("!%s: pmemblk_create", path);
+				UT_FATAL("!%s: pmemblk_create", path);
 			break;
 		case 'o':
 			handle = pmemblk_open(path, Bsize);
 			if (handle == NULL)
-				FATAL("!%s: pmemblk_open", path);
+				UT_FATAL("!%s: pmemblk_open", path);
 			break;
 	}
 
-	OUT("%s block size %zu usable blocks %zu",
+	UT_OUT("%s block size %zu usable blocks %zu",
 			argv[1], Bsize, pmemblk_nblock(handle));
 
 	/* map each file argument with the given map type */
 	for (int arg = 4; arg < argc; arg++) {
 		if (strchr("rwze", argv[arg][0]) == NULL || argv[arg][1] != ':')
-			FATAL("op must be r: or w: or z: or e:");
+			UT_FATAL("op must be r: or w: or z: or e:");
 		off_t lba = strtol(&argv[arg][2], NULL, 0);
 
 		unsigned char buf[Bsize];
@@ -121,31 +121,33 @@ main(int argc, char *argv[])
 		switch (argv[arg][0]) {
 		case 'r':
 			if (pmemblk_read(handle, buf, lba) < 0)
-				OUT("!read      lba %jd", lba);
+				UT_OUT("!read      lba %jd", lba);
 			else
-				OUT("read      lba %jd: %s", lba, ident(buf));
+				UT_OUT("read      lba %jd: %s", lba,
+						ident(buf));
 			break;
 
 		case 'w':
 			construct(buf);
 			if (pmemblk_write(handle, buf, lba) < 0)
-				OUT("!write     lba %jd", lba);
+				UT_OUT("!write     lba %jd", lba);
 			else
-				OUT("write     lba %jd: %s", lba, ident(buf));
+				UT_OUT("write     lba %jd: %s", lba,
+						ident(buf));
 			break;
 
 		case 'z':
 			if (pmemblk_set_zero(handle, lba) < 0)
-				OUT("!set_zero  lba %jd", lba);
+				UT_OUT("!set_zero  lba %jd", lba);
 			else
-				OUT("set_zero  lba %jd", lba);
+				UT_OUT("set_zero  lba %jd", lba);
 			break;
 
 		case 'e':
 			if (pmemblk_set_error(handle, lba) < 0)
-				OUT("!set_error lba %jd", lba);
+				UT_OUT("!set_error lba %jd", lba);
 			else
-				OUT("set_error lba %jd", lba);
+				UT_OUT("set_error lba %jd", lba);
 			break;
 		}
 	}
@@ -154,9 +156,9 @@ main(int argc, char *argv[])
 
 	int result = pmemblk_check(path, Bsize);
 	if (result < 0)
-		OUT("!%s: pmemblk_check", path);
+		UT_OUT("!%s: pmemblk_check", path);
 	else if (result == 0)
-		OUT("%s: pmemblk_check: not consistent", path);
+		UT_OUT("%s: pmemblk_check: not consistent", path);
 
 	DONE(NULL);
 }

--- a/src/test/blk_rw_mt/blk_rw_mt.c
+++ b/src/test/blk_rw_mt/blk_rw_mt.c
@@ -71,7 +71,7 @@ check(unsigned char *buf)
 
 	for (int i = 1; i < Bsize; i++)
 		if (buf[i] != val) {
-			OUT("{%u} TORN at byte %d", val, i);
+			UT_OUT("{%u} TORN at byte %d", val, i);
 			break;
 		}
 }
@@ -93,14 +93,14 @@ worker(void *arg)
 		if (rand_r(&myseed) % 2) {
 			/* read */
 			if (pmemblk_read(Handle, buf, lba) < 0)
-				OUT("!read      lba %zu", lba);
+				UT_OUT("!read      lba %zu", lba);
 			else
 				check(buf);
 		} else {
 			/* write */
 			construct(&ord, buf);
 			if (pmemblk_write(Handle, buf, lba) < 0)
-				OUT("!write     lba %zu", lba);
+				UT_OUT("!write     lba %zu", lba);
 		}
 	}
 
@@ -113,7 +113,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "blk_rw_mt");
 
 	if (argc != 6)
-		FATAL("usage: %s bsize file seed nthread nops", argv[0]);
+		UT_FATAL("usage: %s bsize file seed nthread nops", argv[0]);
 
 	Bsize = strtoul(argv[1], NULL, 0);
 
@@ -121,7 +121,7 @@ main(int argc, char *argv[])
 
 	if ((Handle = pmemblk_create(path, Bsize, 0,
 			S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!%s: pmemblk_create", path);
+		UT_FATAL("!%s: pmemblk_create", path);
 
 	if (Nblock == 0)
 		Nblock = pmemblk_nblock(Handle);
@@ -129,7 +129,7 @@ main(int argc, char *argv[])
 	Nthread = strtoul(argv[4], NULL, 0);
 	Nops = strtoul(argv[5], NULL, 0);
 
-	OUT("%s block size %zu usable blocks %zu", argv[1], Bsize, Nblock);
+	UT_OUT("%s block size %zu usable blocks %zu", argv[1], Bsize, Nblock);
 
 	pthread_t threads[Nthread];
 
@@ -146,9 +146,9 @@ main(int argc, char *argv[])
 	/* XXX not ready to pass this part of the test yet */
 	int result = pmemblk_check(path, Bsize);
 	if (result < 0)
-		OUT("!%s: pmemblk_check", path);
+		UT_OUT("!%s: pmemblk_check", path);
 	else if (result == 0)
-		OUT("%s: pmemblk_check: not consistent", path);
+		UT_OUT("%s: pmemblk_check: not consistent", path);
 
 	DONE(NULL);
 }

--- a/src/test/checksum/checksum.c
+++ b/src/test/checksum/checksum.c
@@ -50,7 +50,7 @@
 static uint64_t
 fletcher64(void *addr, size_t len)
 {
-	ASSERT(len % 4 == 0);
+	UT_ASSERT(len % 4 == 0);
 	uint32_t *p32 = addr;
 	uint32_t *p32end = (uint32_t *)((char *)addr + len);
 	uint32_t lo32 = 0;
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "checksum");
 
 	if (argc < 2)
-		FATAL("usage: %s files...", argv[0]);
+		UT_FATAL("usage: %s files...", argv[0]);
 
 	for (int arg = 1; arg < argc; arg++) {
 		int fd = OPEN(argv[arg], O_RDONLY);
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 			/*
 			 * verify inserted checksum checks out
 			 */
-			ASSERT(util_checksum(addr, stbuf.st_size, ptr, 0));
+			UT_ASSERT(util_checksum(addr, stbuf.st_size, ptr, 0));
 
 			/* put a zero where the checksum was installed */
 			*ptr = 0;
@@ -125,14 +125,14 @@ main(int argc, char *argv[])
 			/*
 			 * verify checksum now fails
 			 */
-			ASSERT(!util_checksum(addr, stbuf.st_size, ptr, 0));
+			UT_ASSERT(!util_checksum(addr, stbuf.st_size, ptr, 0));
 
 			/*
 			 * verify the checksum matched the gold version
 			 */
-			ASSERTeq(csum, gold_csum);
+			UT_ASSERTeq(csum, gold_csum);
 
-			OUT("%s:%lu 0x%lx", argv[arg],
+			UT_OUT("%s:%lu 0x%lx", argv[arg],
 				(char *)ptr - (char *)addr, csum);
 
 			ptr++;

--- a/src/test/log_basic/log_basic.c
+++ b/src/test/log_basic/log_basic.c
@@ -48,7 +48,7 @@ static void
 do_nbyte(PMEMlogpool *plp)
 {
 	size_t nbyte = pmemlog_nbyte(plp);
-	OUT("usable size: %zu", nbyte);
+	UT_OUT("usable size: %zu", nbyte);
 }
 
 /*
@@ -70,13 +70,13 @@ do_append(PMEMlogpool *plp)
 		int rv = pmemlog_append(plp, str[i], strlen(str[i]));
 		switch (rv) {
 		case 0:
-			OUT("append   str[%i] %s", i, str[i]);
+			UT_OUT("append   str[%i] %s", i, str[i]);
 			break;
 		case -1:
-			OUT("!append   str[%i] %s", i, str[i]);
+			UT_OUT("!append   str[%i] %s", i, str[i]);
 			break;
 		default:
-			OUT("!append: wrong return value");
+			UT_OUT("!append: wrong return value");
 			break;
 		}
 	}
@@ -130,13 +130,13 @@ do_appendv(PMEMlogpool *plp)
 	int rv = pmemlog_appendv(plp, iov, 9);
 	switch (rv) {
 	case 0:
-		OUT("appendv");
+		UT_OUT("appendv");
 		break;
 	case -1:
-		OUT("!appendv");
+		UT_OUT("!appendv");
 		break;
 	default:
-		OUT("!appendv: wrong return value");
+		UT_OUT("!appendv: wrong return value");
 		break;
 	}
 }
@@ -148,7 +148,7 @@ static void
 do_tell(PMEMlogpool *plp)
 {
 	off_t tell = pmemlog_tell(plp);
-	OUT("tell %zu", tell);
+	UT_OUT("tell %zu", tell);
 }
 
 /*
@@ -158,7 +158,7 @@ static void
 do_rewind(PMEMlogpool *plp)
 {
 	pmemlog_rewind(plp);
-	OUT("rewind");
+	UT_OUT("rewind");
 }
 
 /*
@@ -173,7 +173,7 @@ printit(const void *buf, size_t len, void *arg)
 
 	strncpy(str, buf, len);
 	str[len] = '\0';
-	OUT("%s", str);
+	UT_OUT("%s", str);
 
 	return 1;
 }
@@ -187,9 +187,9 @@ static void
 do_walk(PMEMlogpool *plp)
 {
 	pmemlog_walk(plp, 0, printit, NULL);
-	OUT("walk all at once");
+	UT_OUT("walk all at once");
 	pmemlog_walk(plp, 16, printit, NULL);
-	OUT("walk by 16");
+	UT_OUT("walk by 16");
 }
 
 int
@@ -201,19 +201,19 @@ main(int argc, char *argv[])
 	START(argc, argv, "log_basic");
 
 	if (argc < 3)
-		FATAL("usage: %s file-name op:n|a|v|t|r|w", argv[0]);
+		UT_FATAL("usage: %s file-name op:n|a|v|t|r|w", argv[0]);
 
 	const char *path = argv[1];
 
 	if ((plp = pmemlog_create(path, 0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemlog_create: %s", path);
+		UT_FATAL("!pmemlog_create: %s", path);
 
 	/* go through all arguments one by one */
 	for (int arg = 2; arg < argc; arg++) {
 		/* Scan the character of each argument. */
 		if (strchr("navtrw", argv[arg][0]) == NULL ||
 				argv[arg][1] != '\0')
-			FATAL("op must be n or a or v or t or r or w");
+			UT_FATAL("op must be n or a or v or t or r or w");
 
 		switch (argv[arg][0]) {
 		case 'n':
@@ -247,9 +247,9 @@ main(int argc, char *argv[])
 	/* check consistency again */
 	result = pmemlog_check(path);
 	if (result < 0)
-		OUT("!%s: pmemlog_check", path);
+		UT_OUT("!%s: pmemlog_check", path);
 	else if (result == 0)
-		OUT("%s: pmemlog_check: not consistent", path);
+		UT_OUT("%s: pmemlog_check: not consistent", path);
 
 	DONE(NULL);
 }

--- a/src/test/log_pool/log_pool.c
+++ b/src/test/log_pool/log_pool.c
@@ -51,12 +51,12 @@ pool_create(const char *path, size_t poolsize, unsigned mode)
 	PMEMlogpool *plp = pmemlog_create(path, poolsize, mode);
 
 	if (plp == NULL)
-		OUT("!%s: pmemlog_create", path);
+		UT_OUT("!%s: pmemlog_create", path);
 	else {
 		struct stat stbuf;
 		STAT(path, &stbuf);
 
-		OUT("%s: file size %zu usable space %zu mode 0%o",
+		UT_OUT("%s: file size %zu usable space %zu mode 0%o",
 				path, stbuf.st_size,
 				pmemlog_nbyte(plp),
 				stbuf.st_mode & 0777);
@@ -66,9 +66,9 @@ pool_create(const char *path, size_t poolsize, unsigned mode)
 		int result = pmemlog_check(path);
 
 		if (result < 0)
-			OUT("!%s: pmemlog_check", path);
+			UT_OUT("!%s: pmemlog_check", path);
 		else if (result == 0)
-			OUT("%s: pmemlog_check: not consistent", path);
+			UT_OUT("%s: pmemlog_check: not consistent", path);
 	}
 }
 
@@ -77,9 +77,9 @@ pool_open(const char *path)
 {
 	PMEMlogpool *plp = pmemlog_open(path);
 	if (plp == NULL)
-		OUT("!%s: pmemlog_open", path);
+		UT_OUT("!%s: pmemlog_open", path);
 	else {
-		OUT("%s: pmemlog_open: Success", path);
+		UT_OUT("%s: pmemlog_open: Success", path);
 		pmemlog_close(plp);
 	}
 }
@@ -90,7 +90,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "log_pool");
 
 	if (argc < 3)
-		FATAL("usage: %s op path [poolsize mode]", argv[0]);
+		UT_FATAL("usage: %s op path [poolsize mode]", argv[0]);
 
 	size_t poolsize;
 	unsigned mode;
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
 		break;
 
 	default:
-		FATAL("unknown operation");
+		UT_FATAL("unknown operation");
 	}
 
 	DONE(NULL);

--- a/src/test/log_pool_lock/log_pool_lock.c
+++ b/src/test/log_pool_lock/log_pool_lock.c
@@ -43,20 +43,20 @@ test_reopen(const char *path)
 	PMEMlogpool *log1 = pmemlog_create(path, PMEMLOG_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	if (!log1)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	PMEMlogpool *log2 = pmemlog_open(path);
 	if (log2)
-		FATAL("pmemlog_open should not succeed");
+		UT_FATAL("pmemlog_open should not succeed");
 
 	if (errno != EWOULDBLOCK)
-		FATAL("!pmemlog_open failed but for unexpected reason");
+		UT_FATAL("!pmemlog_open failed but for unexpected reason");
 
 	pmemlog_close(log1);
 
 	log2 = pmemlog_open(path);
 	if (!log2)
-		FATAL("pmemlog_open should succeed after close");
+		UT_FATAL("pmemlog_open should succeed after close");
 
 	pmemlog_close(log2);
 
@@ -70,7 +70,7 @@ test_open_in_different_process(const char *path, int sleep)
 	PMEMlogpool *log;
 
 	if (pid < 0)
-		FATAL("fork failed");
+		UT_FATAL("fork failed");
 
 	if (pid == 0) {
 		/* child */
@@ -81,10 +81,10 @@ test_open_in_different_process(const char *path, int sleep)
 
 		log = pmemlog_open(path);
 		if (log)
-			FATAL("pmemlog_open after fork should not succeed");
+			UT_FATAL("pmemlog_open after fork should not succeed");
 
 		if (errno != EWOULDBLOCK)
-			FATAL("!pmemlog_open after fork failed but for "
+			UT_FATAL("!pmemlog_open after fork failed but for "
 				"unexpected reason");
 
 		exit(0);
@@ -92,15 +92,15 @@ test_open_in_different_process(const char *path, int sleep)
 
 	log = pmemlog_create(path, PMEMLOG_MIN_POOL, S_IWUSR | S_IRUSR);
 	if (!log)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	int status;
 
 	if (waitpid(pid, &status, 0) < 0)
-		FATAL("!waitpid failed");
+		UT_FATAL("!waitpid failed");
 
 	if (!WIFEXITED(status))
-		FATAL("child process failed");
+		UT_FATAL("child process failed");
 
 	pmemlog_close(log);
 
@@ -113,7 +113,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "log_pool_lock");
 
 	if (argc < 2)
-		FATAL("usage: %s path", argv[0]);
+		UT_FATAL("usage: %s path", argv[0]);
 
 	test_reopen(argv[1]);
 

--- a/src/test/log_walker/log_walker.c
+++ b/src/test/log_walker/log_walker.c
@@ -59,13 +59,13 @@ do_append(PMEMlogpool *plp)
 		int rv = pmemlog_append(plp, str[i], strlen(str[i]));
 		switch (rv) {
 		case 0:
-			OUT("append   str[%i] %s", i, str[i]);
+			UT_OUT("append   str[%i] %s", i, str[i]);
 			break;
 		case -1:
-			OUT("!append   str[%i] %s", i, str[i]);
+			UT_OUT("!append   str[%i] %s", i, str[i]);
 			break;
 		default:
-			OUT("!append: wrong return value");
+			UT_OUT("!append: wrong return value");
 			break;
 		}
 	}
@@ -90,7 +90,7 @@ static void
 do_walk(PMEMlogpool *plp)
 {
 	pmemlog_walk(plp, 0, try_to_store, NULL);
-	OUT("walk all at once");
+	UT_OUT("walk all at once");
 }
 
 sigjmp_buf Jmp;
@@ -101,7 +101,7 @@ sigjmp_buf Jmp;
 static void
 signal_handler(int sig)
 {
-	OUT("signal: %s", strsignal(sig));
+	UT_OUT("signal: %s", strsignal(sig));
 
 	siglongjmp(Jmp, 1);
 }
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "log_walker");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -123,12 +123,12 @@ main(int argc, char *argv[])
 	/* pre-allocate 2MB of persistent memory */
 	errno = posix_fallocate(fd, (off_t)0, (size_t)(2 * 1024 * 1024));
 	if (errno != 0)
-		FATAL("!posix_fallocate");
+		UT_FATAL("!posix_fallocate");
 
 	CLOSE(fd);
 
 	if ((plp = pmemlog_create(path, 0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemlog_create: %s", path);
+		UT_FATAL("!pmemlog_create: %s", path);
 
 	/* append some data */
 	do_append(plp);

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -93,7 +93,7 @@ test_alloc_api(PMEMobjpool *pop)
 
 	POBJ_ZNEW(pop, &node_zeroed, struct dummy_node);
 
-	ASSERT(OID_INSTANCEOF(node_zeroed.oid, struct dummy_node));
+	UT_ASSERT(OID_INSTANCEOF(node_zeroed.oid, struct dummy_node));
 
 	int *test_val = MALLOC(sizeof (*test_val));
 	*test_val = TEST_VALUE;
@@ -105,12 +105,12 @@ test_alloc_api(PMEMobjpool *pop)
 	TOID(struct dummy_node) iter;
 
 	POBJ_FOREACH_TYPE(pop, iter) {
-		ASSERTeq(D_RO(iter)->value, 0);
+		UT_ASSERTeq(D_RO(iter)->value, 0);
 	}
 
 	TOID(struct dummy_node_c) iter_c;
 	POBJ_FOREACH_TYPE(pop, iter_c) {
-		ASSERTeq(D_RO(iter_c)->value, TEST_VALUE);
+		UT_ASSERTeq(D_RO(iter_c)->value, TEST_VALUE);
 	}
 
 	PMEMoid oid_iter;
@@ -118,7 +118,7 @@ test_alloc_api(PMEMobjpool *pop)
 	POBJ_FOREACH(pop, oid_iter) {
 		nodes_count++;
 	}
-	ASSERTne(nodes_count, 0);
+	UT_ASSERTne(nodes_count, 0);
 
 	POBJ_FREE(&node_zeroed);
 	POBJ_FREE(&node_constructed);
@@ -127,7 +127,7 @@ test_alloc_api(PMEMobjpool *pop)
 	POBJ_FOREACH(pop, oid_iter) {
 		nodes_count++;
 	}
-	ASSERTeq(nodes_count, 0);
+	UT_ASSERTeq(nodes_count, 0);
 
 	int val = 10;
 	POBJ_ALLOC(pop, &node_constructed, struct dummy_node_c,
@@ -137,13 +137,13 @@ test_alloc_api(PMEMobjpool *pop)
 	POBJ_REALLOC(pop, &node_constructed, struct dummy_node_c,
 			sizeof (struct dummy_node_c) + 1000);
 
-	ASSERTeq(pmemobj_type_num(node_constructed.oid),
+	UT_ASSERTeq(pmemobj_type_num(node_constructed.oid),
 			TOID_TYPE_NUM(struct dummy_node_c));
 
 	POBJ_ZREALLOC(pop, &node_constructed, struct dummy_node_c,
 			sizeof (struct dummy_node_c) + 2000);
 
-	ASSERTeq(pmemobj_type_num(node_constructed.oid),
+	UT_ASSERTeq(pmemobj_type_num(node_constructed.oid),
 			TOID_TYPE_NUM(struct dummy_node_c));
 
 	POBJ_FREE(&node_constructed);
@@ -156,21 +156,21 @@ test_alloc_api(PMEMobjpool *pop)
 	int err = 0;
 
 	err = pmemobj_alloc(pop, NULL, SIZE_MAX, 0, NULL, NULL);
-	ASSERTeq(err, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(err, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 
 	err = pmemobj_zalloc(pop, NULL, SIZE_MAX, 0);
-	ASSERTeq(err, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(err, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 
 	err = pmemobj_alloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0, NULL,
 		NULL);
-	ASSERTeq(err, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(err, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 
 	err = pmemobj_zalloc(pop, NULL, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0);
-	ASSERTeq(err, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(err, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 }
 
 static void
@@ -180,88 +180,88 @@ test_realloc_api(PMEMobjpool *pop)
 	int ret;
 
 	ret = pmemobj_alloc(pop, &oid, 128, 0, NULL, NULL);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("alloc: %u, size: %zu", 128,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("alloc: %u, size: %zu", 128,
 			pmemobj_alloc_usable_size(oid));
 
 	/* grow */
 	ret = pmemobj_realloc(pop, &oid, 655360, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 128, 655360,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 128, 655360,
 			pmemobj_alloc_usable_size(oid));
 
 	/* shrink */
 	ret = pmemobj_realloc(pop, &oid, 1, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 655360, 1,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 655360, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	/* free */
 	ret = pmemobj_realloc(pop, &oid, 0, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(OID_IS_NULL(oid));
-	OUT("free");
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(OID_IS_NULL(oid));
+	UT_OUT("free");
 
 	/* alloc */
 	ret = pmemobj_realloc(pop, &oid, 777, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 0, 777,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 0, 777,
 			pmemobj_alloc_usable_size(oid));
 
 	/* shrink */
 	ret = pmemobj_realloc(pop, &oid, 1, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 777, 1,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 777, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	pmemobj_free(&oid);
-	ASSERT(OID_IS_NULL(oid));
-	OUT("free");
+	UT_ASSERT(OID_IS_NULL(oid));
+	UT_OUT("free");
 
 	/* alloc */
 	ret = pmemobj_realloc(pop, &oid, 1, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 0, 1,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 0, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	/* do nothing */
 	ret = pmemobj_realloc(pop, &oid, 1, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
-	OUT("realloc: %u => %u, size: %zu", 1, 1,
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
+	UT_OUT("realloc: %u => %u, size: %zu", 1, 1,
 			pmemobj_alloc_usable_size(oid));
 
 	pmemobj_free(&oid);
-	ASSERT(OID_IS_NULL(oid));
-	OUT("free");
+	UT_ASSERT(OID_IS_NULL(oid));
+	UT_OUT("free");
 
 	/* do nothing */
 	ret = pmemobj_realloc(pop, &oid, 0, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(OID_IS_NULL(oid));
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(OID_IS_NULL(oid));
 
 	/* alloc */
 	ret = pmemobj_realloc(pop, &oid, 1, 0);
-	ASSERTeq(ret, 0);
-	ASSERT(!OID_IS_NULL(oid));
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
 
 	/* grow beyond reasonable size */
 	ret = pmemobj_realloc(pop, &oid, SIZE_MAX, 0);
-	ASSERTeq(ret, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 
 	ret = pmemobj_realloc(pop, &oid, PMEMOBJ_MAX_ALLOC_SIZE + 1, 0);
-	ASSERTeq(ret, -1);
-	ASSERTeq(errno, ENOMEM);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(errno, ENOMEM);
 
 	pmemobj_free(&oid);
-	ASSERT(OID_IS_NULL(oid));
+	UT_ASSERT(OID_IS_NULL(oid));
 }
 
 static void
@@ -271,19 +271,19 @@ test_list_api(PMEMobjpool *pop)
 	root = POBJ_ROOT(pop, struct dummy_root);
 	int nodes_count = 0;
 
-	ASSERTeq(pmemobj_type_num(root.oid), POBJ_ROOT_TYPE_NUM);
+	UT_ASSERTeq(pmemobj_type_num(root.oid), POBJ_ROOT_TYPE_NUM);
 	UT_COMPILE_ERROR_ON(TOID_TYPE_NUM_OF(root) != POBJ_ROOT_TYPE_NUM);
 
 	TOID(struct dummy_node) first;
 	TOID(struct dummy_node) iter;
 
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+		UT_OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
 					D_RO(iter)->value);
 		nodes_count++;
 	}
 
-	ASSERTeq(nodes_count, 0);
+	UT_ASSERTeq(nodes_count, 0);
 
 	int test_val = TEST_VALUE;
 	PMEMoid ret;
@@ -292,15 +292,15 @@ test_list_api(PMEMobjpool *pop)
 	ret = POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->dummies, plist,
 			SIZE_MAX, dummy_node_constructor,
 			&test_val);
-	ASSERTeq(errno, ENOMEM);
-	ASSERT(OID_IS_NULL(ret));
+	UT_ASSERTeq(errno, ENOMEM);
+	UT_ASSERT(OID_IS_NULL(ret));
 
 	errno = 0;
 	ret = POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->dummies, plist,
 			PMEMOBJ_MAX_ALLOC_SIZE + 1, dummy_node_constructor,
 			&test_val);
-	ASSERTeq(errno, ENOMEM);
-	ASSERT(OID_IS_NULL(ret));
+	UT_ASSERTeq(errno, ENOMEM);
+	UT_ASSERT(OID_IS_NULL(ret));
 
 	POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->dummies, plist,
 			sizeof (struct dummy_node), dummy_node_constructor,
@@ -318,27 +318,27 @@ test_list_api(PMEMobjpool *pop)
 	nodes_count = 0;
 
 	POBJ_LIST_FOREACH(iter, &D_RO(root)->dummies, plist) {
-		OUT("POBJ_LIST_FOREACH: dummy_node %d", D_RO(iter)->value);
+		UT_OUT("POBJ_LIST_FOREACH: dummy_node %d", D_RO(iter)->value);
 		nodes_count++;
 	}
 
-	ASSERTeq(nodes_count, 3);
+	UT_ASSERTeq(nodes_count, 3);
 
 	/* now do the same, but w/o using FOREACH macro */
 	nodes_count = 0;
 	first = POBJ_LIST_FIRST(&D_RO(root)->dummies);
 	iter = first;
 	do {
-		OUT("POBJ_LIST_NEXT: dummy_node %d", D_RO(iter)->value);
+		UT_OUT("POBJ_LIST_NEXT: dummy_node %d", D_RO(iter)->value);
 		nodes_count++;
 		iter = POBJ_LIST_NEXT(iter, plist);
 	} while (!TOID_EQUALS(iter, first));
-	ASSERTeq(nodes_count, 3);
+	UT_ASSERTeq(nodes_count, 3);
 
 	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, &D_RW(root)->dummies,
 		&D_RW(root)->moved, node, plist, plist_m);
 
-	ASSERTeq(POBJ_LIST_EMPTY(&D_RW(root)->moved), 0);
+	UT_ASSERTeq(POBJ_LIST_EMPTY(&D_RW(root)->moved), 0);
 
 	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, &D_RW(root)->moved,
 		&D_RW(root)->dummies, node, plist_m, plist);
@@ -346,7 +346,7 @@ test_list_api(PMEMobjpool *pop)
 	POBJ_LIST_MOVE_ELEMENT_TAIL(pop, &D_RW(root)->dummies,
 		&D_RW(root)->moved, node, plist, plist_m);
 
-	ASSERTeq(POBJ_LIST_EMPTY(&D_RW(root)->moved), 0);
+	UT_ASSERTeq(POBJ_LIST_EMPTY(&D_RW(root)->moved), 0);
 
 	POBJ_LIST_MOVE_ELEMENT_TAIL(pop, &D_RW(root)->moved,
 		&D_RW(root)->dummies, node, plist_m, plist);
@@ -357,22 +357,22 @@ test_list_api(PMEMobjpool *pop)
 
 	nodes_count = 0;
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+		UT_OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
 					D_RO(iter)->value);
 		nodes_count++;
 	}
-	ASSERTeq(nodes_count, 2);
+	UT_ASSERTeq(nodes_count, 2);
 
 	/* now do the same, but w/o using FOREACH macro */
 	nodes_count = 0;
 	first = POBJ_LIST_FIRST(&D_RO(root)->dummies);
 	iter = first;
 	do {
-		OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
+		UT_OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
 		nodes_count++;
 		iter = POBJ_LIST_PREV(iter, plist);
 	} while (!TOID_EQUALS(iter, first));
-	ASSERTeq(nodes_count, 2);
+	UT_ASSERTeq(nodes_count, 2);
 
 	test_val++;
 	POBJ_LIST_INSERT_NEW_AFTER(pop, &D_RW(root)->dummies,
@@ -388,22 +388,22 @@ test_list_api(PMEMobjpool *pop)
 
 	nodes_count = 0;
 	POBJ_LIST_FOREACH_REVERSE(iter, &D_RO(root)->dummies, plist) {
-		OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
+		UT_OUT("POBJ_LIST_FOREACH_REVERSE: dummy_node %d",
 					D_RO(iter)->value);
 		nodes_count++;
 	}
-	ASSERTeq(nodes_count, 4);
+	UT_ASSERTeq(nodes_count, 4);
 
 	/* now do the same, but w/o using FOREACH macro */
 	nodes_count = 0;
 	first = POBJ_LIST_LAST(&D_RO(root)->dummies, plist);
 	iter = first;
 	do {
-		OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
+		UT_OUT("POBJ_LIST_PREV: dummy_node %d", D_RO(iter)->value);
 		nodes_count++;
 		iter = POBJ_LIST_PREV(iter, plist);
 	} while (!TOID_EQUALS(iter, first));
-	ASSERTeq(nodes_count, 4);
+	UT_ASSERTeq(nodes_count, 4);
 }
 
 static void
@@ -425,45 +425,45 @@ test_tx_api(PMEMobjpool *pop)
 		vstate = NULL;
 	} TX_END
 
-	ASSERTeq(vstate, NULL);
-	ASSERTeq(D_RW(root)->value, TEST_VALUE);
+	UT_ASSERTeq(vstate, NULL);
+	UT_ASSERTeq(D_RW(root)->value, TEST_VALUE);
 
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		TX_ADD(root);
 		D_RW(root)->node = TX_ALLOC(struct dummy_node, SIZE_MAX);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERT(TOID_IS_NULL(D_RO(root)->node));
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
 
 	errno = 0;
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		D_RW(root)->node = TX_ZALLOC(struct dummy_node, SIZE_MAX);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERT(TOID_IS_NULL(D_RO(root)->node));
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
 
 	errno = 0;
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		D_RW(root)->node = TX_ALLOC(struct dummy_node,
 			PMEMOBJ_MAX_ALLOC_SIZE + 1);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERT(TOID_IS_NULL(D_RO(root)->node));
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
 
 	errno = 0;
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		D_RW(root)->node = TX_ZALLOC(struct dummy_node,
 			PMEMOBJ_MAX_ALLOC_SIZE + 1);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERT(TOID_IS_NULL(D_RO(root)->node));
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
 
 	errno = 0;
@@ -471,22 +471,22 @@ test_tx_api(PMEMobjpool *pop)
 		TX_ADD(root);
 		D_RW(root)->node = TX_ZNEW(struct dummy_node);
 		TX_REALLOC(D_RO(root)->node, SIZE_MAX);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
-	ASSERT(TOID_IS_NULL(D_RO(root)->node));
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
 
 	errno = 0;
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		TX_ADD(root);
 		D_RW(root)->node = TX_ZNEW(struct dummy_node);
 		TX_REALLOC(D_RO(root)->node, PMEMOBJ_MAX_ALLOC_SIZE + 1);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONABORT {
-		ASSERTeq(errno, ENOMEM);
+		UT_ASSERTeq(errno, ENOMEM);
 	} TX_END
-	ASSERT(TOID_IS_NULL(D_RO(root)->node));
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->node));
 
 	errno = 0;
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
@@ -497,13 +497,13 @@ test_tx_api(PMEMobjpool *pop)
 			TEST_STR_LEN);
 		TX_SET(D_RW(root)->node, value, TEST_VALUE);
 	} TX_END
-	ASSERTeq(D_RW(D_RW(root)->node)->value, TEST_VALUE);
-	ASSERT(strncmp(D_RW(D_RW(root)->node)->teststr, TEST_STR,
+	UT_ASSERTeq(D_RW(D_RW(root)->node)->value, TEST_VALUE);
+	UT_ASSERT(strncmp(D_RW(D_RW(root)->node)->teststr, TEST_STR,
 		TEST_STR_LEN) == 0);
 
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
 		TX_ADD(root);
-		ASSERT(!TOID_IS_NULL(D_RW(root)->node));
+		UT_ASSERT(!TOID_IS_NULL(D_RW(root)->node));
 		TX_FREE(D_RW(root)->node);
 		D_RW(root)->node = TOID_NULL(struct dummy_node);
 		TOID_ASSIGN(D_RW(root)->node, OID_NULL);
@@ -513,18 +513,18 @@ test_tx_api(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TX_BEGIN(NULL) {
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
-		ASSERT(errno == EFAULT);
+		UT_ASSERT(errno == EFAULT);
 	} TX_END
 
 	errno = 0;
 	TX_BEGIN(pop) {
 		TX_BEGIN((void *)(uintptr_t)7) {
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
-		ASSERT(errno == EINVAL);
+		UT_ASSERT(errno == EINVAL);
 	} TX_END
 }
 
@@ -534,7 +534,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_basic_integration");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -542,7 +542,7 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(basic),
 			0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	test_alloc_api(pop);
 	test_realloc_api(pop);

--- a/src/test/obj_bucket/obj_bucket.c
+++ b/src/test/obj_bucket/obj_bucket.c
@@ -94,15 +94,15 @@ test_new_delete_bucket()
 
 	/* b malloc fail */
 	b = bucket_new(1, BUCKET_HUGE, CONTAINER_CTREE, 1, 1);
-	ASSERT(b == NULL);
+	UT_ASSERT(b == NULL);
 
 	/* b->ctree fail */
 	b = bucket_new(2, BUCKET_HUGE, CONTAINER_CTREE, 1, 1);
-	ASSERT(b == NULL);
+	UT_ASSERT(b == NULL);
 
 	/* all ok */
 	b = bucket_new(4, BUCKET_HUGE, CONTAINER_CTREE, 1, 1);
-	ASSERT(b != NULL);
+	UT_ASSERT(b != NULL);
 
 	bucket_delete(b);
 }
@@ -112,14 +112,14 @@ test_bucket_bitmap_correctness()
 {
 	struct bucket *b = bucket_new(1, BUCKET_RUN, CONTAINER_CTREE,
 		(RUNSIZE / 10), TEST_MAX_UNIT);
-	ASSERT(b != NULL);
+	UT_ASSERT(b != NULL);
 
 	/* 54 set (not available for allocations), and 10 clear (available) */
 	uint64_t bitmap_lastval =
 	0b1111111111111111111111111111111111111111111111111111110000000000;
 
 	struct bucket_run *r = (struct bucket_run *)b;
-	ASSERTeq(r->bitmap_lastval, bitmap_lastval);
+	UT_ASSERTeq(r->bitmap_lastval, bitmap_lastval);
 
 	bucket_delete(b);
 }
@@ -129,11 +129,11 @@ test_bucket()
 {
 	struct bucket *b = bucket_new(1, BUCKET_HUGE, CONTAINER_CTREE,
 		TEST_UNIT_SIZE, TEST_MAX_UNIT);
-	ASSERT(b != NULL);
+	UT_ASSERT(b != NULL);
 
-	ASSERT(b->unit_size == TEST_UNIT_SIZE);
-	ASSERT(b->type == BUCKET_HUGE);
-	ASSERT(b->calc_units(b, TEST_SIZE) == TEST_SIZE_UNITS);
+	UT_ASSERT(b->unit_size == TEST_UNIT_SIZE);
+	UT_ASSERT(b->type == BUCKET_HUGE);
+	UT_ASSERT(b->calc_units(b, TEST_SIZE) == TEST_SIZE_UNITS);
 
 	bucket_delete(b);
 }
@@ -143,22 +143,22 @@ test_bucket_insert_get()
 {
 	struct bucket *b = bucket_new(1, BUCKET_RUN, CONTAINER_CTREE,
 		TEST_UNIT_SIZE, TEST_MAX_UNIT);
-	ASSERT(b != NULL);
+	UT_ASSERT(b != NULL);
 
 	struct memory_block m = {TEST_CHUNK_ID, TEST_ZONE_ID,
 		TEST_SIZE_IDX, TEST_BLOCK_OFF};
 
 	/* get from empty */
-	ASSERT(CNT_OP(b, get_rm_bestfit, &m) != 0);
+	UT_ASSERT(CNT_OP(b, get_rm_bestfit, &m) != 0);
 
-	ASSERT(CNT_OP(b, insert, NULL, m) == 0);
+	UT_ASSERT(CNT_OP(b, insert, NULL, m) == 0);
 
-	ASSERT(CNT_OP(b, get_rm_bestfit, &m) == 0);
+	UT_ASSERT(CNT_OP(b, get_rm_bestfit, &m) == 0);
 
-	ASSERT(m.chunk_id == TEST_CHUNK_ID);
-	ASSERT(m.zone_id == TEST_ZONE_ID);
-	ASSERT(m.size_idx == TEST_SIZE_IDX);
-	ASSERT(m.block_off == TEST_BLOCK_OFF);
+	UT_ASSERT(m.chunk_id == TEST_CHUNK_ID);
+	UT_ASSERT(m.zone_id == TEST_ZONE_ID);
+	UT_ASSERT(m.size_idx == TEST_SIZE_IDX);
+	UT_ASSERT(m.block_off == TEST_BLOCK_OFF);
 
 	bucket_delete(b);
 }
@@ -168,14 +168,14 @@ test_bucket_remove()
 {
 	struct bucket *b = bucket_new(1, BUCKET_RUN, CONTAINER_CTREE,
 		TEST_UNIT_SIZE, TEST_MAX_UNIT);
-	ASSERT(b != NULL);
+	UT_ASSERT(b != NULL);
 
 	struct memory_block m = {TEST_CHUNK_ID, TEST_ZONE_ID,
 		TEST_SIZE_IDX, TEST_BLOCK_OFF};
 
-	ASSERT(CNT_OP(b, insert, NULL, m) == 0);
+	UT_ASSERT(CNT_OP(b, insert, NULL, m) == 0);
 
-	ASSERT(CNT_OP(b, get_rm_exact, m) == 0);
+	UT_ASSERT(CNT_OP(b, get_rm_exact, m) == 0);
 
 	bucket_delete(b);
 }

--- a/src/test/obj_check/obj_check.c
+++ b/src/test/obj_check/obj_check.c
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_check");
 	if (argc < 2) {
-		FATAL("usage: obj_check file");
+		UT_FATAL("usage: obj_check file");
 	}
 
 	const char *path = argv[1];
@@ -53,13 +53,13 @@ main(int argc, char *argv[])
 
 	switch (ret) {
 	case 1:
-		OUT("consistent");
+		UT_OUT("consistent");
 		break;
 	case 0:
-		OUT("not consistent: %s", pmemobj_errormsg());
+		UT_OUT("not consistent: %s", pmemobj_errormsg());
 		break;
 	default:
-		OUT("error: %s", pmemobj_errormsg());
+		UT_OUT("error: %s", pmemobj_errormsg());
 		break;
 	}
 

--- a/src/test/obj_constructor/obj_constructor.c
+++ b/src/test/obj_constructor/obj_constructor.c
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_constructor");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(constr),
 			0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	/*
 	 * Allocate memory until OOM, so we can check later if the alloc
@@ -96,7 +96,7 @@ main(int argc, char *argv[])
 			NULL, NULL) == 0)
 		allocs++;
 
-	ASSERTne(allocs, 0);
+	UT_ASSERTne(allocs, 0);
 
 	PMEMoid oid;
 	PMEMoid next;
@@ -106,33 +106,33 @@ main(int argc, char *argv[])
 	errno = 0;
 	root.oid = pmemobj_root_construct(pop, sizeof (struct root),
 			root_constr_cancel, NULL);
-	ASSERT(TOID_IS_NULL(root));
-	ASSERTeq(errno, ECANCELED);
+	UT_ASSERT(TOID_IS_NULL(root));
+	UT_ASSERTeq(errno, ECANCELED);
 
 	errno = 0;
 	ret = pmemobj_alloc(pop, NULL, sizeof (struct node), 1,
 			node_constr_cancel, NULL);
-	ASSERTeq(ret, -1);
-	ASSERTeq(errno, ECANCELED);
+	UT_ASSERTeq(ret, -1);
+	UT_ASSERTeq(errno, ECANCELED);
 
 	/* the same number of allocations should be possible. */
 	while (pmemobj_alloc(pop, NULL, sizeof (struct node), 1,
 			NULL, NULL) == 0)
 		allocs--;
-	ASSERTeq(allocs, 0);
+	UT_ASSERTeq(allocs, 0);
 	POBJ_FOREACH_SAFE(pop, oid, next)
 		pmemobj_free(&oid);
 
 	root.oid = pmemobj_root_construct(pop, sizeof (struct root),
 			NULL, NULL);
-	ASSERT(!TOID_IS_NULL(root));
+	UT_ASSERT(!TOID_IS_NULL(root));
 
 	errno = 0;
 	node.oid = pmemobj_list_insert_new(pop, offsetof(struct node, next),
 			&D_RW(root)->list, OID_NULL, 0, sizeof (struct node),
 			1, node_constr_cancel, NULL);
-	ASSERT(TOID_IS_NULL(node));
-	ASSERTeq(errno, ECANCELED);
+	UT_ASSERT(TOID_IS_NULL(node));
+	UT_ASSERTeq(errno, ECANCELED);
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -97,7 +97,7 @@ void reader_mutex(persistent_ptr<struct root> proot)
 	while (proot->counter != limit)
 		proot->cond.wait(proot->pmutex);
 
-	ASSERTeq(proot->counter, limit);
+	UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -110,7 +110,7 @@ void reader_mutex_pred(persistent_ptr<struct root> proot)
 	proot->cond.wait(proot->pmutex,
 			[&](){ return proot->counter == limit; });
 
-	ASSERTeq(proot->counter, limit);
+	UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -123,7 +123,7 @@ void reader_lock(persistent_ptr<struct root> proot)
 	while (proot->counter != limit)
 		proot->cond.wait(proot->pmutex);
 
-	ASSERTeq(proot->counter, limit);
+	UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -135,7 +135,7 @@ void reader_lock_pred(persistent_ptr<struct root> proot)
 	std::unique_lock<mutex> lock(proot->pmutex);
 	proot->cond.wait(lock, [&](){ return proot->counter == limit; });
 
-	ASSERTeq(proot->counter, limit);
+	UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -151,9 +151,9 @@ void reader_mutex_until(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::steady_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -170,9 +170,9 @@ void reader_mutex_until_pred(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -188,9 +188,9 @@ void reader_lock_until(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -207,9 +207,9 @@ void reader_lock_until_pred(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -225,9 +225,9 @@ void reader_mutex_for(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -244,9 +244,9 @@ void reader_mutex_for_pred(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	proot->pmutex.unlock();
 }
 
@@ -262,9 +262,9 @@ void reader_lock_for(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -281,9 +281,9 @@ void reader_lock_for_pred(persistent_ptr<struct root> proot)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq(proot->counter, limit);
+		UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
 }
 
@@ -317,7 +317,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_cond_var");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -327,7 +327,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	std::vector<reader_type> notify_functions({ reader_mutex,

--- a/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
+++ b/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
@@ -108,7 +108,7 @@ void *reader_mutex(void *arg)
 	while ((*proot)->counter != limit)
 		(*proot)->cond.wait((*proot)->pmutex);
 
-	ASSERTeq((*proot)->counter, limit);
+	UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -125,7 +125,7 @@ void *reader_mutex_pred(void *arg)
 	(*proot)->cond.wait((*proot)->pmutex,
 			[&](){ return (*proot)->counter == limit; });
 
-	ASSERTeq((*proot)->counter, limit);
+	UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -142,7 +142,7 @@ void *reader_lock(void *arg)
 	while ((*proot)->counter != limit)
 		(*proot)->cond.wait((*proot)->pmutex);
 
-	ASSERTeq((*proot)->counter, limit);
+	UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -158,7 +158,7 @@ void *reader_lock_pred(void *arg)
 	std::unique_lock<mutex> lock((*proot)->pmutex);
 	(*proot)->cond.wait(lock, [&](){ return (*proot)->counter == limit; });
 
-	ASSERTeq((*proot)->counter, limit);
+	UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -178,9 +178,9 @@ void *reader_mutex_until(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -201,9 +201,9 @@ void *reader_mutex_until_pred(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -223,9 +223,9 @@ void *reader_lock_until(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -246,9 +246,9 @@ void *reader_lock_until_pred(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -268,9 +268,9 @@ void *reader_mutex_for(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -291,9 +291,9 @@ void *reader_mutex_for_pred(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -313,9 +313,9 @@ void *reader_lock_for(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -336,9 +336,9 @@ void *reader_lock_for_pred(void *arg)
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false)
-		ASSERT(now >= until);
+		UT_ASSERT(now >= until);
 	else
-		ASSERTeq((*proot)->counter, limit);
+		UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
 
 	return nullptr;
@@ -375,7 +375,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_cond_var_posix");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -385,7 +385,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	std::vector<reader_type> notify_functions({ reader_mutex,

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
@@ -71,9 +71,9 @@ public:
 	 */
 	void check_foo(int val, char arr_val)
 	{
-		ASSERTeq(val, this->bar);
+		UT_ASSERTeq(val, this->bar);
 		for (int i = 0; i < TEST_ARR_SIZE; ++i)
-			ASSERTeq(arr_val, this->arr[i]);
+			UT_ASSERTeq(arr_val, this->arr[i]);
 	}
 
 	p<int> bar;
@@ -93,19 +93,19 @@ test_make_no_args(pool<struct root> &pop)
 	persistent_ptr<root> r = pop.get_root();
 
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		r->pfoo = make_persistent<foo>();
 		r->pfoo->check_foo(1, 1);
 
 		delete_persistent<foo>(r->pfoo);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 /*
@@ -116,26 +116,26 @@ test_make_args(pool<struct root> &pop)
 {
 	persistent_ptr<root> r = pop.get_root();
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		pmemobj_tx_add_range_direct(&r->pfoo, sizeof(r->pfoo));
 		r->pfoo = make_persistent<foo>(2);
 		r->pfoo->check_foo(2, 2);
 
 		delete_persistent<foo>(r->pfoo);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		r->pfoo = make_persistent<foo>(3, 4);
 		r->pfoo->check_foo(3, 4);
 
 		delete_persistent<foo>(r->pfoo);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 /*
@@ -147,31 +147,31 @@ test_additional_delete(pool<struct root> &pop)
 	persistent_ptr<root> r = pop.get_root();
 
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		r->pfoo = make_persistent<foo>();
 		r->pfoo->check_foo(1, 1);
 	} TX_END
 
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo != nullptr);
+		UT_ASSERT(r->pfoo != nullptr);
 		delete_persistent<foo>(r->pfoo);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 		delete_persistent<foo>(r->pfoo);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		pmemobj_tx_abort(EINVAL);
 	} TX_END
 
-	ASSERT(r->pfoo != nullptr);
+	UT_ASSERT(r->pfoo != nullptr);
 	r->pfoo->check_foo(1, 1);
 
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo != nullptr);
+		UT_ASSERT(r->pfoo != nullptr);
 		delete_persistent<foo>(r->pfoo);
 	} TX_END
 
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 }
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_make_persistent");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -192,7 +192,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	test_make_no_args(pop);

--- a/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
+++ b/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
@@ -61,9 +61,9 @@ public:
 	 */
 	void check_foo()
 	{
-		ASSERTeq(1, this->bar);
+		UT_ASSERTeq(1, this->bar);
 		for (int i = 0; i < TEST_ARR_SIZE; ++i)
-			ASSERTeq(1, this->arr[i]);
+			UT_ASSERTeq(1, this->arr[i]);
 	}
 
 	~foo()
@@ -94,24 +94,24 @@ test_make_one_d(pool_base &pop)
 			pfoo[i].check_foo();
 
 		delete_persistent<foo[]>(pfoo, 5);
-		ASSERT(pfoo == nullptr);
+		UT_ASSERT(pfoo == nullptr);
 
 		auto pfoo2 = make_persistent<foo[]>(6);
 		for (int i = 0; i < 6; ++i)
 			pfoo2[i].check_foo();
 
 		delete_persistent<foo[]>(pfoo2, 6);
-		ASSERT(pfoo2 == nullptr);
+		UT_ASSERT(pfoo2 == nullptr);
 
 		auto pfooN = make_persistent<foo[5]>();
 		for (int i = 0; i < 5; ++i)
 			pfooN[i].check_foo();
 
 		delete_persistent<foo[5]>(pfooN);
-		ASSERT(pfooN == nullptr);
+		UT_ASSERT(pfooN == nullptr);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 }
 
@@ -129,7 +129,7 @@ test_make_two_d(pool_base &pop)
 				pfoo[i][j].check_foo();
 
 		delete_persistent<foo[][2]>(pfoo, 5);
-		ASSERT(pfoo == nullptr);
+		UT_ASSERT(pfoo == nullptr);
 
 		auto pfoo2 = make_persistent<foo[][3]>(6);
 		for (int i = 0; i < 6; ++i)
@@ -137,7 +137,7 @@ test_make_two_d(pool_base &pop)
 				pfoo2[i][j].check_foo();
 
 		delete_persistent<foo[][3]>(pfoo2, 6);
-		ASSERT(pfoo2 == nullptr);
+		UT_ASSERT(pfoo2 == nullptr);
 
 		auto pfooN = make_persistent<foo[5][2]>();
 		for (int i = 0; i < 5; ++i)
@@ -145,10 +145,10 @@ test_make_two_d(pool_base &pop)
 				pfooN[i][j].check_foo();
 
 		delete_persistent<foo[5][2]>(pfooN);
-		ASSERT(pfooN == nullptr);
+		UT_ASSERT(pfooN == nullptr);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 }
 
@@ -168,21 +168,21 @@ test_abort_revert(pool_base &pop)
 	} TX_END
 
 	TX_BEGIN(pop.get_handle()) {
-		ASSERT(r->pfoo != nullptr);
+		UT_ASSERT(r->pfoo != nullptr);
 		delete_persistent<foo[]>(r->pfoo, 5);
-		ASSERT(r->pfoo == nullptr);
+		UT_ASSERT(r->pfoo == nullptr);
 
 		pmemobj_tx_abort(EINVAL);
 	} TX_END
 
-	ASSERT(r->pfoo != nullptr);
+	UT_ASSERT(r->pfoo != nullptr);
 	for (int i = 0; i < 5; ++i)
 		r->pfoo[i].check_foo();
 
 	TX_BEGIN(pop.get_handle()) {
 		delete_persistent<foo[]>(r->pfoo, 5);
 	} TX_END
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 }
@@ -193,7 +193,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_make_persistent_array");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -203,7 +203,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	test_make_one_d(pop);

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
@@ -62,9 +62,9 @@ public:
 	 */
 	void check_foo()
 	{
-		ASSERTeq(1, this->bar);
+		UT_ASSERTeq(1, this->bar);
 		for (int i = 0; i < TEST_ARR_SIZE; ++i)
-			ASSERTeq(1, this->arr[i]);
+			UT_ASSERTeq(1, this->arr[i]);
 	}
 
 	~foo() = default;
@@ -97,14 +97,14 @@ test_make_one_d(pool_base &pop)
 		pfoo[i].check_foo();
 
 	delete_persistent_atomic<foo[]>(pfoo, 5);
-	ASSERT(pfoo == nullptr);
+	UT_ASSERT(pfoo == nullptr);
 
 	make_persistent_atomic<foo[]>(pop, pfoo, 6);
 	for (int i = 0; i < 6; ++i)
 		pfoo[i].check_foo();
 
 	delete_persistent_atomic<foo[]>(pfoo, 6);
-	ASSERT(pfoo == nullptr);
+	UT_ASSERT(pfoo == nullptr);
 
 	persistent_ptr<foo[5]> pfooN;
 	make_persistent_atomic<foo[5]>(pop, pfooN);
@@ -112,7 +112,7 @@ test_make_one_d(pool_base &pop)
 		pfooN[i].check_foo();
 
 	delete_persistent_atomic<foo[5]>(pfooN);
-	ASSERT(pfooN == nullptr);
+	UT_ASSERT(pfooN == nullptr);
 }
 
 /*
@@ -128,7 +128,7 @@ test_make_two_d(pool_base &pop)
 			pfoo[i][j].check_foo();
 
 	delete_persistent_atomic<foo[][2]>(pfoo, 5);
-	ASSERT(pfoo == nullptr);
+	UT_ASSERT(pfoo == nullptr);
 
 	persistent_ptr<foo[][3]> pfoo2;
 	make_persistent_atomic<foo[][3]>(pop, pfoo2, 6);
@@ -137,7 +137,7 @@ test_make_two_d(pool_base &pop)
 			pfoo2[i][j].check_foo();
 
 	delete_persistent_atomic<foo[][3]>(pfoo2, 6);
-	ASSERT(pfoo2 == nullptr);
+	UT_ASSERT(pfoo2 == nullptr);
 
 	persistent_ptr<foo[5][2]> pfooN;
 	make_persistent_atomic<foo[5][2]>(pop, pfooN);
@@ -146,7 +146,7 @@ test_make_two_d(pool_base &pop)
 			pfooN[i][j].check_foo();
 
 	delete_persistent_atomic<foo[5][2]>(pfooN);
-	ASSERT(pfooN == nullptr);
+	UT_ASSERT(pfooN == nullptr);
 }
 
 /*
@@ -164,7 +164,7 @@ test_constructor_exception(pool_base &pop)
 		except = true;
 	}
 
-	ASSERT(except);
+	UT_ASSERT(except);
 }
 
 }
@@ -175,7 +175,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_make_persistent_array_atomic");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -185,7 +185,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	test_make_one_d(pop);

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
@@ -72,9 +72,9 @@ public:
 	 */
 	void check_foo(int val, char arr_val)
 	{
-		ASSERTeq(val, this->bar);
+		UT_ASSERTeq(val, this->bar);
 		for (int i = 0; i < TEST_ARR_SIZE; ++i)
-			ASSERTeq(arr_val, this->arr[i]);
+			UT_ASSERTeq(arr_val, this->arr[i]);
 	}
 
 	p<int> bar;
@@ -93,13 +93,13 @@ test_make_no_args(pool<struct root> &pop)
 {
 	persistent_ptr<root> r = pop.get_root();
 
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 
 	make_persistent_atomic<foo>(pop, r->pfoo);
 	r->pfoo->check_foo(1, 1);
 
 	delete_persistent_atomic<foo>(r->pfoo);
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 /*
@@ -109,19 +109,19 @@ void
 test_make_args(pool<struct root> &pop)
 {
 	persistent_ptr<root> r = pop.get_root();
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 
 	make_persistent_atomic<foo>(pop, r->pfoo, 2);
 	r->pfoo->check_foo(2, 2);
 
 	delete_persistent_atomic<foo>(r->pfoo);
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 
 	make_persistent_atomic<foo>(pop, r->pfoo, 3, 4);
 	r->pfoo->check_foo(3, 4);
 
 	delete_persistent_atomic<foo>(r->pfoo);
-	ASSERT(r->pfoo == nullptr);
+	UT_ASSERT(r->pfoo == nullptr);
 }
 
 }
@@ -132,7 +132,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_make_persistent_atomic");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -142,7 +142,7 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	test_make_no_args(pop);

--- a/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
+++ b/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
@@ -123,7 +123,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_mutex");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -133,17 +133,17 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	mutex_test(pop, increment_pint);
-	ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
 
 	mutex_test(pop, decrement_pint);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	mutex_test(pop, trylock_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	/* pmemcheck related persist */
 	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),

--- a/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
+++ b/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
@@ -133,7 +133,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_mutex_posix");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -143,17 +143,17 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	mutex_test(pop, increment_pint);
-	ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
 
 	mutex_test(pop, decrement_pint);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	mutex_test(pop, trylock_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	/* pmemcheck related persist */
 	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -73,8 +73,8 @@ persistent_ptr<root> init_foobar(pmemobjpool *pop)
 {
 	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
 		TX_BEGIN(pop) {
-			ASSERT(r->bar_ptr == nullptr);
-			ASSERT(r->foo_ptr == nullptr);
+			UT_ASSERT(r->bar_ptr == nullptr);
+			UT_ASSERT(r->foo_ptr == nullptr);
 
 			r->bar_ptr = pmemobj_tx_alloc(sizeof (bar), 0);
 			r->foo_ptr = pmemobj_tx_alloc(sizeof (foo), 0);
@@ -86,7 +86,7 @@ persistent_ptr<root> init_foobar(pmemobjpool *pop)
 			r->foo_ptr->pint = 1;
 			r->foo_ptr->pllong = 2;
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 	return r;
@@ -100,19 +100,19 @@ void cleanup_foobar(pmemobjpool *pop)
 	persistent_ptr<root> r = pmemobj_root(pop, sizeof (root));
 
 	TX_BEGIN(pop) {
-		ASSERT(r->bar_ptr != nullptr);
-		ASSERT(r->foo_ptr != nullptr);
+		UT_ASSERT(r->bar_ptr != nullptr);
+		UT_ASSERT(r->foo_ptr != nullptr);
 
 		pmemobj_tx_free(r->bar_ptr.raw());
 		r->bar_ptr = nullptr;
 		pmemobj_tx_free(r->foo_ptr.raw());
 		r->foo_ptr = nullptr;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(r->bar_ptr == nullptr);
-	ASSERT(r->foo_ptr == nullptr);
+	UT_ASSERT(r->bar_ptr == nullptr);
+	UT_ASSERT(r->foo_ptr == nullptr);
 }
 
 /*
@@ -129,12 +129,12 @@ void arithmetic_test(pmemobjpool *pop)
 		r->foo_ptr->puchar += r->foo_ptr->puchar;
 		r->foo_ptr->puchar += r->foo_ptr->pint;
 		r->foo_ptr->puchar += 2;
-		ASSERTeq(r->foo_ptr->puchar, 3);
+		UT_ASSERTeq(r->foo_ptr->puchar, 3);
 
 		r->foo_ptr->pint = r->foo_ptr->pint + r->foo_ptr->puchar;
 		r->foo_ptr->pint = r->foo_ptr->pint + r->foo_ptr->pint;
 		r->foo_ptr->pint = r->foo_ptr->pllong + 8;
-		ASSERTeq(r->foo_ptr->pint, 10);
+		UT_ASSERTeq(r->foo_ptr->pint, 10);
 
 		/* for float assertions */
 		float epsilon = 0.001;
@@ -142,20 +142,20 @@ void arithmetic_test(pmemobjpool *pop)
 		/* subtraction */
 		r->bar_ptr->pdouble -= r->foo_ptr->puchar;
 		r->bar_ptr->pfloat -= 2;
-		ASSERT(std::fabs(r->bar_ptr->pdouble + 2) < epsilon);
-		ASSERT(std::fabs(r->bar_ptr->pfloat) < epsilon);
+		UT_ASSERT(std::fabs(r->bar_ptr->pdouble + 2) < epsilon);
+		UT_ASSERT(std::fabs(r->bar_ptr->pfloat) < epsilon);
 
 		r->bar_ptr->pfloat = r->bar_ptr->pfloat - r->bar_ptr->pdouble;
 		r->bar_ptr->pdouble = r->bar_ptr->pdouble - r->bar_ptr->pfloat;
-		ASSERT(std::fabs(r->bar_ptr->pfloat - 2) < epsilon);
-		ASSERT(std::fabs(r->bar_ptr->pdouble + 4) < epsilon);
+		UT_ASSERT(std::fabs(r->bar_ptr->pfloat - 2) < epsilon);
+		UT_ASSERT(std::fabs(r->bar_ptr->pdouble + 4) < epsilon);
 
 
 		/* multiplication */
 		r->foo_ptr->puchar *= r->foo_ptr->puchar;
 		r->foo_ptr->puchar *= r->foo_ptr->pint;
 		r->foo_ptr->puchar *= r->foo_ptr->pllong;
-		ASSERTeq(r->foo_ptr->puchar, 180);
+		UT_ASSERTeq(r->foo_ptr->puchar, 180);
 
 
 		r->foo_ptr->pint = r->foo_ptr->pint * r->foo_ptr->puchar;
@@ -175,24 +175,24 @@ void arithmetic_test(pmemobjpool *pop)
 		/* prefix */
 		++r->foo_ptr->pllong;
 		--r->foo_ptr->pllong;
-		ASSERTeq(r->foo_ptr->pllong, 2);
+		UT_ASSERTeq(r->foo_ptr->pllong, 2);
 
 		/* postfix */
 		r->foo_ptr->pllong++;
 		r->foo_ptr->pllong--;
-		ASSERTeq(r->foo_ptr->pllong, 2);
+		UT_ASSERTeq(r->foo_ptr->pllong, 2);
 
 		/* modulo */
 		r->foo_ptr->pllong = 12;
 		r->foo_ptr->pllong %= 7;
-		ASSERTeq(r->foo_ptr->pllong, 5);
+		UT_ASSERTeq(r->foo_ptr->pllong, 5);
 		r->foo_ptr->pllong = r->foo_ptr->pllong % 3;
-		ASSERTeq(r->foo_ptr->pllong, 2);
+		UT_ASSERTeq(r->foo_ptr->pllong, 2);
 		r->foo_ptr->pllong = r->foo_ptr->pllong % r->foo_ptr->pllong;
-		ASSERTeq(r->foo_ptr->pllong, 0);
+		UT_ASSERTeq(r->foo_ptr->pllong, 0);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	cleanup_foobar(pop);
@@ -209,34 +209,34 @@ void bitwise_test(pmemobjpool *pop)
 		r->foo_ptr->puchar |= r->foo_ptr->pllong;
 		r->foo_ptr->puchar |= r->foo_ptr->pint;
 		r->foo_ptr->puchar |= 4;
-		ASSERTeq(r->foo_ptr->puchar, 7);
+		UT_ASSERTeq(r->foo_ptr->puchar, 7);
 
 		r->foo_ptr->pint = r->foo_ptr->pint | r->foo_ptr->puchar;
 		r->foo_ptr->pint = r->foo_ptr->pint | r->foo_ptr->pint;
 		r->foo_ptr->pint = r->foo_ptr->pllong | 0xF;
-		ASSERTeq(r->foo_ptr->pint, 15);
+		UT_ASSERTeq(r->foo_ptr->pint, 15);
 
 		/* AND */
 		r->foo_ptr->puchar &= r->foo_ptr->puchar;
 		r->foo_ptr->puchar &= r->foo_ptr->pint;
 		r->foo_ptr->puchar &= 2;
-		ASSERTeq(r->foo_ptr->puchar, 2);
+		UT_ASSERTeq(r->foo_ptr->puchar, 2);
 
 		r->foo_ptr->pint = r->foo_ptr->pint & r->foo_ptr->puchar;
 		r->foo_ptr->pint = r->foo_ptr->pint & r->foo_ptr->pint;
 		r->foo_ptr->pint = r->foo_ptr->pllong & 8;
-		ASSERTeq(r->foo_ptr->pint, 0);
+		UT_ASSERTeq(r->foo_ptr->pint, 0);
 
 		/* XOR */
 		r->foo_ptr->puchar ^= r->foo_ptr->puchar;
 		r->foo_ptr->puchar ^= r->foo_ptr->pint;
 		r->foo_ptr->puchar ^= 2;
-		ASSERTeq(r->foo_ptr->puchar, 2);
+		UT_ASSERTeq(r->foo_ptr->puchar, 2);
 
 		r->foo_ptr->pint = r->foo_ptr->pint ^ r->foo_ptr->puchar;
 		r->foo_ptr->pint = r->foo_ptr->pint ^ r->foo_ptr->pint;
 		r->foo_ptr->pint = r->foo_ptr->pllong ^ 8;
-		ASSERTeq(r->foo_ptr->pint, 10);
+		UT_ASSERTeq(r->foo_ptr->pint, 10);
 
 		/* RSHIFT */
 		r->foo_ptr->puchar = 255;
@@ -244,7 +244,7 @@ void bitwise_test(pmemobjpool *pop)
 		r->foo_ptr->puchar >>= r->foo_ptr->pllong;
 		r->foo_ptr->puchar = r->foo_ptr->pllong >> 2;
 		r->foo_ptr->puchar = r->foo_ptr->pllong >> r->foo_ptr->pllong;
-		ASSERTeq(r->foo_ptr->puchar, 0);
+		UT_ASSERTeq(r->foo_ptr->puchar, 0);
 
 		/* LSHIFT */
 		r->foo_ptr->puchar = 1;
@@ -252,14 +252,14 @@ void bitwise_test(pmemobjpool *pop)
 		r->foo_ptr->puchar <<= r->foo_ptr->pllong;
 		r->foo_ptr->puchar = r->foo_ptr->pllong << 2;
 		r->foo_ptr->puchar = r->foo_ptr->pllong << r->foo_ptr->pllong;
-		ASSERTeq(r->foo_ptr->puchar, 8);
+		UT_ASSERTeq(r->foo_ptr->puchar, 8);
 
 		/* COMPLEMENT */
 		r->foo_ptr->pint = 1;
-		ASSERTeq(~r->foo_ptr->pint, ~1);
+		UT_ASSERTeq(~r->foo_ptr->pint, ~1);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	cleanup_foobar(pop);
@@ -280,9 +280,9 @@ void stream_test(pmemobjpool *pop)
 		r->bar_ptr->pdouble += 3.7;
 		stream << r->bar_ptr->pdouble;
 		stream >> r->foo_ptr->pint;
-		ASSERTeq(r->foo_ptr->pint, 16);
+		UT_ASSERTeq(r->foo_ptr->pint, 16);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	cleanup_foobar(pop);
@@ -296,7 +296,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_p_ext");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -304,7 +304,7 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	arithmetic_test(pop);
 	bitwise_test(pop);

--- a/src/test/obj_cpp_pool/obj_cpp_pool.cpp
+++ b/src/test/obj_cpp_pool/obj_cpp_pool.cpp
@@ -62,30 +62,30 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 		pop = pool<root>::create(path, layout, poolsize,
 				mode);
 		persistent_ptr<root> root = pop.get_root();
-		ASSERT(root != nullptr);
+		UT_ASSERT(root != nullptr);
 	} catch (nvml::pool_error &) {
-		OUT("!%s: pool::create", path);
+		UT_OUT("!%s: pool::create", path);
 		return;
 	}
 
 	struct stat stbuf;
 	STAT(path, &stbuf);
 
-	OUT("%s: file size %zu mode 0%o", path, stbuf.st_size,
+	UT_OUT("%s: file size %zu mode 0%o", path, stbuf.st_size,
 			stbuf.st_mode & 0777);
 	try {
 		pop.close();
 	} catch (std::logic_error &lr) {
-		OUT("%s: pool.close: %s", path, lr.what());
+		UT_OUT("%s: pool.close: %s", path, lr.what());
 		return;
 	}
 
 	int result = pool<root>::check(path, layout);
 
 	if (result < 0)
-		OUT("!%s: pool::check", path);
+		UT_OUT("!%s: pool::check", path);
 	else if (result == 0)
-		OUT("%s: pool::check: not consistent", path);
+		UT_OUT("%s: pool::check: not consistent", path);
 }
 
 /*
@@ -98,16 +98,16 @@ pool_open(const char *path, const char *layout)
 	try {
 		pop = pool<root>::open(path, layout);
 	} catch (nvml::pool_error &) {
-		OUT("!%s: pool::open", path);
+		UT_OUT("!%s: pool::open", path);
 		return;
 	}
 
-	OUT("%s: pool::open: Success", path);
+	UT_OUT("%s: pool::open: Success", path);
 
 	try {
 		pop.close();
 	} catch (std::logic_error &lr) {
-		OUT("%s: pool.close: %s", path, lr.what());
+		UT_OUT("%s: pool.close: %s", path, lr.what());
 	}
 
 }
@@ -124,18 +124,18 @@ double_close(const char *path, const char *layout, size_t poolsize,
 		pop = pool<root>::create(path, layout, poolsize,
 				mode);
 	} catch (nvml::pool_error &) {
-		OUT("!%s: pool::create", path);
+		UT_OUT("!%s: pool::create", path);
 		return;
 	}
 
-	OUT("%s: pool::create: Success", path);
+	UT_OUT("%s: pool::create: Success", path);
 
 	try {
 		pop.close();
-		OUT("%s: pool.close: Success", path);
+		UT_OUT("%s: pool.close: Success", path);
 		pop.close();
 	} catch (std::logic_error &lr) {
-		OUT("%s: pool.close: %s", path, lr.what());
+		UT_OUT("%s: pool.close: %s", path, lr.what());
 	}
 
 }
@@ -148,7 +148,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_pool");
 
 	if (argc < 4)
-		FATAL("usage: %s op path layout [poolsize mode]", argv[0]);
+		UT_FATAL("usage: %s op path layout [poolsize mode]", argv[0]);
 
 	const char * layout = nullptr;
 	size_t poolsize;
@@ -177,7 +177,7 @@ main(int argc, char *argv[])
 		double_close(argv[2], layout, poolsize, mode);
 		break;
 	default:
-		FATAL("unknown operation");
+		UT_FATAL("unknown operation");
 	}
 
 	DONE(NULL);

--- a/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
+++ b/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
@@ -64,15 +64,15 @@ void
 pool_test_memset(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	void *ret = pop.memset_persist(&root->val, TEST_VAL,
 			sizeof (root->val));
-	ASSERTeq(ret, &root->val);
+	UT_ASSERTeq(ret, &root->val);
 
 	int c;
 	memset(&c, TEST_VAL, sizeof (c));
-	ASSERTeq(root->val, c);
+	UT_ASSERTeq(root->val, c);
 }
 
 /*
@@ -82,13 +82,13 @@ void
 pool_test_memcpy(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	int v = TEST_VAL;
 	void *ret = pop.memcpy_persist(&root->val, &v,
 			sizeof (root->val));
-	ASSERTeq(ret, &root->val);
-	ASSERTeq(root->val, v);
+	UT_ASSERTeq(ret, &root->val);
+	UT_ASSERTeq(root->val, v);
 }
 
 /*
@@ -107,7 +107,7 @@ void
 pool_test_flush(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
 
@@ -121,7 +121,7 @@ void
 pool_test_flush_p(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
 
@@ -135,7 +135,7 @@ void
 pool_test_flush_ptr(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 
@@ -150,7 +150,7 @@ void
 pool_test_flush_ptr_obj(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 	root->val = TEST_VAL;
@@ -166,7 +166,7 @@ void
 pool_test_flush_ptr_obj_no_pop(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 	root->val = TEST_VAL;
@@ -181,7 +181,7 @@ void
 pool_test_persist(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
 
@@ -195,7 +195,7 @@ void
 pool_test_persist_p(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->val = TEST_VAL;
 
@@ -209,7 +209,7 @@ void
 pool_test_persist_ptr(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 
@@ -224,7 +224,7 @@ void
 pool_test_persist_ptr_obj(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 	root->val = TEST_VAL;
@@ -240,7 +240,7 @@ void
 pool_test_persist_ptr_obj_no_pop(pool<root> &pop)
 {
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	root->me = root;
 	root->val = TEST_VAL;
@@ -258,7 +258,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 	pool<root> pop = pool<root>::create(path, layout, poolsize,
 			mode);
 	persistent_ptr<root> root = pop.get_root();
-	ASSERT(root != nullptr);
+	UT_ASSERT(root != nullptr);
 
 	return pop;
 }
@@ -272,7 +272,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_pool_primitives");
 
 	if (argc != 2)
-		FATAL("usage: %s path", argv[0]);
+		UT_FATAL("usage: %s path", argv[0]);
 
 	pool<root> pop = pool_create(argv[1], "layout", 32 * MB, 0666);
 

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
@@ -63,7 +63,7 @@ prepare_array(PMEMobjpool *pop)
 	ret = pmemobj_alloc(pop, parr_vsize.raw_ptr(),
 		sizeof (T) * TEST_ARR_SIZE,
 		0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 
 	T *parray = parr_vsize.get();
 
@@ -72,11 +72,11 @@ prepare_array(PMEMobjpool *pop)
 			parray[i] = i;
 		}
 	} TX_ONABORT {
-		FATAL("Transactional prepare_array aborted");
+		UT_FATAL("Transactional prepare_array aborted");
 	} TX_END;
 
 	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
-		ASSERTeq(parray[i], i);
+		UT_ASSERTeq(parray[i], i);
 	}
 
 	return parr_vsize;
@@ -92,55 +92,55 @@ test_arith(PMEMobjpool *pop)
 
 	/* test prefix postfix operators */
 	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
-		ASSERTeq(*parr_vsize, i);
+		UT_ASSERTeq(*parr_vsize, i);
 		parr_vsize++;
 	}
 
 	for (int i = TEST_ARR_SIZE; i > 0; --i) {
 		parr_vsize--;
-		ASSERTeq(*parr_vsize, i - 1);
+		UT_ASSERTeq(*parr_vsize, i - 1);
 	}
 
 	for (int i = 0; i < TEST_ARR_SIZE; ++i) {
-		ASSERTeq(*parr_vsize, i);
+		UT_ASSERTeq(*parr_vsize, i);
 		++parr_vsize;
 	}
 
 	for (int i = TEST_ARR_SIZE; i > 0; --i) {
 		--parr_vsize;
-		ASSERTeq(*parr_vsize, i - 1);
+		UT_ASSERTeq(*parr_vsize, i - 1);
 	}
 
 	/* test addition assignment and subtraction */
 	parr_vsize += 2;
-	ASSERTeq(*parr_vsize, 2);
+	UT_ASSERTeq(*parr_vsize, 2);
 
 	parr_vsize -= 2;
-	ASSERTeq(*parr_vsize, 0);
+	UT_ASSERTeq(*parr_vsize, 0);
 
 	/* test strange invocations, parameter ignored */
 	parr_vsize.operator++(5);
-	ASSERTeq(*parr_vsize, 1);
+	UT_ASSERTeq(*parr_vsize, 1);
 
 	parr_vsize.operator--(2);
-	ASSERTeq(*parr_vsize, 0);
+	UT_ASSERTeq(*parr_vsize, 0);
 
 	/* test subtraction and addition */
 	for (int i = 0; i < TEST_ARR_SIZE; ++i)
-		ASSERTeq(*(parr_vsize + i), i);
+		UT_ASSERTeq(*(parr_vsize + i), i);
 
 	/* using STL one-pas-end style */
 	persistent_ptr<p<int>> parr_end = parr_vsize + TEST_ARR_SIZE;
 
 	for (int i = TEST_ARR_SIZE; i > 0; --i)
-		ASSERTeq(*(parr_end - i), TEST_ARR_SIZE - i);
+		UT_ASSERTeq(*(parr_end - i), TEST_ARR_SIZE - i);
 
-	ASSERTeq(parr_end - parr_vsize, TEST_ARR_SIZE);
+	UT_ASSERTeq(parr_end - parr_vsize, TEST_ARR_SIZE);
 
 	/* check ostream operator */
 	std::stringstream stream;
 	stream << parr_vsize;
-	OUT("%s", stream.str().c_str());
+	UT_OUT("%s", stream.str().c_str());
 }
 
 /*
@@ -153,36 +153,36 @@ test_relational(PMEMobjpool *pop)
 	persistent_ptr<p<int>> first_elem = prepare_array<p<int>>(pop);
 	persistent_ptr<p<int>> last_elem = first_elem + TEST_ARR_SIZE - 1;
 
-	ASSERT(first_elem != last_elem);
-	ASSERT(first_elem <= last_elem);
-	ASSERT(first_elem < last_elem);
-	ASSERT(last_elem > first_elem );
-	ASSERT(last_elem >= first_elem );
-	ASSERT(first_elem == first_elem);
-	ASSERT(first_elem >= first_elem);
-	ASSERT(first_elem <= first_elem);
+	UT_ASSERT(first_elem != last_elem);
+	UT_ASSERT(first_elem <= last_elem);
+	UT_ASSERT(first_elem < last_elem);
+	UT_ASSERT(last_elem > first_elem );
+	UT_ASSERT(last_elem >= first_elem );
+	UT_ASSERT(first_elem == first_elem);
+	UT_ASSERT(first_elem >= first_elem);
+	UT_ASSERT(first_elem <= first_elem);
 
 	/* nullptr comparisons */
-	ASSERT(first_elem != nullptr);
-	ASSERT(nullptr != first_elem);
-	ASSERT(!(first_elem == nullptr));
-	ASSERT(!(nullptr == first_elem));
+	UT_ASSERT(first_elem != nullptr);
+	UT_ASSERT(nullptr != first_elem);
+	UT_ASSERT(!(first_elem == nullptr));
+	UT_ASSERT(!(nullptr == first_elem));
 
-	ASSERT(nullptr < first_elem);
-	ASSERT(!(first_elem < nullptr));
-	ASSERT(nullptr <= first_elem);
-	ASSERT(!(first_elem <= nullptr));
+	UT_ASSERT(nullptr < first_elem);
+	UT_ASSERT(!(first_elem < nullptr));
+	UT_ASSERT(nullptr <= first_elem);
+	UT_ASSERT(!(first_elem <= nullptr));
 
-	ASSERT(first_elem > nullptr);
-	ASSERT(!(nullptr > first_elem));
-	ASSERT(first_elem >= nullptr);
-	ASSERT(!(nullptr >= first_elem));
+	UT_ASSERT(first_elem > nullptr);
+	UT_ASSERT(!(nullptr > first_elem));
+	UT_ASSERT(first_elem >= nullptr);
+	UT_ASSERT(!(nullptr >= first_elem));
 
 	persistent_ptr<p<double>> different_array =
 			prepare_array<p<double>>(pop);
 
 	/* only verify if this compiles */
-	ASSERT((first_elem < different_array) || true);
+	UT_ASSERT((first_elem < different_array) || true);
 }
 
 }
@@ -193,7 +193,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_ptr_arith");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -201,7 +201,7 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	test_arith(pop);
 	test_relational(pop);

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
@@ -80,7 +80,7 @@ void reader(persistent_ptr<struct root> proot)
 {
 	for (int i = 0; i < num_ops; ++i) {
 		proot->pmutex.lock_shared();
-		ASSERTeq(proot->counter % 2, 0);
+		UT_ASSERTeq(proot->counter % 2, 0);
 		proot->pmutex.unlock_shared();
 	}
 }
@@ -107,7 +107,7 @@ void reader_trylock(persistent_ptr<struct root> proot)
 {
 	for (;;) {
 		if (proot->pmutex.try_lock_shared()) {
-			ASSERTeq(proot->counter % 2, 0);
+			UT_ASSERTeq(proot->counter % 2, 0);
 			proot->pmutex.unlock_shared();
 			return;
 		}
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_shared_mutex");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -153,17 +153,17 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	int expected = num_threads * num_ops * 2;
 	mutex_test(pop, writer, reader);
-	ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.get_root()->counter, expected);
 
 	/* trylocks are not tested as exhaustively */
 	expected -= num_threads * 2;
 	mutex_test(pop, writer_trylock, reader_trylock);
-	ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.get_root()->counter, expected);
 
 	/* pmemcheck related persist */
 	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),

--- a/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
+++ b/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
@@ -86,7 +86,7 @@ void *reader(void *arg)
 				static_cast<persistent_ptr<struct root>*>(arg);
 	for (int i = 0; i < num_ops; ++i) {
 		(*proot)->pmutex.lock_shared();
-		ASSERTeq((*proot)->counter % 2, 0);
+		UT_ASSERTeq((*proot)->counter % 2, 0);
 		(*proot)->pmutex.unlock_shared();
 	}
 	return nullptr;
@@ -119,7 +119,7 @@ void *reader_trylock(void *arg)
 				static_cast<persistent_ptr<struct root>*>(arg);
 	for (;;) {
 		if ((*proot)->pmutex.try_lock_shared()) {
-			ASSERTeq((*proot)->counter % 2, 0);
+			UT_ASSERTeq((*proot)->counter % 2, 0);
 			(*proot)->pmutex.unlock_shared();
 			break;
 		}
@@ -155,7 +155,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_shared_mutex_posix");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -165,17 +165,17 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	int expected = num_threads * num_ops * 2;
 	mutex_test(pop, writer, reader);
-	ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.get_root()->counter, expected);
 
 	/* trylocks are not tested as exhaustively */
 	expected -= num_threads * 2;
 	mutex_test(pop, writer_trylock, reader_trylock);
-	ASSERTeq(pop.get_root()->counter, expected);
+	UT_ASSERTeq(pop.get_root()->counter, expected);
 
 	/* pmemcheck related persist */
 	pmemobj_persist(pop.get_handle(), &(pop.get_root()->counter),

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
@@ -119,7 +119,7 @@ trylock_for_test(persistent_ptr<struct root> proot)
 	} else {
 		auto t2 = clk::now();
 		auto t_diff = t2 - t1;
-		ASSERT(t_diff >= timeout);
+		UT_ASSERT(t_diff >= timeout);
 	}
 
 	return;
@@ -140,7 +140,7 @@ trylock_until_test(persistent_ptr<struct root> proot)
 	} else {
 		auto t2 = clk::now();
 		auto t_diff = t2 - t1;
-		ASSERT(t_diff >= timeout);
+		UT_ASSERT(t_diff >= timeout);
 	}
 
 	return;
@@ -171,7 +171,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_timed_mtx");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -181,31 +181,31 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	timed_mtx_test(pop, increment_pint);
-	ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
 
 	timed_mtx_test(pop, decrement_pint);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_until_test);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_for_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	pop.get_root()->pmutex.lock();
 
 	timed_mtx_test(pop, trylock_until_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_for_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	pop.get_root()->pmutex.unlock();
 

--- a/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
+++ b/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
@@ -131,7 +131,7 @@ trylock_for_test(void *arg)
 	} else {
 		auto t2 = clk::now();
 		auto t_diff = t2 - t1;
-		ASSERT(t_diff >= timeout);
+		UT_ASSERT(t_diff >= timeout);
 	}
 
 	return nullptr;
@@ -154,7 +154,7 @@ trylock_until_test(void *arg)
 	} else {
 		auto t2 = clk::now();
 		auto t_diff = t2 - t1;
-		ASSERT(t_diff >= timeout);
+		UT_ASSERT(t_diff >= timeout);
 	}
 
 	return nullptr;
@@ -185,7 +185,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_cpp_mutex_posix");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -195,31 +195,31 @@ main(int argc, char *argv[])
 		pop = pool<struct root>::create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	} catch (nvml::pool_error &pe) {
-		FATAL("!pool::create: %s %s", pe.what(), path);
+		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
 
 	timed_mtx_test(pop, increment_pint);
-	ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);
 
 	timed_mtx_test(pop, decrement_pint);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_until_test);
-	ASSERTeq(pop.get_root()->counter, 0);
+	UT_ASSERTeq(pop.get_root()->counter, 0);
 
 	timed_mtx_test(pop, trylock_for_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	pop.get_root()->pmutex.lock();
 
 	timed_mtx_test(pop, trylock_until_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	timed_mtx_test(pop, trylock_for_test);
-	ASSERTeq(pop.get_root()->counter, num_threads);
+	UT_ASSERTeq(pop.get_root()->counter, num_threads);
 
 	pop.get_root()->pmutex.unlock();
 

--- a/src/test/obj_ctree/obj_ctree.c
+++ b/src/test/obj_ctree/obj_ctree.c
@@ -67,11 +67,11 @@ test_ctree_new_delete_empty()
 
 	/* t Malloc fail */
 	t = ctree_new();
-	ASSERT(t == NULL);
+	UT_ASSERT(t == NULL);
 
 	/* all OK and delete */
 	t = ctree_new();
-	ASSERT(t != NULL);
+	UT_ASSERT(t != NULL);
 
 	ctree_delete(t);
 }
@@ -80,28 +80,28 @@ static void
 test_ctree_insert()
 {
 	struct ctree *t = ctree_new();
-	ASSERT(t != NULL);
+	UT_ASSERT(t != NULL);
 
 	FUNC_MOCK_RCOUNTER_SET(malloc, TEST_INSERT);
 
-	ASSERT(ctree_is_empty(t));
+	UT_ASSERT(ctree_is_empty(t));
 
 	/* leaf Malloc fail */
-	ASSERT(ctree_insert(t, TEST_VAL_A, 0) != 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_A, 0) != 0);
 
 	/* all OK root */
-	ASSERT(ctree_insert(t, TEST_VAL_B, 0) == 0); /* insert +2 mallocs */
+	UT_ASSERT(ctree_insert(t, TEST_VAL_B, 0) == 0); /* insert +2 mallocs */
 
 	/* accessor Malloc fail */
-	ASSERT(ctree_insert(t, TEST_VAL_A, 0) != 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_A, 0) != 0);
 
 	/* insert duplicate */
-	ASSERT(ctree_insert(t, TEST_VAL_B, 0) != 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_B, 0) != 0);
 
 	/* all OK second */
-	ASSERT(ctree_insert(t, TEST_VAL_A, 0) == 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_A, 0) == 0);
 
-	ASSERT(!ctree_is_empty(t));
+	UT_ASSERT(!ctree_is_empty(t));
 
 	ctree_delete(t);
 }
@@ -110,23 +110,23 @@ static void
 test_ctree_find()
 {
 	struct ctree *t = ctree_new();
-	ASSERT(t != NULL);
+	UT_ASSERT(t != NULL);
 
 	/* search empty tree */
 	uint64_t k = TEST_VAL_A;
-	ASSERT(ctree_find_le(t, &k) == 0);
+	UT_ASSERT(ctree_find_le(t, &k) == 0);
 
 	/* insert 2 valid elements */
-	ASSERT(ctree_insert(t, TEST_VAL_A, TEST_VAL_A) == 0);
-	ASSERT(ctree_insert(t, TEST_VAL_B, TEST_VAL_B) == 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_A, TEST_VAL_A) == 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_B, TEST_VAL_B) == 0);
 
 	/* search for values */
 	k = 0;
-	ASSERT(ctree_find_le(t, &k) == 0);
+	UT_ASSERT(ctree_find_le(t, &k) == 0);
 	k = TEST_VAL_A;
-	ASSERT(ctree_find_le(t, &k) == TEST_VAL_A);
+	UT_ASSERT(ctree_find_le(t, &k) == TEST_VAL_A);
 	k = TEST_VAL_B;
-	ASSERT(ctree_find_le(t, &k) == TEST_VAL_B);
+	UT_ASSERT(ctree_find_le(t, &k) == TEST_VAL_B);
 
 	ctree_delete(t);
 }
@@ -135,25 +135,25 @@ static void
 test_ctree_remove()
 {
 	struct ctree *t = ctree_new();
-	ASSERT(t != NULL);
+	UT_ASSERT(t != NULL);
 
 	FUNC_MOCK_RCOUNTER_SET(malloc, TEST_REMOVE);
 
 	/* remove from empty tree */
-	ASSERT(ctree_remove(t, TEST_VAL_A, 0) == 0);
+	UT_ASSERT(ctree_remove(t, TEST_VAL_A, 0) == 0);
 
 	/* insert 2 valid values */
-	ASSERT(ctree_insert(t, TEST_VAL_A, 0) == 0);
-	ASSERT(ctree_insert(t, TEST_VAL_B, 0) == 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_A, 0) == 0);
+	UT_ASSERT(ctree_insert(t, TEST_VAL_B, 0) == 0);
 
 	/* fail to remove equal greater */
-	ASSERT(ctree_remove(t, TEST_VAL_C, 0) == 0);
+	UT_ASSERT(ctree_remove(t, TEST_VAL_C, 0) == 0);
 
 	/* remove accessor */
-	ASSERT(ctree_remove(t, TEST_VAL_A, 1) == TEST_VAL_A);
+	UT_ASSERT(ctree_remove(t, TEST_VAL_A, 1) == TEST_VAL_A);
 
 	/* remove root */
-	ASSERT(ctree_remove(t, TEST_VAL_B, 1) == TEST_VAL_B);
+	UT_ASSERT(ctree_remove(t, TEST_VAL_B, 1) == TEST_VAL_B);
 
 	ctree_delete(t);
 }

--- a/src/test/obj_cuckoo/obj_cuckoo.c
+++ b/src/test/obj_cuckoo/obj_cuckoo.c
@@ -59,15 +59,15 @@ test_cuckoo_new_delete()
 
 	/* cuckoo malloc fail */
 	c = cuckoo_new();
-	ASSERT(c == NULL);
+	UT_ASSERT(c == NULL);
 
 	/* tab malloc fail */
 	c = cuckoo_new();
-	ASSERT(c == NULL);
+	UT_ASSERT(c == NULL);
 
 	/* all ok */
 	c = cuckoo_new();
-	ASSERT(c != NULL);
+	UT_ASSERT(c != NULL);
 
 	cuckoo_delete(c);
 }
@@ -76,22 +76,22 @@ static void
 test_insert_get_remove()
 {
 	struct cuckoo *c = cuckoo_new();
-	ASSERT(c != NULL);
+	UT_ASSERT(c != NULL);
 
 	for (int i = 0; i < TEST_INSERTS; ++i)
-		ASSERT(cuckoo_insert(c, i, TEST_VAL(i)) == 0);
+		UT_ASSERT(cuckoo_insert(c, i, TEST_VAL(i)) == 0);
 
 	for (int i = 0; i < TEST_INSERTS; ++i)
-		ASSERT(cuckoo_get(c, i) == TEST_VAL(i));
+		UT_ASSERT(cuckoo_get(c, i) == TEST_VAL(i));
 
 	for (int i = 0; i < TEST_INSERTS; ++i)
-		ASSERT(cuckoo_remove(c, i) == TEST_VAL(i));
+		UT_ASSERT(cuckoo_remove(c, i) == TEST_VAL(i));
 
 	for (int i = 0; i < TEST_INSERTS; ++i)
-		ASSERT(cuckoo_remove(c, i) == NULL);
+		UT_ASSERT(cuckoo_remove(c, i) == NULL);
 
 	for (int i = 0; i < TEST_INSERTS; ++i)
-		ASSERT(cuckoo_get(c, i) == NULL);
+		UT_ASSERT(cuckoo_get(c, i) == NULL);
 
 	cuckoo_delete(c);
 }

--- a/src/test/obj_debug/obj_debug.c
+++ b/src/test/obj_debug/obj_debug.c
@@ -85,7 +85,7 @@ test_FOREACH(const char *path)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
 	POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(root)->lhead, next,
@@ -95,7 +95,7 @@ test_FOREACH(const char *path)
 	TX_BEGIN(pop) {
 		COMMANDS_FOREACH();
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 	COMMANDS_FOREACH();
 
@@ -124,7 +124,7 @@ test_lists(const char *path)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	TOID_ASSIGN(root, pmemobj_root(pop, sizeof (struct root)));
 
@@ -132,7 +132,7 @@ test_lists(const char *path)
 	TX_BEGIN(pop) {
 		COMMANDS_LISTS();
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 	COMMANDS_LISTS();
 
@@ -161,7 +161,7 @@ test_alloc_construct(const char *path)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	TX_BEGIN(pop) {
 		struct int3_s args = { 1, 2, 3 };
@@ -169,7 +169,7 @@ test_alloc_construct(const char *path)
 		pmemobj_alloc(pop, &allocation, sizeof (allocation), 1,
 				int3_constructor, &args);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	pmemobj_close(pop);
@@ -182,12 +182,12 @@ test_double_free(const char *path)
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	PMEMoid oid, oid2;
 	int err = pmemobj_zalloc(pop, &oid, 100, 0);
-	ASSERTeq(err, 0);
-	ASSERT(!OID_IS_NULL(oid));
+	UT_ASSERTeq(err, 0);
+	UT_ASSERT(!OID_IS_NULL(oid));
 
 	oid2 = oid;
 
@@ -201,12 +201,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_debug");
 
 	if (argc != 3)
-		FATAL("usage: %s file-name op:f|l|r|a", argv[0]);
+		UT_FATAL("usage: %s file-name op:f|l|r|a", argv[0]);
 
 	const char *path = argv[1];
 
 	if (strchr("flrap", argv[2][0]) == NULL || argv[2][1] != '\0')
-		FATAL("op must be f or l or r or a or p");
+		UT_FATAL("op must be f or l or r or a or p");
 
 	switch (argv[2][0]) {
 		case 'f':

--- a/src/test/obj_direct/obj_direct.c
+++ b/src/test/obj_direct/obj_direct.c
@@ -54,12 +54,12 @@ static void *
 test_worker(void *arg)
 {
 	/* before pool is closed */
-	ASSERTne(pmemobj_direct(thread_oid), NULL);
+	UT_ASSERTne(pmemobj_direct(thread_oid), NULL);
 
 	flag = 0;
 	pthread_mutex_lock(&lock);
 	/* after pool is closed */
-	ASSERTeq(pmemobj_direct(thread_oid), NULL);
+	UT_ASSERTeq(pmemobj_direct(thread_oid), NULL);
 
 	pthread_mutex_unlock(&lock);
 
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_direct");
 
 	if (argc != 3)
-		FATAL("usage: %s [directory] [# of pools]", argv[0]);
+		UT_FATAL("usage: %s [directory] [# of pools]", argv[0]);
 
 	int npools = atoi(argv[2]);
 	const char *dir = argv[1];
@@ -87,31 +87,31 @@ main(int argc, char *argv[])
 				S_IWUSR | S_IRUSR);
 
 		if (pops[i] == NULL)
-			FATAL("!pmemobj_create");
+			UT_FATAL("!pmemobj_create");
 	}
 
 	PMEMoid oids[npools];
 	PMEMoid tmpoids[npools];
 
 	oids[0] = OID_NULL;
-	ASSERTeq(pmemobj_direct(oids[0]), NULL);
+	UT_ASSERTeq(pmemobj_direct(oids[0]), NULL);
 
 	for (int i = 0; i < npools; ++i) {
 		oids[i] = (PMEMoid) {pops[i]->uuid_lo, 0};
-		ASSERTeq(pmemobj_direct(oids[i]), NULL);
+		UT_ASSERTeq(pmemobj_direct(oids[i]), NULL);
 
 		uint64_t off = pops[i]->heap_offset;
 		oids[i] = (PMEMoid) {pops[i]->uuid_lo, off};
-		ASSERTeq((char *)pmemobj_direct(oids[i]) - off,
+		UT_ASSERTeq((char *)pmemobj_direct(oids[i]) - off,
 			(char *)pops[i]);
 
 		r = pmemobj_alloc(pops[i], &tmpoids[i], 100, 1, NULL, NULL);
-		ASSERTeq(r, 0);
+		UT_ASSERTeq(r, 0);
 	}
 
 	r = pmemobj_alloc(pops[0], &thread_oid, 100, 2, NULL, NULL);
-	ASSERTeq(r, 0);
-	ASSERTne(pmemobj_direct(thread_oid), NULL);
+	UT_ASSERTeq(r, 0);
+	UT_ASSERTne(pmemobj_direct(thread_oid), NULL);
 
 	pthread_mutex_lock(&lock);
 
@@ -123,13 +123,13 @@ main(int argc, char *argv[])
 		;
 
 	for (int i = 0; i < npools; ++i) {
-		ASSERTne(pmemobj_direct(tmpoids[i]), NULL);
+		UT_ASSERTne(pmemobj_direct(tmpoids[i]), NULL);
 
 		pmemobj_free(&tmpoids[i]);
 
-		ASSERTeq(pmemobj_direct(tmpoids[i]), NULL);
+		UT_ASSERTeq(pmemobj_direct(tmpoids[i]), NULL);
 		pmemobj_close(pops[i]);
-		ASSERTeq(pmemobj_direct(oids[i]), NULL);
+		UT_ASSERTeq(pmemobj_direct(oids[i]), NULL);
 	}
 	pthread_mutex_unlock(&lock);
 

--- a/src/test/obj_first_next/obj_first_next.c
+++ b/src/test/obj_first_next/obj_first_next.c
@@ -56,7 +56,7 @@ typedef void (*fn_op)(int id);
 typedef void (*fn_void)();
 
 #define	FATAL_USAGE()\
-	FATAL("usage: obj_first_next <file> [Parfn]")
+	UT_FATAL("usage: obj_first_next <file> [Parfn]")
 
 /*
  * get_item_type -- get nth item from list
@@ -95,9 +95,9 @@ static void
 do_print_type()
 {
 	TOID(struct type) item;
-	OUT("type:");
+	UT_OUT("type:");
 	POBJ_FOREACH_TYPE(pop, item) {
-		OUT("id = %d", D_RO(item)->id);
+		UT_OUT("id = %d", D_RO(item)->id);
 	}
 }
 
@@ -108,9 +108,9 @@ static void
 do_print_type_sec()
 {
 	TOID(struct type_sec) item;
-	OUT("type_sec:");
+	UT_OUT("type_sec:");
 	POBJ_FOREACH_TYPE(pop, item) {
-		OUT("id = %d", D_RO(item)->id);
+		UT_OUT("id = %d", D_RO(item)->id);
 	}
 }
 
@@ -126,7 +126,7 @@ type_constructor(PMEMobjpool *pop, void *ptr, void *arg)
 	int id = *(int *)arg;
 	struct type *item = (struct type *)ptr;
 	item->id = id;
-	OUT("constructor(id = %d)", id);
+	UT_OUT("constructor(id = %d)", id);
 
 	return 0;
 }
@@ -141,7 +141,7 @@ type_sec_constructor(PMEMobjpool *pop, void *ptr, void *arg)
 	int id = *(int *)arg;
 	struct type_sec *item = (struct type_sec *)ptr;
 	item->id = id;
-	OUT("constructor(id = %d)", id);
+	UT_OUT("constructor(id = %d)", id);
 
 	return 0;
 }
@@ -155,7 +155,7 @@ do_alloc_type(int id)
 	TOID(struct type) item;
 	POBJ_NEW(pop, &item, struct type, type_constructor, &id);
 	if (TOID_IS_NULL(item))
-		FATAL("POBJ_NEW");
+		UT_FATAL("POBJ_NEW");
 }
 
 /*
@@ -167,7 +167,7 @@ do_alloc_type_sec(int id)
 	TOID(struct type_sec) item;
 	POBJ_NEW(pop, &item, struct type_sec, type_sec_constructor, &id);
 	if (TOID_IS_NULL(item))
-		FATAL("POBJ_NEW");
+		UT_FATAL("POBJ_NEW");
 }
 
 fn_op do_alloc[] = {do_alloc_type, do_alloc_type_sec};
@@ -182,7 +182,7 @@ do_free_type(int n)
 	if (TOID_IS_NULL(POBJ_FIRST(pop, struct type)))
 		return;
 	item = get_item_type(n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	POBJ_FREE(&item);
 }
 
@@ -196,7 +196,7 @@ do_free_type_sec(int n)
 	if (TOID_IS_NULL(POBJ_FIRST(pop, struct type_sec)))
 		return;
 	item = get_item_type_sec(n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	POBJ_FREE(&item);
 }
 
@@ -209,7 +209,7 @@ static void
 do_first_type()
 {
 	TOID(struct type) first = POBJ_FIRST(pop, struct type);
-	OUT("first id = %d", D_RO(first)->id);
+	UT_OUT("first id = %d", D_RO(first)->id);
 }
 
 /*
@@ -219,7 +219,7 @@ static void
 do_first_type_sec()
 {
 	TOID(struct type_sec) first = POBJ_FIRST(pop, struct type_sec);
-	OUT("first id = %d", D_RO(first)->id);
+	UT_OUT("first id = %d", D_RO(first)->id);
 }
 
 fn_void do_first[] = {do_first_type, do_first_type_sec};
@@ -234,9 +234,9 @@ do_next_type(int n)
 	if (TOID_IS_NULL(POBJ_FIRST(pop, struct type)))
 		return;
 	item = get_item_type(n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	item = POBJ_NEXT(item);
-	OUT("next id = %d", D_RO(item)->id);
+	UT_OUT("next id = %d", D_RO(item)->id);
 }
 
 /*
@@ -249,9 +249,9 @@ do_next_type_sec(int n)
 	if (TOID_IS_NULL(POBJ_FIRST(pop, struct type_sec)))
 		return;
 	item = get_item_type_sec(n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	item = POBJ_NEXT(item);
-	OUT("next id = %d", D_RO(item)->id);
+	UT_OUT("next id = %d", D_RO(item)->id);
 }
 
 fn_op do_next[] = {do_next_type, do_next_type_sec};
@@ -280,12 +280,12 @@ test_internal_object_mask(PMEMobjpool *pop)
 
 	PMEMoid oid;
 	pmemobj_alloc(pop, &oid, sizeof (struct type), 0, NULL, NULL);
-	ASSERT(!OID_IS_NULL(oid));
+	UT_ASSERT(!OID_IS_NULL(oid));
 
 	/* verify that there's no root object nor range cache anywhere */
 	for (PMEMoid iter = pmemobj_first(pop); !OID_IS_NULL(iter);
 		iter = pmemobj_next(iter)) {
-		ASSERT(OID_EQUALS(iter, oid));
+		UT_ASSERT(OID_EQUALS(iter, oid));
 	}
 }
 
@@ -299,7 +299,7 @@ main(int argc, char *argv[])
 	const char *path = argv[1];
 	if ((pop = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 						S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	for (int i = 2; i < argc; i++) {
 		int list_num;

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -73,24 +73,24 @@ test_heap()
 	pop->heap_offset = (uint64_t)((uint64_t)&mpop->heap - (uint64_t)mpop);
 	pop->persist = obj_heap_persist;
 
-	ASSERT(heap_check(pop) != 0);
-	ASSERT(heap_init(pop) == 0);
-	ASSERT(heap_boot(pop) == 0);
-	ASSERT(pop->heap != NULL);
+	UT_ASSERT(heap_check(pop) != 0);
+	UT_ASSERT(heap_init(pop) == 0);
+	UT_ASSERT(heap_boot(pop) == 0);
+	UT_ASSERT(pop->heap != NULL);
 
 	Lane_idx = 0;
 
 	struct bucket *b_small = heap_get_best_bucket(pop, 1);
 	struct bucket *b_big = heap_get_best_bucket(pop, 2048);
 
-	ASSERT(b_small->unit_size < b_big->unit_size);
+	UT_ASSERT(b_small->unit_size < b_big->unit_size);
 
 	struct bucket *b_def = heap_get_best_bucket(pop, CHUNKSIZE);
-	ASSERT(b_def->unit_size == CHUNKSIZE);
+	UT_ASSERT(b_def->unit_size == CHUNKSIZE);
 
 	/* new small buckets should be empty */
-	ASSERT(b_small->type == BUCKET_RUN);
-	ASSERT(b_big->type == BUCKET_RUN);
+	UT_ASSERT(b_small->type == BUCKET_RUN);
+	UT_ASSERT(b_big->type == BUCKET_RUN);
 
 	struct memory_block blocks[MAX_BLOCKS] = {
 		{0, 0, 1, 0},
@@ -100,24 +100,24 @@ test_heap()
 
 	for (int i = 0; i < MAX_BLOCKS; ++i) {
 		heap_get_bestfit_block(pop, b_def, &blocks[i]);
-		ASSERT(blocks[i].block_off == 0);
+		UT_ASSERT(blocks[i].block_off == 0);
 	}
 
 	struct memory_block *blocksp[MAX_BLOCKS] = {NULL};
 
 	struct memory_block prev;
 	heap_get_adjacent_free_block(pop, b_def, &prev, blocks[1], 1);
-	ASSERT(prev.chunk_id == blocks[0].chunk_id);
+	UT_ASSERT(prev.chunk_id == blocks[0].chunk_id);
 	blocksp[0] = &prev;
 
 	struct memory_block cnt;
 	heap_get_adjacent_free_block(pop, b_def, &cnt, blocks[0], 0);
-	ASSERT(cnt.chunk_id == blocks[1].chunk_id);
+	UT_ASSERT(cnt.chunk_id == blocks[1].chunk_id);
 	blocksp[1] = &cnt;
 
 	struct memory_block next;
 	heap_get_adjacent_free_block(pop, b_def, &next, blocks[1], 0);
-	ASSERT(next.chunk_id == blocks[2].chunk_id);
+	UT_ASSERT(next.chunk_id == blocks[2].chunk_id);
 	blocksp[2] = &next;
 
 	struct operation_context *ctx = operation_init(pop, NULL);
@@ -126,12 +126,12 @@ test_heap()
 	operation_process(ctx);
 	operation_delete(ctx);
 
-	ASSERT(result.size_idx == 3);
-	ASSERT(result.chunk_id == prev.chunk_id);
+	UT_ASSERT(result.size_idx == 3);
+	UT_ASSERT(result.chunk_id == prev.chunk_id);
 
-	ASSERT(heap_check(pop) == 0);
+	UT_ASSERT(heap_check(pop) == 0);
 	heap_cleanup(pop);
-	ASSERT(pop->heap == NULL);
+	UT_ASSERT(pop->heap == NULL);
 
 	Free(mpop);
 }

--- a/src/test/obj_heap_state/obj_heap_state.c
+++ b/src/test/obj_heap_state/obj_heap_state.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_heap_state");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -71,20 +71,20 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	pmemobj_root(pop, ROOT_SIZE); /* just to trigger allocation */
 
 	pmemobj_close(pop);
 
 	pop = pmemobj_open(path, LAYOUT_NAME);
-	ASSERTne(pop, NULL);
+	UT_ASSERTne(pop, NULL);
 
 	for (int i = 0; i < ALLOCS; ++i) {
 		PMEMoid oid;
 		pmemobj_alloc(pop, &oid, ALLOC_SIZE, 0,
 				test_constructor, NULL);
-		OUT("%d %lu", i, oid.off);
+		UT_OUT("%d %lu", i, oid.off);
 	}
 
 	pmemobj_close(pop);

--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -68,7 +68,7 @@ static int construct_fail;
 static int
 lane_noop_construct(PMEMobjpool *pop, struct lane_section *section)
 {
-	OUT("lane_noop_construct");
+	UT_OUT("lane_noop_construct");
 	if (construct_fail)
 		return EINVAL;
 
@@ -80,7 +80,7 @@ lane_noop_construct(PMEMobjpool *pop, struct lane_section *section)
 static void
 lane_noop_destruct(PMEMobjpool *pop, struct lane_section *section)
 {
-	OUT("lane_noop_destruct");
+	UT_OUT("lane_noop_destruct");
 }
 
 static int recovery_check_fail;
@@ -89,7 +89,7 @@ static int
 lane_noop_recovery(PMEMobjpool *pop,
 	struct lane_section_layout *section)
 {
-	OUT("lane_noop_recovery %p", RPTR(section));
+	UT_OUT("lane_noop_recovery %p", RPTR(section));
 	if (recovery_check_fail)
 		return EINVAL;
 
@@ -100,7 +100,7 @@ static int
 lane_noop_check(PMEMobjpool *pop,
 	struct lane_section_layout *section)
 {
-	OUT("lane_noop_check %p", RPTR(section));
+	UT_OUT("lane_noop_check %p", RPTR(section));
 	if (recovery_check_fail)
 		return EINVAL;
 
@@ -110,7 +110,7 @@ lane_noop_check(PMEMobjpool *pop,
 static int
 lane_noop_boot(PMEMobjpool *pop)
 {
-	OUT("lane_noop_init");
+	UT_OUT("lane_noop_init");
 
 	return 0;
 }
@@ -139,19 +139,19 @@ test_lane_boot_cleanup_ok()
 	base_ptr = &pop.p;
 
 	pop.p.lanes_offset = (uint64_t)&pop.l - (uint64_t)&pop.p;
-	ASSERTeq(lane_boot(&pop.p), 0);
-	ASSERTne(pop.p.lanes, NULL);
+	UT_ASSERTeq(lane_boot(&pop.p), 0);
+	UT_ASSERTne(pop.p.lanes, NULL);
 	for (int i = 0; i < MAX_MOCK_LANES; ++i) {
 		for (int j = 0; j < MAX_LANE_SECTION; ++j) {
-			ASSERTeq(pop.p.lanes[i].sections[j].layout,
+			UT_ASSERTeq(pop.p.lanes[i].sections[j].layout,
 				&pop.l[i].sections[j]);
-			ASSERTeq(pop.p.lanes[i].sections[j].runtime,
+			UT_ASSERTeq(pop.p.lanes[i].sections[j].runtime,
 				MOCK_RUNTIME);
 		}
 	}
 
 	lane_cleanup(&pop.p);
-	ASSERTeq(pop.p.lanes, NULL);
+	UT_ASSERTeq(pop.p.lanes, NULL);
 }
 
 static void
@@ -168,11 +168,11 @@ test_lane_boot_fail()
 
 	construct_fail = 1;
 
-	ASSERTne(lane_boot(&pop.p), 0);
+	UT_ASSERTne(lane_boot(&pop.p), 0);
 
 	construct_fail = 0;
 
-	ASSERTeq(pop.p.lanes, NULL);
+	UT_ASSERTeq(pop.p.lanes, NULL);
 }
 
 static void
@@ -187,8 +187,8 @@ test_lane_recovery_check_ok()
 	base_ptr = &pop.p;
 	pop.p.lanes_offset = (uint64_t)&pop.l - (uint64_t)&pop.p;
 
-	ASSERTeq(lane_recover_and_section_boot(&pop.p), 0);
-	ASSERTeq(lane_check(&pop.p), 0);
+	UT_ASSERTeq(lane_recover_and_section_boot(&pop.p), 0);
+	UT_ASSERTeq(lane_check(&pop.p), 0);
 }
 
 static void
@@ -205,9 +205,9 @@ test_lane_recovery_check_fail()
 
 	recovery_check_fail = 1;
 
-	ASSERTne(lane_recover_and_section_boot(&pop.p), 0);
+	UT_ASSERTne(lane_recover_and_section_boot(&pop.p), 0);
 
-	ASSERTne(lane_check(&pop.p), 0);
+	UT_ASSERTne(lane_check(&pop.p), 0);
 }
 
 sigjmp_buf Jmp;
@@ -246,9 +246,9 @@ test_lane_hold_release()
 
 	struct lane_section *sec;
 	lane_hold(&pop.p, &sec, LANE_SECTION_ALLOCATOR);
-	ASSERTeq(sec->runtime, MOCK_RUNTIME);
+	UT_ASSERTeq(sec->runtime, MOCK_RUNTIME);
 	lane_hold(&pop.p, &sec, LANE_SECTION_LIST);
-	ASSERTeq(sec->runtime, MOCK_RUNTIME_2);
+	UT_ASSERTeq(sec->runtime, MOCK_RUNTIME_2);
 
 	lane_release(&pop.p);
 	lane_release(&pop.p);
@@ -257,7 +257,7 @@ test_lane_hold_release()
 
 	if (!sigsetjmp(Jmp, 1)) {
 		lane_release(&pop.p); /* only two sections were held */
-		ERR("we should not get here");
+		UT_ERR("we should not get here");
 	}
 
 	signal(SIGABRT, old);

--- a/src/test/obj_list/obj_list.c
+++ b/src/test/obj_list/obj_list.c
@@ -110,23 +110,23 @@ TOID(struct oob_item) *Item;
 
 /* usage macros */
 #define	FATAL_USAGE()\
-	FATAL("usage: obj_list <file> [PRnifr]")
+	UT_FATAL("usage: obj_list <file> [PRnifr]")
 #define	FATAL_USAGE_PRINT()\
-	FATAL("usage: obj_list <file> P:<list>")
+	UT_FATAL("usage: obj_list <file> P:<list>")
 #define	FATAL_USAGE_PRINT_REVERSE()\
-	FATAL("usage: obj_list <file> R:<list>")
+	UT_FATAL("usage: obj_list <file> R:<list>")
 #define	FATAL_USAGE_INSERT()\
-	FATAL("usage: obj_list <file> i:<where>:<num>")
+	UT_FATAL("usage: obj_list <file> i:<where>:<num>")
 #define	FATAL_USAGE_REMOVE_FREE()\
-	FATAL("usage: obj_list <file> f:<list>:<num>:<from>")
+	UT_FATAL("usage: obj_list <file> f:<list>:<num>:<from>")
 #define	FATAL_USAGE_REMOVE()\
-	FATAL("usage: obj_list <file> r:<num>")
+	UT_FATAL("usage: obj_list <file> r:<num>")
 #define	FATAL_USAGE_MOVE()\
-	FATAL("usage: obj_list <file> m:<num>:<where>:<num>")
+	UT_FATAL("usage: obj_list <file> m:<num>:<where>:<num>")
 #define	FATAL_USAGE_MOVE_OOB()\
-	FATAL("usage: obj_list <file> o:<num>")
+	UT_FATAL("usage: obj_list <file> o:<num>")
 #define	FATAL_USAGE_FAIL()\
-	FATAL("usage: obj_list <file> "\
+	UT_FATAL("usage: obj_list <file> "\
 	"F:<after_finish|before_finish|after_process>")
 
 /*
@@ -189,7 +189,7 @@ FUNC_MOCK_RUN_DEFAULT {
 
 	void *addr = pmem_map_file(fname, 0, 0, 0, &size, &is_pmem);
 	if (!addr) {
-		OUT("!%s: pmem_map_file", fname);
+		UT_OUT("!%s: pmem_map_file", fname);
 		return NULL;
 	}
 
@@ -364,7 +364,7 @@ FUNC_MOCK(pmalloc, int, PMEMobjpool *pop, uint64_t *ptr, size_t size)
 			size + OOB_OFF;
 		Pop->persist(Pop, Heap_offset, sizeof (*Heap_offset));
 
-		OUT("pmalloc(id = %d)", item->item.id);
+		UT_OUT("pmalloc(id = %d)", item->item.id);
 		return 0;
 	}
 FUNC_MOCK_END
@@ -378,7 +378,7 @@ FUNC_MOCK(pfree, int, PMEMobjpool *pop, uint64_t *ptr)
 	FUNC_MOCK_RUN_DEFAULT {
 		struct oob_item *item =
 			(struct oob_item *)((uintptr_t)Pop + *ptr - OOB_OFF);
-		OUT("pfree(id = %d)", item->item.id);
+		UT_OUT("pfree(id = %d)", item->item.id);
 		*ptr = 0;
 		Pop->persist(Pop, ptr, sizeof (*ptr));
 
@@ -428,12 +428,12 @@ FUNC_MOCK(prealloc, int, PMEMobjpool *pop, uint64_t *off, size_t size)
 			*alloc_size = size;
 			Pop->persist(Pop, alloc_size, sizeof (*alloc_size));
 
-			OUT("prealloc(id = %d, size = %zu) = true",
+			UT_OUT("prealloc(id = %d, size = %zu) = true",
 				item->id,
 				(size - OOB_OFF) / sizeof (struct item));
 			return 0;
 		} else {
-			OUT("prealloc(id = %d, size = %zu) = false",
+			UT_OUT("prealloc(id = %d, size = %zu) = false",
 				item->id,
 				(size - OOB_OFF) / sizeof (struct item));
 			return -1;
@@ -713,27 +713,27 @@ do_print(PMEMobjpool *pop, const char *arg)
 
 	if (L == 1) {
 		TOID(struct oob_item) oob_item;
-		OUT("oob list:");
+		UT_OUT("oob list:");
 		LIST_FOREACH_OOB(oob_item, List_oob, head) {
-			OUT("id = %d", D_RO(oob_item)->item.id);
+			UT_OUT("id = %d", D_RO(oob_item)->item.id);
 		}
 	} else if (L == 2) {
 		TOID(struct item) item;
-		OUT("list:");
+		UT_OUT("list:");
 		LIST_FOREACH(item, List, head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else if (L == 3) {
 		TOID(struct oob_item) oob_item;
-		OUT("oob list sec:");
+		UT_OUT("oob list sec:");
 		LIST_FOREACH_OOB(oob_item, List_oob_sec, head) {
-			OUT("id = %d", D_RO(oob_item)->item.id);
+			UT_OUT("id = %d", D_RO(oob_item)->item.id);
 		}
 	} else if (L == 4) {
 		TOID(struct item) item;
-		OUT("list sec:");
+		UT_OUT("list sec:");
 		LIST_FOREACH(item, List_sec, head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else {
 		FATAL_USAGE_PRINT();
@@ -751,29 +751,29 @@ do_print_reverse(PMEMobjpool *pop, const char *arg)
 		FATAL_USAGE_PRINT_REVERSE();
 	if (L == 1) {
 		TOID(struct oob_item) oob_item;
-		OUT("oob list reverse:");
+		UT_OUT("oob list reverse:");
 		LIST_FOREACH_REVERSE_OOB(oob_item,
 			List_oob, head) {
-			OUT("id = %d", D_RO(oob_item)->item.id);
+			UT_OUT("id = %d", D_RO(oob_item)->item.id);
 		}
 	} else if (L == 2) {
 		TOID(struct item) item;
-		OUT("list reverse:");
+		UT_OUT("list reverse:");
 		LIST_FOREACH_REVERSE(item, List, head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else if (L == 3) {
 		TOID(struct oob_item) oob_item;
-		OUT("oob list sec reverse:");
+		UT_OUT("oob list sec reverse:");
 		LIST_FOREACH_REVERSE_OOB(oob_item,
 			List_oob_sec, head) {
-			OUT("id = %d", D_RO(oob_item)->item.id);
+			UT_OUT("id = %d", D_RO(oob_item)->item.id);
 		}
 	} else if (L == 4) {
 		TOID(struct item) item;
-		OUT("list sec reverse:");
+		UT_OUT("list sec reverse:");
 		LIST_FOREACH_REVERSE(item, List_sec, head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else {
 		FATAL_USAGE_PRINT_REVERSE();
@@ -791,7 +791,7 @@ item_constructor(PMEMobjpool *pop, void *ptr, size_t usable_size, void *arg)
 	struct item *item = (struct item *)ptr;
 	item->id = id;
 	pop->persist(Pop, &item->id, sizeof (item->id));
-	OUT("constructor(id = %d)", id);
+	UT_OUT("constructor(id = %d)", id);
 
 	return 0;
 }
@@ -824,7 +824,7 @@ do_insert_new(PMEMobjpool *pop, const char *arg)
 			&id, (PMEMoid *)Item);
 
 		if (ret)
-			FATAL("list_insert_new(List, List_oob) failed");
+			UT_FATAL("list_insert_new(List, List_oob) failed");
 	} else if (ret == 2) {
 		ret = list_insert_new_user(pop,
 			(struct list_head *)&D_RW(List_oob)->head,
@@ -836,7 +836,7 @@ do_insert_new(PMEMobjpool *pop, const char *arg)
 			NULL, NULL, (PMEMoid *)Item);
 
 		if (ret)
-			FATAL("list_insert_new(List, List_oob) failed");
+			UT_FATAL("list_insert_new(List, List_oob) failed");
 	} else {
 		ret = list_insert_new_user(pop,
 			(struct list_head *)&D_RW(List_oob)->head,
@@ -845,7 +845,7 @@ do_insert_new(PMEMobjpool *pop, const char *arg)
 			NULL, NULL, (PMEMoid *)Item);
 
 		if (ret)
-			FATAL("list_insert_new(List_oob) failed");
+			UT_FATAL("list_insert_new(List_oob) failed");
 	}
 }
 
@@ -871,7 +871,7 @@ do_insert(PMEMobjpool *pop, const char *arg)
 		get_item_list(List.oid, n),
 		before,
 		it)) {
-		FATAL("list_insert(List) failed");
+		UT_FATAL("list_insert(List) failed");
 	}
 }
 
@@ -902,7 +902,7 @@ do_remove_free(PMEMobjpool *pop, const char *arg)
 			0,
 			NULL,
 			&oid)) {
-			FATAL("list_remove_free(List_oob) failed");
+			UT_FATAL("list_remove_free(List_oob) failed");
 		}
 	} else if (N == 2) {
 		if (list_remove_free_user(pop,
@@ -910,7 +910,7 @@ do_remove_free(PMEMobjpool *pop, const char *arg)
 			offsetof(struct item, next),
 			(struct list_head *)&D_RW(List)->head,
 			&oid)) {
-			FATAL("list_remove_free(List_oob, List) failed");
+			UT_FATAL("list_remove_free(List_oob, List) failed");
 		}
 	} else {
 		FATAL_USAGE_REMOVE_FREE();
@@ -931,7 +931,7 @@ do_remove(PMEMobjpool *pop, const char *arg)
 		offsetof(struct item, next),
 		(struct list_head *)&D_RW(List)->head,
 		get_item_list(List.oid, n))) {
-		FATAL("list_remove(List) failed");
+		UT_FATAL("list_remove(List) failed");
 	}
 }
 
@@ -971,7 +971,7 @@ do_move(PMEMobjpool *pop, const char *arg)
 		get_item_list(List_sec.oid, d),
 		before,
 		get_item_list(List.oid, n))) {
-		FATAL("list_move(List, List_sec) failed");
+		UT_FATAL("list_move(List, List_sec) failed");
 	}
 }
 
@@ -995,7 +995,7 @@ do_move_one_list(PMEMobjpool *pop, const char *arg)
 		get_item_list(List.oid, d),
 		before,
 		get_item_list(List.oid, n))) {
-		FATAL("list_move(List, List) failed");
+		UT_FATAL("list_move(List, List) failed");
 	}
 }
 
@@ -1029,10 +1029,10 @@ main(int argc, char *argv[])
 
 	UT_COMPILE_ERROR_ON(OOB_OFF != 48);
 	PMEMobjpool *pop = pmemobj_open(path, NULL);
-	ASSERTne(pop, NULL);
+	UT_ASSERTne(pop, NULL);
 
-	ASSERT(!TOID_IS_NULL(List));
-	ASSERT(!TOID_IS_NULL(List_oob));
+	UT_ASSERT(!TOID_IS_NULL(List));
+	UT_ASSERT(!TOID_IS_NULL(List_oob));
 
 	int i;
 	for (i = 2; i < argc; i++) {

--- a/src/test/obj_list_macro/obj_list_macro.c
+++ b/src/test/obj_list_macro/obj_list_macro.c
@@ -59,21 +59,21 @@ TOID(struct list) List_sec;
 
 /* usage macros */
 #define	FATAL_USAGE()\
-	FATAL("usage: obj_list_macro <file> [PRnifr]")
+	UT_FATAL("usage: obj_list_macro <file> [PRnifr]")
 #define	FATAL_USAGE_PRINT()\
-	FATAL("usage: obj_list_macro <file> P:<list>")
+	UT_FATAL("usage: obj_list_macro <file> P:<list>")
 #define	FATAL_USAGE_PRINT_REVERSE()\
-	FATAL("usage: obj_list_macro <file> R:<list>")
+	UT_FATAL("usage: obj_list_macro <file> R:<list>")
 #define	FATAL_USAGE_INSERT()\
-	FATAL("usage: obj_list_macro <file> i:<where>:<num>[:<id>]")
+	UT_FATAL("usage: obj_list_macro <file> i:<where>:<num>[:<id>]")
 #define	FATAL_USAGE_INSERT_NEW()\
-	FATAL("usage: obj_list_macro <file> n:<where>:<num>[:<id>]")
+	UT_FATAL("usage: obj_list_macro <file> n:<where>:<num>[:<id>]")
 #define	FATAL_USAGE_REMOVE_FREE()\
-	FATAL("usage: obj_list_macro <file> f:<list>:<num>")
+	UT_FATAL("usage: obj_list_macro <file> f:<list>:<num>")
 #define	FATAL_USAGE_REMOVE()\
-	FATAL("usage: obj_list_macro <file> r:<list>:<num>")
+	UT_FATAL("usage: obj_list_macro <file> r:<list>:<num>")
 #define	FATAL_USAGE_MOVE()\
-	FATAL("usage: obj_list_macro <file> m:<num>:<where>:<num>")
+	UT_FATAL("usage: obj_list_macro <file> m:<num>:<where>:<num>")
 
 /*
  * get_item_list -- get nth item from list
@@ -111,14 +111,14 @@ do_print(PMEMobjpool *pop, const char *arg)
 
 	TOID(struct item) item;
 	if (L == 1) {
-		OUT("list:");
+		UT_OUT("list:");
 		POBJ_LIST_FOREACH(item, &D_RW(List)->head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else if (L == 2) {
-		OUT("list sec:");
+		UT_OUT("list sec:");
 		POBJ_LIST_FOREACH(item, &D_RW(List_sec)->head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else {
 		FATAL_USAGE_PRINT();
@@ -136,14 +136,14 @@ do_print_reverse(PMEMobjpool *pop, const char *arg)
 		FATAL_USAGE_PRINT_REVERSE();
 	TOID(struct item) item;
 	if (L == 1) {
-		OUT("list reverse:");
+		UT_OUT("list reverse:");
 		POBJ_LIST_FOREACH_REVERSE(item, &D_RW(List)->head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else if (L == 2) {
-		OUT("list sec reverse:");
+		UT_OUT("list sec reverse:");
 		POBJ_LIST_FOREACH_REVERSE(item, &D_RW(List_sec)->head, next) {
-			OUT("id = %d", D_RO(item)->id);
+			UT_OUT("id = %d", D_RO(item)->id);
 		}
 	} else {
 		FATAL_USAGE_PRINT_REVERSE();
@@ -160,7 +160,7 @@ item_constructor(PMEMobjpool *pop, void *ptr, void *arg)
 	int id = *(int *)arg;
 	struct item *item = (struct item *)ptr;
 	item->id = id;
-	OUT("constructor(id = %d)", id);
+	UT_OUT("constructor(id = %d)", id);
 
 	return 0;
 }
@@ -183,22 +183,22 @@ do_insert_new(PMEMobjpool *pop, const char *arg)
 		POBJ_LIST_INSERT_NEW_HEAD(pop, &D_RW(List)->head, next,
 				sizeof (struct item), item_constructor, &ptr);
 		if (POBJ_LIST_EMPTY(&D_RW(List)->head))
-			FATAL("POBJ_LIST_INSERT_NEW_HEAD");
+			UT_FATAL("POBJ_LIST_INSERT_NEW_HEAD");
 	} else {
 		item = get_item_list(List, n);
-		ASSERT(!TOID_IS_NULL(item));
+		UT_ASSERT(!TOID_IS_NULL(item));
 		if (!before) {
 			POBJ_LIST_INSERT_NEW_AFTER(pop, &D_RW(List)->head,
 					item, next, sizeof (struct item),
 					item_constructor, &ptr);
 			if (TOID_IS_NULL(POBJ_LIST_NEXT(item, next)))
-				FATAL("POBJ_LIST_INSERT_NEW_AFTER");
+				UT_FATAL("POBJ_LIST_INSERT_NEW_AFTER");
 		} else {
 			POBJ_LIST_INSERT_NEW_BEFORE(pop, &D_RW(List)->head,
 					item, next, sizeof (struct item),
 					item_constructor, &ptr);
 			if (TOID_IS_NULL(POBJ_LIST_PREV(item, next)))
-				FATAL("POBJ_LIST_INSERT_NEW_BEFORE");
+				UT_FATAL("POBJ_LIST_INSERT_NEW_BEFORE");
 		}
 	}
 }
@@ -219,25 +219,25 @@ do_insert(PMEMobjpool *pop, const char *arg)
 
 	TOID(struct item) item;
 	POBJ_NEW(pop, &item, struct item, item_constructor, &ptr);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	if (POBJ_LIST_EMPTY(&D_RW(List)->head)) {
 		POBJ_LIST_INSERT_HEAD(pop, &D_RW(List)->head,
 						item, next);
 		if (POBJ_LIST_EMPTY(&D_RW(List)->head))
-			FATAL("POBJ_LIST_INSERT_HEAD");
+			UT_FATAL("POBJ_LIST_INSERT_HEAD");
 	} else {
 		TOID(struct item) elm = get_item_list(List, n);
-		ASSERT(!TOID_IS_NULL(elm));
+		UT_ASSERT(!TOID_IS_NULL(elm));
 		if (!before) {
 			POBJ_LIST_INSERT_AFTER(pop, &D_RW(List)->head,
 							elm, item, next);
 			if (!TOID_EQUALS(item, POBJ_LIST_NEXT(elm, next)))
-				FATAL("POBJ_LIST_INSERT_AFTER");
+				UT_FATAL("POBJ_LIST_INSERT_AFTER");
 		} else {
 			POBJ_LIST_INSERT_BEFORE(pop, &D_RW(List)->head,
 							elm, item, next);
 			if (!TOID_EQUALS(item, POBJ_LIST_PREV(elm, next)))
-				FATAL("POBJ_LIST_INSERT_BEFORE");
+				UT_FATAL("POBJ_LIST_INSERT_BEFORE");
 		}
 	}
 }
@@ -265,10 +265,10 @@ do_remove_free(PMEMobjpool *pop, const char *arg)
 	if (POBJ_LIST_EMPTY(&D_RW(tmp_list)->head))
 		return;
 	item = get_item_list(tmp_list, n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	if (POBJ_LIST_REMOVE_FREE(pop, &D_RW(tmp_list)->head,
 						item, next) != 0)
-		FATAL("POBJ_LIST_REMOVE_FREE");
+		UT_FATAL("POBJ_LIST_REMOVE_FREE");
 }
 
 /*
@@ -294,9 +294,9 @@ do_remove(PMEMobjpool *pop, const char *arg)
 	if (POBJ_LIST_EMPTY(&D_RW(tmp_list)->head))
 		return;
 	item = get_item_list(tmp_list, n);
-	ASSERT(!TOID_IS_NULL(item));
+	UT_ASSERT(!TOID_IS_NULL(item));
 	if (POBJ_LIST_REMOVE(pop, &D_RW(tmp_list)->head, item, next) != 0)
-		FATAL("POBJ_LIST_REMOVE");
+		UT_FATAL("POBJ_LIST_REMOVE");
 	POBJ_FREE(&item);
 }
 
@@ -319,7 +319,7 @@ do_move(PMEMobjpool *pop, const char *arg)
 				&D_RW(List_sec)->head,
 				get_item_list(List, n),
 				next, next) != 0) {
-			FATAL("POBJ_LIST_MOVE_ELEMENT_HEAD");
+			UT_FATAL("POBJ_LIST_MOVE_ELEMENT_HEAD");
 		}
 	} else {
 		if (before) {
@@ -329,7 +329,7 @@ do_move(PMEMobjpool *pop, const char *arg)
 					get_item_list(List_sec, d),
 					get_item_list(List, n),
 					next, next) != 0) {
-				FATAL("POBJ_LIST_MOVE_ELEMENT_BEFORE");
+				UT_FATAL("POBJ_LIST_MOVE_ELEMENT_BEFORE");
 			}
 		} else {
 			if (POBJ_LIST_MOVE_ELEMENT_AFTER(pop, &D_RW(List)->head,
@@ -337,7 +337,7 @@ do_move(PMEMobjpool *pop, const char *arg)
 					get_item_list(List_sec, d),
 					get_item_list(List, n),
 					next, next) != 0) {
-				FATAL("POBJ_LIST_MOVE_ELEMENT_AFTER");
+				UT_FATAL("POBJ_LIST_MOVE_ELEMENT_AFTER");
 			}
 		}
 	}
@@ -367,7 +367,7 @@ main(int argc, char *argv[])
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(path, LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 						S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	POBJ_ZNEW(pop, &List, struct list);
 	POBJ_ZNEW(pop, &List_sec, struct list);

--- a/src/test/obj_many_size_allocs/obj_many_size_allocs.c
+++ b/src/test/obj_many_size_allocs/obj_many_size_allocs.c
@@ -65,25 +65,25 @@ test_allocs(PMEMobjpool *pop, const char *path)
 	PMEMoid oid[TEST_ALLOC_SIZE];
 
 	if (pmemobj_alloc(pop, &oid[0], 0, 0, NULL, NULL) == 0)
-		FATAL("pmemobj_alloc(0) succeeded");
+		UT_FATAL("pmemobj_alloc(0) succeeded");
 
 	for (int i = 1; i < TEST_ALLOC_SIZE; ++i) {
 		struct cargs args = { i };
 		if (pmemobj_alloc(pop, &oid[i], i, 0,
 				test_constructor, &args) != 0)
-			FATAL("!pmemobj_alloc");
-		ASSERT(!OID_IS_NULL(oid[i]));
+			UT_FATAL("!pmemobj_alloc");
+		UT_ASSERT(!OID_IS_NULL(oid[i]));
 	}
 
 	pmemobj_close(pop);
 
-	ASSERT(pmemobj_check(path, LAYOUT_NAME) == 1);
+	UT_ASSERT(pmemobj_check(path, LAYOUT_NAME) == 1);
 
-	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
+	UT_ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
 
 	for (int i = 1; i < TEST_ALLOC_SIZE; ++i) {
 		pmemobj_free(&oid[i]);
-		ASSERT(OID_IS_NULL(oid[i]));
+		UT_ASSERT(OID_IS_NULL(oid[i]));
 	}
 
 	pmemobj_close(pop);
@@ -95,19 +95,19 @@ test_lazy_load(PMEMobjpool *pop, const char *path)
 	PMEMoid oid[3];
 
 	int ret = pmemobj_alloc(pop, &oid[0], LAZY_LOAD_SIZE, 0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_SIZE, 0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 	ret = pmemobj_alloc(pop, &oid[2], LAZY_LOAD_SIZE, 0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 
 	pmemobj_close(pop);
-	ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
+	UT_ASSERT((pop = pmemobj_open(path, LAYOUT_NAME)) != NULL);
 
 	pmemobj_free(&oid[1]);
 
 	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_BIG_SIZE, 0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 }
 
 
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_many_size_allocs");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
@@ -125,7 +125,7 @@ main(int argc, char *argv[])
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			0, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	test_lazy_load(pop, path);
 	test_allocs(pop, path);

--- a/src/test/obj_memcheck/obj_memcheck.c
+++ b/src/test/obj_memcheck/obj_memcheck.c
@@ -77,7 +77,7 @@ test_everything(const char *path)
 
 	if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(mc),
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	struct root *rt = D_RW(POBJ_ROOT(pop, struct root));
 
@@ -145,7 +145,7 @@ test_everything(const char *path)
 
 static void usage(const char *a)
 {
-	FATAL("usage: %s [m|t] file-name", a);
+	UT_FATAL("usage: %s [m|t] file-name", a);
 }
 
 int

--- a/src/test/obj_out_of_memory/obj_out_of_memory.c
+++ b/src/test/obj_out_of_memory/obj_out_of_memory.c
@@ -65,7 +65,7 @@ test_alloc(PMEMobjpool *pop, size_t size)
 		cnt++;
 	}
 
-	OUT("size: %zu allocs: %lu", size, cnt);
+	UT_OUT("size: %zu allocs: %lu", size, cnt);
 }
 
 static void
@@ -84,7 +84,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_out_of_memory");
 
 	if (argc < 3)
-		FATAL("usage: %s size filename ...", argv[0]);
+		UT_FATAL("usage: %s size filename ...", argv[0]);
 
 	size_t size = atoll(argv[1]);
 
@@ -94,13 +94,13 @@ main(int argc, char *argv[])
 		PMEMobjpool *pop = pmemobj_create(path, LAYOUT_NAME, 0,
 					S_IWUSR | S_IRUSR);
 		if (pop == NULL)
-			FATAL("!pmemobj_create: %s", path);
+			UT_FATAL("!pmemobj_create: %s", path);
 
 		test_alloc(pop, size);
 
 		pmemobj_close(pop);
 
-		ASSERTeq(pmemobj_check(path, LAYOUT_NAME), 1);
+		UT_ASSERTeq(pmemobj_check(path, LAYOUT_NAME), 1);
 
 		/*
 		 * To prevent subsequent opens from receiving exactly the same
@@ -110,7 +110,7 @@ main(int argc, char *argv[])
 		 */
 		void *heap_touch = MALLOC(1);
 
-		ASSERTne(pop = pmemobj_open(path, LAYOUT_NAME), NULL);
+		UT_ASSERTne(pop = pmemobj_open(path, LAYOUT_NAME), NULL);
 
 		test_free(pop);
 

--- a/src/test/obj_persist_count/obj_persist_count.c
+++ b/src/test/obj_persist_count/obj_persist_count.c
@@ -88,7 +88,7 @@ reset_counters(void)
 static void
 print_reset_counters(const char *task)
 {
-	OUT("%d\t;%d\t;%d\t;%d\t;%s",
+	UT_OUT("%d\t;%d\t;%d\t;%d\t;%s",
 		ops_counter.n_persist, ops_counter.n_msync,
 		ops_counter.n_flush, ops_counter.n_drain, task);
 
@@ -108,16 +108,16 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_persist_count");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(path, "persist_count",
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
-	OUT("persist\t;msync\t;flush\t;drain\t;task");
+	UT_OUT("persist\t;msync\t;flush\t;drain\t;task");
 
 	print_reset_counters("pool_create");
 
@@ -126,12 +126,12 @@ main(int argc, char *argv[])
 	reset_counters();
 
 	PMEMoid root = pmemobj_root(pop, sizeof (struct foo));
-	ASSERT(!OID_IS_NULL(root));
+	UT_ASSERT(!OID_IS_NULL(root));
 	print_reset_counters("root_alloc");
 
 	PMEMoid oid;
 	int ret = pmemobj_alloc(pop, &oid, sizeof (struct foo), 0, NULL, NULL);
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 	print_reset_counters("atomic_alloc");
 
 	pmemobj_free(&oid);
@@ -141,7 +141,7 @@ main(int argc, char *argv[])
 
 	TX_BEGIN(pop) {
 		f->bar = pmemobj_tx_alloc(sizeof (struct foo), 0);
-		ASSERT(!OID_IS_NULL(f->bar));
+		UT_ASSERT(!OID_IS_NULL(f->bar));
 	} TX_END
 	print_reset_counters("tx_alloc");
 

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -124,16 +124,16 @@ test_oom_allocs(size_t size)
 		if (pmalloc(mock_pop, &addr->ptr, size)) {
 			break;
 		}
-		ASSERT(addr->ptr != 0);
+		UT_ASSERT(addr->ptr != 0);
 		allocs[count++] = addr->ptr;
 	}
 
 	for (int i = 0; i < count; ++i) {
 		addr->ptr = allocs[i];
 		pfree(mock_pop, &addr->ptr);
-		ASSERT(addr->ptr == 0);
+		UT_ASSERT(addr->ptr == 0);
 	}
-	ASSERT(count != 0);
+	UT_ASSERT(count != 0);
 	FREE(allocs);
 }
 
@@ -143,7 +143,7 @@ test_malloc_free_loop(size_t size)
 	int err;
 	for (int i = 0; i < MAX_MALLOC_FREE_LOOP; ++i) {
 		err = pmalloc(mock_pop, &addr->ptr, size);
-		ASSERTeq(err, 0);
+		UT_ASSERTeq(err, 0);
 		pfree(mock_pop, &addr->ptr);
 	}
 }
@@ -153,11 +153,11 @@ test_realloc(size_t org, size_t dest)
 {
 	int err;
 	err = pmalloc(mock_pop, &addr->ptr, org);
-	ASSERTeq(err, 0);
-	ASSERT(pmalloc_usable_size(mock_pop, addr->ptr) >= org);
+	UT_ASSERTeq(err, 0);
+	UT_ASSERT(pmalloc_usable_size(mock_pop, addr->ptr) >= org);
 	err = prealloc(mock_pop, &addr->ptr, dest);
-	ASSERTeq(err, 0);
-	ASSERT(pmalloc_usable_size(mock_pop, addr->ptr) >= dest);
+	UT_ASSERTeq(err, 0);
+	UT_ASSERT(pmalloc_usable_size(mock_pop, addr->ptr) >= dest);
 	pfree(mock_pop, &addr->ptr);
 }
 
@@ -191,7 +191,7 @@ test_mock_pool_allocs()
 
 	lane_boot(mock_pop);
 
-	ASSERTne(mock_pop->heap, NULL);
+	UT_ASSERTne(mock_pop->heap, NULL);
 
 	test_malloc_free_loop(MALLOC_FREE_SIZE);
 
@@ -221,7 +221,7 @@ test_spec_compliance()
 		sizeof (struct allocation_header) -
 		sizeof (struct oob_header);
 
-	ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
+	UT_ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
 }
 
 int

--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -65,7 +65,7 @@ alloc_worker(void *arg)
 
 	for (int i = 0; i < OPS_PER_THREAD; ++i) {
 		pmalloc(a->pop, &a->r->offs[a->idx][i], ALLOC_SIZE);
-		ASSERTne(a->r->offs[a->idx][i], 0);
+		UT_ASSERTne(a->r->offs[a->idx][i], 0);
 	}
 
 	return NULL;
@@ -78,7 +78,7 @@ realloc_worker(void *arg)
 
 	for (int i = 0; i < OPS_PER_THREAD; ++i) {
 		prealloc(a->pop, &a->r->offs[a->idx][i], REALLOC_SIZE);
-		ASSERTne(a->r->offs[a->idx][i], 0);
+		UT_ASSERTne(a->r->offs[a->idx][i], 0);
 	}
 
 	return NULL;
@@ -91,7 +91,7 @@ free_worker(void *arg)
 
 	for (int i = 0; i < OPS_PER_THREAD; ++i) {
 		pfree(a->pop, &a->r->offs[a->idx][i]);
-		ASSERTeq(a->r->offs[a->idx][i], 0);
+		UT_ASSERTeq(a->r->offs[a->idx][i], 0);
 	}
 
 	return NULL;
@@ -109,12 +109,12 @@ mix_worker(void *arg)
 	for (int i = 0; i < MIX_RERUNS; ++i) {
 		for (int i = 0; i < OPS_PER_THREAD; ++i) {
 			pmalloc(a->pop, &a->r->offs[a->idx][i], ALLOC_SIZE);
-			ASSERTne(a->r->offs[a->idx][i], 0);
+			UT_ASSERTne(a->r->offs[a->idx][i], 0);
 		}
 
 		for (int i = 0; i < OPS_PER_THREAD; ++i) {
 			pfree(a->pop, &a->r->offs[a->idx][i]);
-			ASSERTeq(a->r->offs[a->idx][i], 0);
+			UT_ASSERTeq(a->r->offs[a->idx][i], 0);
 		}
 	}
 
@@ -147,7 +147,7 @@ alloc_free_worker(void *arg)
 	for (int i = 0; i < OPS_PER_THREAD; ++i) {
 		int err = pmemobj_alloc(a->pop, &oid, ALLOC_SIZE,
 				0, NULL, NULL);
-		ASSERTeq(err, 0);
+		UT_ASSERTeq(err, 0);
 		pmemobj_free(&oid);
 	}
 
@@ -172,7 +172,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_pmalloc_mt");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 
@@ -187,11 +187,11 @@ main(int argc, char *argv[])
 	}
 
 	if (pop == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	PMEMoid oid = pmemobj_root(pop, sizeof (struct root));
 	struct root *r = pmemobj_direct(oid);
-	ASSERTne(r, NULL);
+	UT_ASSERTne(r, NULL);
 
 	struct worker_args args[THREADS];
 

--- a/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
+++ b/src/test/obj_pmalloc_oom_mt/obj_pmalloc_oom_mt.c
@@ -65,13 +65,13 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_pmalloc_oom_mt");
 
 	if (argc != 2)
-		FATAL("usage: %s file-name", argv[0]);
+		UT_FATAL("usage: %s file-name", argv[0]);
 
 	const char *path = argv[1];
 
 	if ((pop = pmemobj_create(path, LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	pthread_t t;
 	pthread_create(&t, NULL, oom_worker, NULL);
@@ -82,7 +82,7 @@ main(int argc, char *argv[])
 	pthread_create(&t, NULL, oom_worker, NULL);
 	pthread_join(t, NULL);
 
-	ASSERTeq(first_thread_allocated, allocated);
+	UT_ASSERTeq(first_thread_allocated, allocated);
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_pool/obj_pool.c
+++ b/src/test/obj_pool/obj_pool.c
@@ -52,12 +52,12 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 	PMEMobjpool *pop = pmemobj_create(path, layout, poolsize, mode);
 
 	if (pop == NULL)
-		OUT("!%s: pmemobj_create", path);
+		UT_OUT("!%s: pmemobj_create", path);
 	else {
 		struct stat stbuf;
 		STAT(path, &stbuf);
 
-		OUT("%s: file size %zu mode 0%o",
+		UT_OUT("%s: file size %zu mode 0%o",
 				path, stbuf.st_size,
 				stbuf.st_mode & 0777);
 
@@ -66,9 +66,9 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 		int result = pmemobj_check(path, layout);
 
 		if (result < 0)
-			OUT("!%s: pmemobj_check", path);
+			UT_OUT("!%s: pmemobj_check", path);
 		else if (result == 0)
-			OUT("%s: pmemobj_check: not consistent", path);
+			UT_OUT("%s: pmemobj_check: not consistent", path);
 	}
 }
 
@@ -77,9 +77,9 @@ pool_open(const char *path, const char *layout)
 {
 	PMEMobjpool *pop = pmemobj_open(path, layout);
 	if (pop == NULL)
-		OUT("!%s: pmemobj_open", path);
+		UT_OUT("!%s: pmemobj_open", path);
 	else {
-		OUT("%s: pmemobj_open: Success", path);
+		UT_OUT("%s: pmemobj_open: Success", path);
 		pmemobj_close(pop);
 	}
 }
@@ -90,7 +90,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_pool");
 
 	if (argc < 4)
-		FATAL("usage: %s op path layout [poolsize mode]", argv[0]);
+		UT_FATAL("usage: %s op path layout [poolsize mode]", argv[0]);
 
 	char *layout = NULL;
 	size_t poolsize;
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
 		break;
 
 	default:
-		FATAL("unknown operation");
+		UT_FATAL("unknown operation");
 	}
 
 	DONE(NULL);

--- a/src/test/obj_pool_lock/obj_pool_lock.c
+++ b/src/test/obj_pool_lock/obj_pool_lock.c
@@ -45,20 +45,20 @@ test_reopen(const char *path)
 	PMEMobjpool *pop1 = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR);
 	if (!pop1)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	PMEMobjpool *pop2 = pmemobj_open(path, LAYOUT);
 	if (pop2)
-		FATAL("pmemobj_open should not succeed");
+		UT_FATAL("pmemobj_open should not succeed");
 
 	if (errno != EWOULDBLOCK)
-		FATAL("!pmemobj_open failed but for unexpected reason");
+		UT_FATAL("!pmemobj_open failed but for unexpected reason");
 
 	pmemobj_close(pop1);
 
 	pop2 = pmemobj_open(path, LAYOUT);
 	if (!pop2)
-		FATAL("pmemobj_open should succeed after close");
+		UT_FATAL("pmemobj_open should succeed after close");
 
 	pmemobj_close(pop2);
 
@@ -72,7 +72,7 @@ test_open_in_different_process(const char *path, int sleep)
 	PMEMobjpool *pop;
 
 	if (pid < 0)
-		FATAL("fork failed");
+		UT_FATAL("fork failed");
 
 	if (pid == 0) {
 		/* child */
@@ -83,10 +83,10 @@ test_open_in_different_process(const char *path, int sleep)
 
 		pop = pmemobj_open(path, LAYOUT);
 		if (pop)
-			FATAL("pmemobj_open after fork should not succeed");
+			UT_FATAL("pmemobj_open after fork should not succeed");
 
 		if (errno != EWOULDBLOCK)
-			FATAL("!pmemobj_open after fork failed but for "
+			UT_FATAL("!pmemobj_open after fork failed but for "
 				"unexpected reason");
 
 		exit(0);
@@ -94,15 +94,15 @@ test_open_in_different_process(const char *path, int sleep)
 
 	pop = pmemobj_create(path, LAYOUT, PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR);
 	if (!pop)
-		FATAL("!create");
+		UT_FATAL("!create");
 
 	int status;
 
 	if (waitpid(pid, &status, 0) < 0)
-		FATAL("!waitpid failed");
+		UT_FATAL("!waitpid failed");
 
 	if (!WIFEXITED(status))
-		FATAL("child process failed");
+		UT_FATAL("child process failed");
 
 	pmemobj_close(pop);
 
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_pool_lock");
 
 	if (argc < 2)
-		FATAL("usage: %s path", argv[0]);
+		UT_FATAL("usage: %s path", argv[0]);
 
 	test_reopen(argv[1]);
 

--- a/src/test/obj_pool_lookup/obj_pool_lookup.c
+++ b/src/test/obj_pool_lookup/obj_pool_lookup.c
@@ -47,7 +47,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_direct");
 
 	if (argc != 3)
-		FATAL("usage: %s [directory] [# of pools]", argv[0]);
+		UT_FATAL("usage: %s [directory] [# of pools]", argv[0]);
 
 	int npools = atoi(argv[2]);
 	const char *dir = argv[1];
@@ -71,30 +71,30 @@ main(int argc, char *argv[])
 				PROT_READ | PROT_WRITE,
 				MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
-		ASSERTne(guard_after[i], NULL);
+		UT_ASSERTne(guard_after[i], NULL);
 
 		if (pops[i] == NULL)
-			FATAL("!pmemobj_create");
+			UT_FATAL("!pmemobj_create");
 	}
 
 	PMEMoid oids[npools];
 
 	for (int i = 0; i < npools; ++i) {
 		r = pmemobj_alloc(pops[i], &oids[i], ALLOC_SIZE, 1, NULL, NULL);
-		ASSERTeq(r, 0);
+		UT_ASSERTeq(r, 0);
 	}
 
 	PMEMoid invalid = {123, 321};
 
-	ASSERTeq(pmemobj_pool_by_oid(OID_NULL), NULL);
-	ASSERTeq(pmemobj_pool_by_oid(invalid), NULL);
+	UT_ASSERTeq(pmemobj_pool_by_oid(OID_NULL), NULL);
+	UT_ASSERTeq(pmemobj_pool_by_oid(invalid), NULL);
 
 	for (int i = 0; i < npools; ++i) {
-		ASSERTeq(pmemobj_pool_by_oid(oids[i]), pops[i]);
+		UT_ASSERTeq(pmemobj_pool_by_oid(oids[i]), pops[i]);
 	}
 
-	ASSERTeq(pmemobj_pool_by_ptr(NULL), NULL);
-	ASSERTeq(pmemobj_pool_by_ptr((void *)0xCBA), NULL);
+	UT_ASSERTeq(pmemobj_pool_by_ptr(NULL), NULL);
+	UT_ASSERTeq(pmemobj_pool_by_ptr((void *)0xCBA), NULL);
 
 	for (int i = 0; i < npools; ++i) {
 		void *before_pool = (char *)pops[i] - 1;
@@ -103,14 +103,14 @@ main(int argc, char *argv[])
 		void *middle = (char *)pops[i] + (PMEMOBJ_MIN_POOL / 2);
 		void *in_oid = (char *)pmemobj_direct(oids[i]) +
 			(ALLOC_SIZE / 2);
-		ASSERTeq(pmemobj_pool_by_ptr(before_pool), NULL);
-		ASSERTeq(pmemobj_pool_by_ptr(after_pool), NULL);
-		ASSERTeq(pmemobj_pool_by_ptr(edge), NULL);
-		ASSERTeq(pmemobj_pool_by_ptr(middle), pops[i]);
-		ASSERTeq(pmemobj_pool_by_ptr(in_oid), pops[i]);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(before_pool), NULL);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(after_pool), NULL);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(edge), NULL);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(middle), pops[i]);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(in_oid), pops[i]);
 		pmemobj_close(pops[i]);
-		ASSERTeq(pmemobj_pool_by_ptr(middle), NULL);
-		ASSERTeq(pmemobj_pool_by_ptr(in_oid), NULL);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(middle), NULL);
+		UT_ASSERTeq(pmemobj_pool_by_ptr(in_oid), NULL);
 
 		MUNMAP(guard_after[i], Ut_pagesize);
 	}

--- a/src/test/obj_realloc/obj_realloc.c
+++ b/src/test/obj_realloc/obj_realloc.c
@@ -79,13 +79,13 @@ static void
 test_alloc(PMEMobjpool *pop, size_t size)
 {
 	TOID(struct root) root = POBJ_ROOT(pop, struct root);
-	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 
 	int ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid, size,
 			TOID_TYPE_NUM(struct object));
-	ASSERTeq(ret, 0);
-	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
-	ASSERT(pmemobj_alloc_usable_size(D_RO(root)->obj.oid) >= size);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(pmemobj_alloc_usable_size(D_RO(root)->obj.oid) >= size);
 }
 
 /*
@@ -95,12 +95,12 @@ static void
 test_free(PMEMobjpool *pop)
 {
 	TOID(struct root) root = POBJ_ROOT(pop, struct root);
-	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
 
 	int ret = pmemobj_realloc(pop, &D_RW(root)->obj.oid, 0,
 			TOID_TYPE_NUM(struct object));
-	ASSERTeq(ret, 0);
-	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 }
 
 static int check_integrity = 1;
@@ -125,7 +125,7 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 		unsigned type_from, unsigned type_to, int zrealloc)
 {
 	TOID(struct root) root = POBJ_ROOT(pop, struct root);
-	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 
 	int ret;
 	if (zrealloc)
@@ -135,18 +135,18 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 		ret = pmemobj_alloc(pop, &D_RW(root)->obj.oid,
 			size_from, type_from, NULL, NULL);
 
-	ASSERTeq(ret, 0);
-	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
 	size_t usable_size_from =
 			pmemobj_alloc_usable_size(D_RO(root)->obj.oid);
 
-	ASSERT(usable_size_from >= size_from);
+	UT_ASSERT(usable_size_from >= size_from);
 
 	size_t check_size;
 	uint16_t checksum;
 
 	if (zrealloc) {
-		ASSERT(util_is_zeroed(D_RO(D_RO(root)->obj),
+		UT_ASSERT(util_is_zeroed(D_RO(D_RO(root)->obj),
 					size_from));
 	} else if (check_integrity) {
 		check_size = size_to >= usable_size_from ?
@@ -163,21 +163,21 @@ test_realloc(PMEMobjpool *pop, size_t size_from, size_t size_to,
 				size_to, type_to);
 	}
 
-	ASSERTeq(ret, 0);
-	ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
-	ASSERT(pmemobj_alloc_usable_size(D_RO(root)->obj.oid) >= size_to);
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(pmemobj_alloc_usable_size(D_RO(root)->obj.oid) >= size_to);
 
 	if (zrealloc) {
-		ASSERT(util_is_zeroed(D_RO(D_RO(root)->obj), size_to));
+		UT_ASSERT(util_is_zeroed(D_RO(D_RO(root)->obj), size_to));
 	} else if (check_integrity) {
 		uint16_t checksum2 = ut_checksum(
 				(void *)D_RW(D_RW(root)->obj), check_size);
 		if (checksum2 != checksum)
-			ASSERTinfo(0, "memory corruption");
+			UT_ASSERTinfo(0, "memory corruption");
 	}
 
 	pmemobj_free(&D_RW(root)->obj.oid);
-	ASSERT(TOID_IS_NULL(D_RO(root)->obj));
+	UT_ASSERT(TOID_IS_NULL(D_RO(root)->obj));
 }
 
 /*
@@ -220,11 +220,11 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_realloc");
 
 	if (argc < 2)
-		FATAL("usage: %s file [check_integrity]", argv[0]);
+		UT_FATAL("usage: %s file [check_integrity]", argv[0]);
 
 	PMEMobjpool *pop = pmemobj_open(argv[1], POBJ_LAYOUT_NAME(realloc));
 	if (!pop)
-		FATAL("!pmemobj_open");
+		UT_FATAL("!pmemobj_open");
 
 	if (argc >= 3)
 		check_integrity = atoi(argv[2]);

--- a/src/test/obj_recovery/obj_recovery.c
+++ b/src/test/obj_recovery/obj_recovery.c
@@ -57,7 +57,8 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_recovery");
 
 	if (argc != 5)
-		FATAL("usage: %s [file] [lock: y/n] [cmd: c/o] [type: n/f/s]",
+		UT_FATAL("usage: %s [file] [lock: y/n] "
+			"[cmd: c/o] [type: n/f/s]",
 			argv[0]);
 
 	const char *path = argv[1];
@@ -73,17 +74,17 @@ main(int argc, char *argv[])
 	else if (argv[4][0] == 's')
 		type = TEST_SET;
 	else
-		FATAL("invalid type");
+		UT_FATAL("invalid type");
 
 	if (!exists) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(recovery),
 			0, S_IWUSR | S_IRUSR)) == NULL) {
-			FATAL("failed to create pool\n");
+			UT_FATAL("failed to create pool\n");
 		}
 	} else {
 		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(recovery)))
 						== NULL) {
-			FATAL("failed to open pool\n");
+			UT_FATAL("failed to open pool\n");
 		}
 	}
 
@@ -114,7 +115,7 @@ main(int argc, char *argv[])
 				exit(0); /* simulate a crash */
 			} TX_END
 		} else {
-			ASSERT(D_RW(D_RW(root)->foo)->bar == BAR_VALUE);
+			UT_ASSERT(D_RW(D_RW(root)->foo)->bar == BAR_VALUE);
 		}
 	} else if (type == TEST_NEW) {
 		if (!exists) {
@@ -126,7 +127,7 @@ main(int argc, char *argv[])
 			} TX_END
 
 		} else {
-			ASSERT(TOID_IS_NULL(D_RW(root)->foo));
+			UT_ASSERT(TOID_IS_NULL(D_RW(root)->foo));
 		}
 	} else { /* TEST_FREE */
 		if (!exists) {
@@ -146,11 +147,11 @@ main(int argc, char *argv[])
 			} TX_END
 
 		} else {
-			ASSERT(!TOID_IS_NULL(D_RW(root)->foo));
+			UT_ASSERT(!TOID_IS_NULL(D_RW(root)->foo));
 		}
 	}
 
-	ASSERT(pmemobj_check(path, POBJ_LAYOUT_NAME(recovery)));
+	UT_ASSERT(pmemobj_check(path, POBJ_LAYOUT_NAME(recovery)));
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_recreate/obj_recreate.c
+++ b/src/test/obj_recreate/obj_recreate.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_recreate");
 
 	if (argc < 2)
-		FATAL("usage: %s file-name [trunc]", argv[0]);
+		UT_FATAL("usage: %s file-name [trunc]", argv[0]);
 
 	const char *path = argv[1];
 
@@ -68,7 +68,7 @@ main(int argc, char *argv[])
 	/* create pool 2*N */
 	pop = pmemobj_create(path, LAYOUT_NAME, 2 * N, S_IWUSR | S_IRUSR);
 	if (pop == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	/* allocate 1.5*N */
 	TOID(struct root) root = (TOID(struct root))pmemobj_root(pop, 1.5 * N);
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 	int fd = OPEN(path, O_RDWR);
 
 	if (argc >= 3 && strcmp(argv[2], "trunc") == 0) {
-		OUT("truncating");
+		UT_OUT("truncating");
 		/* shrink file to N */
 		FTRUNCATE(fd, N);
 	}
@@ -95,17 +95,17 @@ main(int argc, char *argv[])
 	/* create pool on existing file */
 	pop = pmemobj_create(path, LAYOUT_NAME, 0, S_IWUSR | S_IRUSR);
 	if (pop == NULL)
-		FATAL("!pmemobj_create: %s", path);
+		UT_FATAL("!pmemobj_create: %s", path);
 
 	/* try to allocate 0.7*N */
 	root = (TOID(struct root))pmemobj_root(pop, 0.5 * N);
 
 	if (TOID_IS_NULL(root))
-		FATAL("couldn't allocate root object");
+		UT_FATAL("couldn't allocate root object");
 
 	/* validate root object is empty */
 	if (!TOID_IS_NULL(D_RW(root)->foo))
-		FATAL("root object is already filled after pmemobj_create!");
+		UT_FATAL("root object is already filled after pmemobj_create!");
 
 	pmemobj_close(pop);
 

--- a/src/test/obj_strdup/obj_strdup.c
+++ b/src/test/obj_strdup/obj_strdup.c
@@ -64,8 +64,8 @@ do_strdup(PMEMobjpool *pop)
 {
 	TOID(char) str = TOID_NULL(char);
 	pmemobj_strdup(pop, &str.oid, TEST_STR_1, TYPE_SIMPLE);
-	ASSERT(!TOID_IS_NULL(str));
-	ASSERTeq(strcmp(D_RO(str), TEST_STR_1), 0);
+	UT_ASSERT(!TOID_IS_NULL(str));
+	UT_ASSERTeq(strcmp(D_RO(str), TEST_STR_1), 0);
 }
 
 /*
@@ -76,7 +76,7 @@ do_strdup_null(PMEMobjpool *pop)
 {
 	TOID(char) str = TOID_NULL(char);
 	pmemobj_strdup(pop, &str.oid, NULL, TYPE_NULL);
-	ASSERT(TOID_IS_NULL(str));
+	UT_ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -88,8 +88,8 @@ do_alloc(PMEMobjpool *pop, const char *s, unsigned type_num)
 	TOID(char) str;
 	POBJ_ZNEW(pop, &str, char);
 	pmemobj_strdup(pop, &str.oid, s, type_num);
-	ASSERT(!TOID_IS_NULL(str));
-	ASSERTeq(strcmp(D_RO(str), s), 0);
+	UT_ASSERT(!TOID_IS_NULL(str));
+	UT_ASSERTeq(strcmp(D_RO(str), s), 0);
 	return str;
 }
 
@@ -102,7 +102,7 @@ do_strdup_alloc(PMEMobjpool *pop)
 	TOID(char) str1 = do_alloc(pop, TEST_STR_1, TYPE_SIMPLE_ALLOC_1);
 	TOID(char) str2 = do_alloc(pop, TEST_STR_2, TYPE_SIMPLE_ALLOC_2);
 	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_SIMPLE_ALLOC);
-	ASSERTeq(strcmp(D_RO(str1), D_RO(str2)), 0);
+	UT_ASSERTeq(strcmp(D_RO(str1), D_RO(str2)), 0);
 }
 
 /*
@@ -114,7 +114,7 @@ do_strdup_null_alloc(PMEMobjpool *pop)
 	TOID(char) str1 = do_alloc(pop, TEST_STR_1, TYPE_NULL_ALLOC_1);
 	TOID(char) str2 = TOID_NULL(char);
 	pmemobj_strdup(pop, &str1.oid, D_RO(str2), TYPE_NULL_ALLOC);
-	ASSERT(!TOID_IS_NULL(str1));
+	UT_ASSERT(!TOID_IS_NULL(str1));
 }
 
 int
@@ -123,12 +123,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_strdup");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_strdup(pop);
 	do_strdup_null(pop);

--- a/src/test/obj_toid/obj_toid.c
+++ b/src/test/obj_toid/obj_toid.c
@@ -52,9 +52,9 @@ do_toid_valid(PMEMobjpool *pop)
 {
 	TOID(struct obj) obj;
 	POBJ_NEW(pop, &obj, struct obj, NULL, NULL);
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
-	ASSERT(TOID_VALID(obj));
+	UT_ASSERT(TOID_VALID(obj));
 	POBJ_FREE(&obj);
 }
 
@@ -68,8 +68,8 @@ do_toid_no_valid(PMEMobjpool *pop)
 	TOID(struct obj) obj;
 	int ret = pmemobj_alloc(pop, &obj.oid, sizeof (struct obj), TEST_NUM,
 								NULL, NULL);
-	ASSERTeq(ret, 0);
-	ASSERT(!TOID_VALID(obj));
+	UT_ASSERTeq(ret, 0);
+	UT_ASSERT(!TOID_VALID(obj));
 	POBJ_FREE(&obj);
 }
 
@@ -83,7 +83,7 @@ do_direct_simple(PMEMobjpool *pop)
 	TOID(struct obj) obj;
 	POBJ_NEW(pop, &obj, struct obj, NULL, NULL);
 	DIRECT_RW(obj)->id = TEST_NUM;
-	ASSERTeq(DIRECT_RO(obj)->id, TEST_NUM);
+	UT_ASSERTeq(DIRECT_RO(obj)->id, TEST_NUM);
 	POBJ_FREE(&obj);
 }
 
@@ -93,12 +93,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_toid");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_toid_valid(pop);
 	do_toid_no_valid(pop);

--- a/src/test/obj_tx_add_range/obj_tx_add_range.c
+++ b/src/test/obj_tx_add_range/obj_tx_add_range.c
@@ -97,27 +97,27 @@ do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
 			DATA_SIZE);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj)->data[i], TEST_VALUE_2);
+		UT_ASSERTeq(D_RO(obj)->data[i], TEST_VALUE_2);
 }
 
 /*
@@ -131,26 +131,26 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range(obj.oid, DATA_OFF, DATA_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
 			DATA_SIZE);
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_OBJ_ABORT));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -164,23 +164,23 @@ do_tx_add_range_twice_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
 }
 
 /*
@@ -194,25 +194,25 @@ do_tx_add_range_twice_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, 0);
+	UT_ASSERTeq(D_RO(obj)->value, 0);
 }
 
 /*
@@ -230,31 +230,31 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
 					DATA_OFF, DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, 0);
+	UT_ASSERTeq(D_RO(obj1)->value, 0);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], 0);
+		UT_ASSERTeq(D_RO(obj2)->data[i], 0);
 }
 
 /*
@@ -272,31 +272,31 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
 					DATA_OFF, DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, 0);
+	UT_ASSERTeq(D_RO(obj1)->value, 0);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], 0);
+		UT_ASSERTeq(D_RO(obj2)->data[i], 0);
 }
 
 /*
@@ -313,29 +313,29 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj1.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_add_range(obj2.oid,
 					DATA_OFF, DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], TEST_VALUE_2);
+		UT_ASSERTeq(D_RO(obj2)->data[i], TEST_VALUE_2);
 }
 
 /*
@@ -350,16 +350,16 @@ do_tx_add_range_abort(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, 0);
+	UT_ASSERTeq(D_RO(obj)->value, 0);
 }
 
 /*
@@ -374,14 +374,14 @@ do_tx_add_range_commit(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_add_range(obj.oid, VALUE_OFF, VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 }
 
 /*
@@ -414,10 +414,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
+	UT_ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
 
 	/*
 	 * ++++----++++
@@ -438,10 +438,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
+	UT_ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
 
 	/*
 	 * ++++----++++
@@ -462,10 +462,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
+	UT_ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
 
 	/*
 	 * ++++-++-++++
@@ -489,10 +489,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
+	UT_ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
 
 	/*
 	 * ++++
@@ -507,10 +507,10 @@ do_tx_add_range_overlapping(PMEMobjpool *pop)
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
+	UT_ASSERT(util_is_zeroed(D_RO(obj)->data, OVERLAP_SIZE));
 }
 
 int
@@ -520,12 +520,12 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_tx_add_range_commit(pop);
 	VALGRIND_WRITE_STATS;

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -90,30 +90,30 @@ do_tx_add_range_alloc_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF,
 				DATA_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
 			DATA_SIZE);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj)->data[i], TEST_VALUE_2);
+		UT_ASSERTeq(D_RO(obj)->data[i], TEST_VALUE_2);
 }
 
 /*
@@ -127,29 +127,29 @@ do_tx_add_range_alloc_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ_ABORT));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + DATA_OFF,
 				DATA_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		pmemobj_memset_persist(pop, D_RW(obj)->data, TEST_VALUE_2,
 			DATA_SIZE);
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_OBJ_ABORT));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -163,26 +163,26 @@ do_tx_add_range_twice_commit(PMEMobjpool *pop)
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
 }
 
 /*
@@ -196,28 +196,28 @@ do_tx_add_range_twice_abort(PMEMobjpool *pop)
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, do_tx_zalloc(pop, TYPE_OBJ));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TX_BEGIN(pop) {
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_2;
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, 0);
+	UT_ASSERTeq(D_RO(obj)->value, 0);
 }
 
 /*
@@ -237,7 +237,7 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -245,24 +245,24 @@ do_tx_add_range_abort_after_nested(PMEMobjpool *pop)
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
 					DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, 0);
+	UT_ASSERTeq(D_RO(obj1)->value, 0);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], 0);
+		UT_ASSERTeq(D_RO(obj2)->data[i], 0);
 }
 
 /*
@@ -282,7 +282,7 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -290,24 +290,24 @@ do_tx_add_range_abort_nested(PMEMobjpool *pop)
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
 					DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, 0);
+	UT_ASSERTeq(D_RO(obj1)->value, 0);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], 0);
+		UT_ASSERTeq(D_RO(obj2)->data[i], 0);
 }
 
 /*
@@ -326,7 +326,7 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 		char *ptr1 = pmemobj_direct(obj1.oid);
 		ret = pmemobj_tx_add_range_direct(ptr1 + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -334,22 +334,22 @@ do_tx_add_range_commit_nested(PMEMobjpool *pop)
 			char *ptr2 = pmemobj_direct(obj2.oid);
 			ret = pmemobj_tx_add_range_direct(ptr2 + DATA_OFF,
 					DATA_SIZE);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_memset_persist(pop, D_RW(obj2)->data,
 				TEST_VALUE_2, DATA_SIZE);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
 
 	size_t i;
 	for (i = 0; i < DATA_SIZE; i++)
-		ASSERTeq(D_RO(obj2)->data[i], TEST_VALUE_2);
+		UT_ASSERTeq(D_RO(obj2)->data[i], TEST_VALUE_2);
 }
 
 /*
@@ -366,16 +366,16 @@ do_tx_add_range_abort(PMEMobjpool *pop)
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, 0);
+	UT_ASSERTeq(D_RO(obj)->value, 0);
 }
 
 /*
@@ -392,14 +392,14 @@ do_tx_add_range_commit(PMEMobjpool *pop)
 		char *ptr = pmemobj_direct(obj.oid);
 		ret = pmemobj_tx_add_range_direct(ptr + VALUE_OFF,
 				VALUE_SIZE);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		D_RW(obj)->value = TEST_VALUE_1;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 }
 
 /*
@@ -415,16 +415,16 @@ do_tx_commit_and_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TX_SET(obj, value, TEST_VALUE_1); /* this will land in cache */
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 }
 
 /*
@@ -441,30 +441,30 @@ test_add_direct_macros(PMEMobjpool *pop)
 		struct object *o = D_RW(obj);
 		TX_SET_DIRECT(o, value, TEST_VALUE_1);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 
 	TX_BEGIN(pop) {
 		struct object *o = D_RW(obj);
 		TX_ADD_DIRECT(o);
 		o->value = TEST_VALUE_2;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_2);
 
 	TX_BEGIN(pop) {
 		struct object *o = D_RW(obj);
 		TX_ADD_FIELD_DIRECT(o, value);
 		o->value = TEST_VALUE_1;
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 }
 
 int
@@ -474,12 +474,12 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 			S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_tx_add_range_commit(pop);
 	VALGRIND_WRITE_STATS;

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -100,15 +100,15 @@ do_tx_alloc_oom(PMEMobjpool *pop)
 	size_t obj_cnt = 0;
 	TOID(struct object) i;
 	POBJ_FOREACH_TYPE(pop, i) {
-		ASSERT(D_RO(i)->value < alloc_cnt);
-		ASSERT(!isset(bitmap, D_RO(i)->value));
+		UT_ASSERT(D_RO(i)->value < alloc_cnt);
+		UT_ASSERT(!isset(bitmap, D_RO(i)->value));
 		setbit(bitmap, D_RO(i)->value);
 		obj_cnt++;
 	}
 
 	free(bitmap);
 
-	ASSERTeq(obj_cnt, alloc_cnt);
+	UT_ASSERTeq(obj_cnt, alloc_cnt);
 }
 
 /*
@@ -124,7 +124,7 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
 				TYPE_ABORT_AFTER_NESTED1));
-		ASSERT(!TOID_IS_NULL(obj1));
+		UT_ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -132,22 +132,22 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
 					TYPE_ABORT_AFTER_NESTED2));
-			ASSERT(!TOID_IS_NULL(obj2));
-			ASSERT(util_is_zeroed(D_RO(obj2),
+			UT_ASSERT(!TOID_IS_NULL(obj2));
+			UT_ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
 
 			D_RW(obj2)->value = TEST_VALUE_2;
 
 		} TX_ONCOMMIT {
-			ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
+			UT_ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 		pmemobj_tx_abort(-1);
 
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj1, OID_NULL);
 		TOID_ASSIGN(obj2, OID_NULL);
@@ -156,16 +156,16 @@ do_tx_alloc_abort_after_nested(PMEMobjpool *pop)
 	TOID(struct object) first;
 
 	/* check the obj1 object */
-	ASSERT(TOID_IS_NULL(obj1));
+	UT_ASSERT(TOID_IS_NULL(obj1));
 
 	first.oid = POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_AFTER_NESTED1);
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 
 	/* check the obj2 object */
-	ASSERT(TOID_IS_NULL(obj2));
+	UT_ASSERT(TOID_IS_NULL(obj2));
 
 	first.oid = POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_AFTER_NESTED2);
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -180,7 +180,7 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
 				TYPE_ABORT_NESTED1));
-		ASSERT(!TOID_IS_NULL(obj1));
+		UT_ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -188,21 +188,21 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
 					TYPE_ABORT_NESTED2));
-			ASSERT(!TOID_IS_NULL(obj2));
-			ASSERT(util_is_zeroed(D_RO(obj2),
+			UT_ASSERT(!TOID_IS_NULL(obj2));
+			UT_ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
 
 			D_RW(obj2)->value = TEST_VALUE_2;
 
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_ONABORT {
 			TOID_ASSIGN(obj2, OID_NULL);
 		} TX_END
 
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj1, OID_NULL);
 	} TX_END
@@ -210,16 +210,16 @@ do_tx_alloc_abort_nested(PMEMobjpool *pop)
 	TOID(struct object) first;
 
 	/* check the obj1 object */
-	ASSERT(TOID_IS_NULL(obj1));
+	UT_ASSERT(TOID_IS_NULL(obj1));
 
 	first.oid = POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_NESTED1);
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 
 	/* check the obj2 object */
-	ASSERT(TOID_IS_NULL(obj2));
+	UT_ASSERT(TOID_IS_NULL(obj2));
 
 	first.oid = POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_NESTED2);
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -234,7 +234,7 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj1, pmemobj_tx_alloc(sizeof (struct object),
 				TYPE_COMMIT_NESTED1));
-		ASSERT(!TOID_IS_NULL(obj1));
+		UT_ASSERT(!TOID_IS_NULL(obj1));
 
 		D_RW(obj1)->value = TEST_VALUE_1;
 
@@ -242,23 +242,23 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 			TOID_ASSIGN(obj2, pmemobj_tx_zalloc(
 					sizeof (struct object),
 					TYPE_COMMIT_NESTED2));
-			ASSERT(!TOID_IS_NULL(obj2));
-			ASSERT(util_is_zeroed(D_RO(obj2),
+			UT_ASSERT(!TOID_IS_NULL(obj2));
+			UT_ASSERT(util_is_zeroed(D_RO(obj2),
 					sizeof (struct object)));
 
 			D_RW(obj2)->value = TEST_VALUE_2;
 		} TX_ONCOMMIT {
-			ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
-			ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
+			UT_ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
+			UT_ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 	} TX_ONCOMMIT {
-		ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
-		ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
+		UT_ASSERTeq(D_RO(obj1)->value, TEST_VALUE_1);
+		UT_ASSERTeq(D_RO(obj2)->value, TEST_VALUE_2);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) first;
@@ -266,19 +266,19 @@ do_tx_alloc_commit_nested(PMEMobjpool *pop)
 
 	/* check the obj1 object */
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_NESTED1));
-	ASSERT(TOID_EQUALS(first, obj1));
-	ASSERTeq(D_RO(first)->value, TEST_VALUE_1);
+	UT_ASSERT(TOID_EQUALS(first, obj1));
+	UT_ASSERTeq(D_RO(first)->value, TEST_VALUE_1);
 
 	TOID_ASSIGN(next, POBJ_NEXT_TYPE_NUM(first.oid));
-	ASSERT(TOID_IS_NULL(next));
+	UT_ASSERT(TOID_IS_NULL(next));
 
 	/* check the obj2 object */
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_NESTED2));
-	ASSERT(TOID_EQUALS(first, obj2));
-	ASSERTeq(D_RO(first)->value, TEST_VALUE_2);
+	UT_ASSERT(TOID_EQUALS(first, obj2));
+	UT_ASSERTeq(D_RO(first)->value, TEST_VALUE_2);
 
 	TOID_ASSIGN(next, POBJ_NEXT_TYPE_NUM(first.oid));
-	ASSERT(TOID_IS_NULL(next));
+	UT_ASSERT(TOID_IS_NULL(next));
 }
 
 /*
@@ -291,21 +291,21 @@ do_tx_alloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
 				TYPE_ABORT));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		D_RW(obj)->value = TEST_VALUE_1;
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -317,18 +317,18 @@ do_tx_alloc_zerolen(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(0, TYPE_ABORT));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -341,18 +341,18 @@ do_tx_alloc_huge(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
 				TYPE_ABORT));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -365,23 +365,23 @@ do_tx_alloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(sizeof (struct object),
 				TYPE_COMMIT));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 
 		D_RW(obj)->value = TEST_VALUE_1;
 	} TX_ONCOMMIT {
-		ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+		UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT));
-	ASSERT(TOID_EQUALS(first, obj));
-	ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
+	UT_ASSERT(TOID_EQUALS(first, obj));
+	UT_ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
 
 	TOID(struct object) next;
 	TOID_ASSIGN(next, pmemobj_next(first.oid));
-	ASSERT(TOID_IS_NULL(next));
+	UT_ASSERT(TOID_IS_NULL(next));
 }
 
 /*
@@ -394,22 +394,22 @@ do_tx_zalloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
 				TYPE_ZEROED_ABORT));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 
 		D_RW(obj)->value = TEST_VALUE_1;
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ZEROED_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -421,18 +421,18 @@ do_tx_zalloc_zerolen(PMEMobjpool *pop)
 	TOID(struct object) obj;
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(0, TYPE_ZEROED_ABORT));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ZEROED_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -445,18 +445,18 @@ do_tx_zalloc_huge(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(PMEMOBJ_MAX_ALLOC_SIZE + 1,
 				TYPE_ZEROED_ABORT));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_ONABORT {
 		TOID_ASSIGN(obj, OID_NULL);
 	} TX_END
 
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ZEROED_ABORT));
-	ASSERT(TOID_IS_NULL(first));
+	UT_ASSERT(TOID_IS_NULL(first));
 }
 
 /*
@@ -469,24 +469,24 @@ do_tx_zalloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zalloc(sizeof (struct object),
 				TYPE_ZEROED_COMMIT));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(util_is_zeroed(D_RO(obj), sizeof (struct object)));
 
 		D_RW(obj)->value = TEST_VALUE_1;
 	} TX_ONCOMMIT {
-		ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+		UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) first;
 	TOID_ASSIGN(first, POBJ_FIRST_TYPE_NUM(pop, TYPE_ZEROED_COMMIT));
-	ASSERT(TOID_EQUALS(first, obj));
-	ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
+	UT_ASSERT(TOID_EQUALS(first, obj));
+	UT_ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
 
 	TOID(struct object) next;
 	TOID_ASSIGN(next, pmemobj_next(first.oid));
-	ASSERT(TOID_IS_NULL(next));
+	UT_ASSERT(TOID_IS_NULL(next));
 }
 
 /*
@@ -498,12 +498,12 @@ do_tx_root(PMEMobjpool *pop)
 	size_t root_size = 24;
 	TX_BEGIN(pop) {
 		PMEMoid root = pmemobj_root(pop, root_size);
-		ASSERT(!OID_IS_NULL(root));
-		ASSERT(util_is_zeroed(pmemobj_direct(root),
+		UT_ASSERT(!OID_IS_NULL(root));
+		UT_ASSERT(util_is_zeroed(pmemobj_direct(root),
 				root_size));
-		ASSERTeq(root_size, pmemobj_root_size(pop));
+		UT_ASSERTeq(root_size, pmemobj_root_size(pop));
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 }
 
@@ -514,12 +514,12 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, 0,
 				S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_tx_root(pop);
 	VALGRIND_WRITE_STATS;

--- a/src/test/obj_tx_flow/obj_tx_flow.c
+++ b/src/test/obj_tx_flow/obj_tx_flow.c
@@ -58,12 +58,12 @@ do_tx_macro_commit(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 	TX_BEGIN(pop) {
 		D_RW(*obj)->a = TEST_VALUE_A;
 	} TX_ONCOMMIT {
-		ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
+		UT_ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
 		D_RW(*obj)->b = TEST_VALUE_B;
 	} TX_ONABORT { /* not called */
 		D_RW(*obj)->a = TEST_VALUE_B;
 	} TX_FINALLY {
-		ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
+		UT_ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
 		D_RW(*obj)->c = TEST_VALUE_C;
 	} TX_END
 }
@@ -81,11 +81,11 @@ do_tx_macro_abort(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 	} TX_ONCOMMIT { /* not called */
 		D_RW(*obj)->a = TEST_VALUE_B;
 	} TX_ONABORT {
-		ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
-		ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
+		UT_ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
+		UT_ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
 		D_RW(*obj)->b = TEST_VALUE_B;
 	} TX_FINALLY {
-		ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
+		UT_ASSERT(D_RW(*obj)->b == TEST_VALUE_B);
 		D_RW(*obj)->c = TEST_VALUE_C;
 	} TX_END
 }
@@ -97,7 +97,7 @@ do_tx_macro_commit_nested(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 		TX_BEGIN(pop) {
 			D_RW(*obj)->a = TEST_VALUE_A;
 		} TX_ONCOMMIT {
-			ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
+			UT_ASSERT(D_RW(*obj)->a == TEST_VALUE_A);
 			D_RW(*obj)->b = TEST_VALUE_B;
 		} TX_END
 	} TX_ONCOMMIT {
@@ -125,27 +125,27 @@ do_tx_macro_abort_nested(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 		} TX_ONCOMMIT { /* not called */
 			a = TEST_VALUE_C;
 		} TX_ONABORT {
-			ASSERT(a == TEST_VALUE_A);
+			UT_ASSERT(a == TEST_VALUE_A);
 			b = TEST_VALUE_B;
 		} TX_FINALLY {
-			ASSERT(b == TEST_VALUE_B);
+			UT_ASSERT(b == TEST_VALUE_B);
 			c = TEST_VALUE_C;
 		} TX_END
 		a = TEST_VALUE_B;
 	} TX_ONCOMMIT { /* not called */
-		ASSERT(a == TEST_VALUE_A);
+		UT_ASSERT(a == TEST_VALUE_A);
 		c = TEST_VALUE_C;
 	} TX_ONABORT {
-		ASSERT(a == TEST_VALUE_A);
-		ASSERT(b == TEST_VALUE_B);
-		ASSERT(c == TEST_VALUE_C);
+		UT_ASSERT(a == TEST_VALUE_A);
+		UT_ASSERT(b == TEST_VALUE_B);
+		UT_ASSERT(c == TEST_VALUE_C);
 		b = TEST_VALUE_A;
 	} TX_FINALLY {
-		ASSERT(b == TEST_VALUE_A);
+		UT_ASSERT(b == TEST_VALUE_A);
 		D_RW(*obj)->c = TEST_VALUE_C;
 		a = TEST_VALUE_B;
 	} TX_END
-	ASSERT(a == TEST_VALUE_B);
+	UT_ASSERT(a == TEST_VALUE_B);
 }
 
 static void
@@ -157,7 +157,7 @@ do_tx_commit(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 	TX_ADD(*obj);
 	D_RW(*obj)->b = TEST_VALUE_B;
 	pmemobj_tx_commit();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
 	D_RW(*obj)->c = TEST_VALUE_C;
 	pmemobj_tx_end();
 }
@@ -173,11 +173,11 @@ do_tx_commit_nested(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 		TX_ADD(*obj);
 		D_RW(*obj)->b = TEST_VALUE_B;
 		pmemobj_tx_commit();
-		ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
+		UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
 		pmemobj_tx_end();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
 	pmemobj_tx_commit();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
 	D_RW(*obj)->c = TEST_VALUE_C;
 	pmemobj_tx_end();
 }
@@ -191,7 +191,7 @@ do_tx_abort(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 	TX_ADD(*obj);
 	D_RW(*obj)->a = 0;
 	pmemobj_tx_abort(EINVAL);
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
 	D_RW(*obj)->c = TEST_VALUE_C;
 	pmemobj_tx_end();
 }
@@ -208,9 +208,9 @@ do_tx_abort_nested(PMEMobjpool *pop, TOID(struct test_obj) *obj)
 		TX_ADD(*obj);
 		D_RW(*obj)->b = 0;
 		pmemobj_tx_abort(EINVAL);
-		ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
+		UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
 		pmemobj_tx_end();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
 	D_RW(*obj)->c = TEST_VALUE_C;
 	pmemobj_tx_end();
 }
@@ -225,37 +225,37 @@ static void
 do_tx_process(PMEMobjpool *pop)
 {
 	pmemobj_tx_begin(pop, NULL, TX_LOCK_NONE);
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
 	pmemobj_tx_process();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
 	pmemobj_tx_process();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
 	pmemobj_tx_process();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
 	pmemobj_tx_end();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
 }
 
 static void
 do_tx_process_nested(PMEMobjpool *pop)
 {
 	pmemobj_tx_begin(pop, NULL, TX_LOCK_NONE);
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
 		pmemobj_tx_begin(pop, NULL, TX_LOCK_NONE);
 		pmemobj_tx_process();
-		ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
+		UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONCOMMIT);
 		pmemobj_tx_process();
-		ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
+		UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
 		pmemobj_tx_end();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
 	pmemobj_tx_abort(EINVAL);
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_ONABORT);
 	pmemobj_tx_process();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_FINALLY);
 	pmemobj_tx_process();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
 	pmemobj_tx_end();
-	ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
+	UT_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
 }
 
 int
@@ -264,12 +264,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_flow");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	TOID(struct test_obj) obj;
 	POBJ_ZNEW(pop, &obj, struct test_obj);
@@ -280,9 +280,9 @@ main(int argc, char *argv[])
 		D_RW(obj)->c = 0;
 		tx_op[i](pop, &obj);
 
-		ASSERT(D_RO(obj)->a == TEST_VALUE_A);
-		ASSERT(D_RO(obj)->b == TEST_VALUE_B);
-		ASSERT(D_RO(obj)->c == TEST_VALUE_C);
+		UT_ASSERT(D_RO(obj)->a == TEST_VALUE_A);
+		UT_ASSERT(D_RO(obj)->b == TEST_VALUE_B);
+		UT_ASSERT(D_RO(obj)->c == TEST_VALUE_C);
 	}
 	do_tx_process(pop);
 	do_tx_process_nested(pop);

--- a/src/test/obj_tx_free/obj_tx_free.c
+++ b/src/test/obj_tx_free/obj_tx_free.c
@@ -95,16 +95,16 @@ do_tx_free_wrong_uuid(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 	} TX_ONABORT {
 		ret = -1;
 	} TX_END
 
-	ASSERTeq(ret, -1);
+	UT_ASSERTeq(ret, -1);
 
 	TOID(struct object) obj;
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_WRONG_UUID));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -121,7 +121,7 @@ do_tx_free_null_oid(PMEMobjpool *pop)
 		ret = -1;
 	} TX_END
 
-	ASSERTeq(ret, 0);
+	UT_ASSERTeq(ret, 0);
 }
 
 /*
@@ -135,15 +135,15 @@ do_tx_free_commit(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) obj;
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_COMMIT));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -157,16 +157,16 @@ do_tx_free_abort(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) obj;
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ABORT));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -181,26 +181,26 @@ do_tx_free_commit_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid1);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_free(oid2);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_COMMIT_NESTED1));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_COMMIT_NESTED2));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -215,27 +215,27 @@ do_tx_free_abort_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid1);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_free(oid2);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ABORT_NESTED1));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ABORT_NESTED2));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -251,27 +251,27 @@ do_tx_free_abort_after_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		ret = pmemobj_tx_free(oid1);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		TX_BEGIN(pop) {
 			ret = pmemobj_tx_free(oid2);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 		} TX_END
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID(struct object) obj;
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop,
 		TYPE_FREE_ABORT_AFTER_NESTED1));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop,
 		TYPE_FREE_ABORT_AFTER_NESTED2));
-	ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERT(!TOID_IS_NULL(obj));
 }
 
 /*
@@ -287,16 +287,16 @@ do_tx_free_alloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(
 				sizeof (struct object), TYPE_FREE_ALLOC));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ALLOC));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -312,15 +312,15 @@ do_tx_free_alloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_alloc(
 				sizeof (struct object), TYPE_FREE_ALLOC));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 		ret = pmemobj_tx_free(obj.oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ALLOC));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -338,13 +338,13 @@ do_tx_free_abort_free(PMEMobjpool *pop)
 		pmemobj_tx_free(oid);
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TX_BEGIN(pop) {
 		pmemobj_tx_free(oid);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 }
 
@@ -355,12 +355,12 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_tx_free_wrong_uuid(pop);
 	VALGRIND_WRITE_STATS;

--- a/src/test/obj_tx_invalid/obj_tx_invalid.c
+++ b/src/test/obj_tx_invalid/obj_tx_invalid.c
@@ -59,7 +59,7 @@ int
 main(int argc, char *argv[])
 {
 	if (argc != 3)
-		FATAL("usage: %s file-name op", argv[0]);
+		UT_FATAL("usage: %s file-name op", argv[0]);
 
 	START(argc, argv, "obj_tx_invalid %s", argv[2]);
 
@@ -69,12 +69,12 @@ main(int argc, char *argv[])
 	if (access(path, F_OK) != 0) {
 		if ((pop = pmemobj_create(path, POBJ_LAYOUT_NAME(tx_invalid),
 			PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL) {
-			FATAL("!pmemobj_create %s", path);
+			UT_FATAL("!pmemobj_create %s", path);
 		}
 	} else {
 		if ((pop = pmemobj_open(path, POBJ_LAYOUT_NAME(tx_invalid)))
 						== NULL) {
-			FATAL("!pmemobj_open %s", path);
+			UT_FATAL("!pmemobj_open %s", path);
 		}
 	}
 
@@ -82,9 +82,9 @@ main(int argc, char *argv[])
 
 	if (OID_IS_NULL(oid)) {
 		if (pmemobj_alloc(pop, &oid, 10, 1, NULL, NULL))
-			FATAL("!pmemobj_alloc");
+			UT_FATAL("!pmemobj_alloc");
 	} else {
-		ASSERTeq(pmemobj_type_num(oid), 1);
+		UT_ASSERTeq(pmemobj_type_num(oid), 1);
 	}
 
 	if (strcmp(argv[2], "alloc") == 0)

--- a/src/test/obj_tx_lock/obj_tx_lock.c
+++ b/src/test/obj_tx_lock/obj_tx_lock.c
@@ -58,7 +58,7 @@ static struct transaction_data {
 	ret += pmemobj_mutex_trylock((pop), &(mtx)[1]);\
 	ret += pmemobj_rwlock_trywrlock((pop), &(rwlock)[0]);\
 	ret += pmemobj_rwlock_trywrlock((pop), &(rwlock)[1]);\
-	ASSERTeq(ret, 0);\
+	UT_ASSERTeq(ret, 0);\
 	pmemobj_mutex_unlock((pop), &(mtx)[0]);\
 	pmemobj_mutex_unlock((pop), &(mtx)[1]);\
 	pmemobj_rwlock_unlock((pop), &(rwlock)[0]);\
@@ -66,13 +66,13 @@ static struct transaction_data {
 
 #define	IS_LOCKED(pop, mtx, rwlock)\
 	ret = pmemobj_mutex_trylock((pop), &(mtx)[0]);\
-	ASSERT(ret != 0);\
+	UT_ASSERT(ret != 0);\
 	ret = pmemobj_mutex_trylock((pop), &(mtx)[1]);\
-	ASSERT(ret != 0);\
+	UT_ASSERT(ret != 0);\
 	ret += pmemobj_rwlock_trywrlock((pop), &(rwlock)[0]);\
-	ASSERT(ret != 0);\
+	UT_ASSERT(ret != 0);\
 	ret += pmemobj_rwlock_trywrlock((pop), &(rwlock)[1]);\
-	ASSERT(ret != 0)
+	UT_ASSERT(ret != 0)
 
 /*
  * do_tx_add_locks -- (internal) transaction where locks are added after
@@ -87,7 +87,7 @@ do_tx_add_locks(struct transaction_data *data)
 		DO_LOCK(data->mutexes, data->rwlocks);
 		IS_LOCKED(data->pop, data->mutexes, data->rwlocks);
 	} TX_ONABORT { /* not called */
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 	IS_UNLOCKED(data->pop, data->mutexes, data->rwlocks);
 	return NULL;
@@ -109,7 +109,7 @@ do_tx_add_locks_nested(struct transaction_data *data)
 		} TX_END
 		IS_LOCKED(data->pop, data->mutexes, data->rwlocks);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 	IS_UNLOCKED(data->pop, data->mutexes, data->rwlocks);
 	return NULL;
@@ -134,7 +134,7 @@ do_tx_add_locks_nested_all(struct transaction_data *data)
 		} TX_END
 		IS_LOCKED(data->pop, data->mutexes, data->rwlocks);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 	IS_UNLOCKED(data->pop, data->mutexes, data->rwlocks);
 	return NULL;
@@ -147,11 +147,11 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_lock");
 
 	if (argc != 2)
-		FATAL("usage: %s <file>", argv[0]);
+		UT_FATAL("usage: %s <file>", argv[0]);
 
 	if ((test_obj.pop = pmemobj_create(argv[1], LAYOUT_NAME,
 	    PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	test_obj.mutexes = CALLOC(NUM_LOCKS, sizeof (PMEMmutex));
 	test_obj.rwlocks = CALLOC(NUM_LOCKS, sizeof (PMEMrwlock));

--- a/src/test/obj_tx_locks/obj_tx_locks.c
+++ b/src/test/obj_tx_locks/obj_tx_locks.c
@@ -69,12 +69,12 @@ do_tx(void *arg)
 	BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
 		data->a = TEST_VALUE_A;
 	} TX_ONCOMMIT {
-		ASSERT(data->a == TEST_VALUE_A);
+		UT_ASSERT(data->a == TEST_VALUE_A);
 		data->b = TEST_VALUE_B;
 	} TX_ONABORT { /* not called */
 		data->a = TEST_VALUE_B;
 	} TX_FINALLY {
-		ASSERT(data->b == TEST_VALUE_B);
+		UT_ASSERT(data->b == TEST_VALUE_B);
 		data->c = TEST_VALUE_C;
 	} TX_END
 
@@ -96,10 +96,10 @@ do_aborted_tx(void *arg)
 	} TX_ONCOMMIT { /* not called */
 		data->a = TEST_VALUE_B;
 	} TX_ONABORT {
-		ASSERT(data->a == TEST_VALUE_A);
+		UT_ASSERT(data->a == TEST_VALUE_A);
 		data->b = TEST_VALUE_B;
 	} TX_FINALLY {
-		ASSERT(data->b == TEST_VALUE_B);
+		UT_ASSERT(data->b == TEST_VALUE_B);
 		data->c = TEST_VALUE_C;
 	} TX_END
 
@@ -118,7 +118,7 @@ do_nested_tx(void *arg)
 		BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
 			data->a = TEST_VALUE_A;
 		} TX_ONCOMMIT {
-			ASSERT(data->a == TEST_VALUE_A);
+			UT_ASSERT(data->a == TEST_VALUE_A);
 			data->b = TEST_VALUE_B;
 		} TX_END
 	} TX_ONCOMMIT {
@@ -145,23 +145,23 @@ do_aborted_nested_tx(void *arg)
 		} TX_ONCOMMIT { /* not called */
 			data->a = TEST_VALUE_C;
 		} TX_ONABORT {
-			ASSERT(data->a == TEST_VALUE_A);
+			UT_ASSERT(data->a == TEST_VALUE_A);
 			data->b = TEST_VALUE_B;
 		} TX_FINALLY {
-			ASSERT(data->b == TEST_VALUE_B);
+			UT_ASSERT(data->b == TEST_VALUE_B);
 			data->c = TEST_VALUE_C;
 		} TX_END
 		data->a = TEST_VALUE_B;
 	} TX_ONCOMMIT { /* not called */
-		ASSERT(data->a == TEST_VALUE_A);
+		UT_ASSERT(data->a == TEST_VALUE_A);
 		data->c = TEST_VALUE_C;
 	} TX_ONABORT {
-		ASSERT(data->a == TEST_VALUE_A);
-		ASSERT(data->b == TEST_VALUE_B);
-		ASSERT(data->c == TEST_VALUE_C);
+		UT_ASSERT(data->a == TEST_VALUE_A);
+		UT_ASSERT(data->b == TEST_VALUE_B);
+		UT_ASSERT(data->c == TEST_VALUE_C);
 		data->a = TEST_VALUE_B;
 	} TX_FINALLY {
-		ASSERT(data->a == TEST_VALUE_B);
+		UT_ASSERT(data->a == TEST_VALUE_B);
 		data->b = TEST_VALUE_A;
 	} TX_END
 
@@ -186,17 +186,17 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_locks");
 
 	if (argc > 3)
-		FATAL("usage: %s <file> [m]", argv[0]);
+		UT_FATAL("usage: %s <file> [m]", argv[0]);
 
 	if ((test_obj.pop = pmemobj_create(argv[1], LAYOUT_NAME,
 	    PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	int multithread = 0;
 	if (argc == 3) {
 		multithread = (argv[2][0] == 'm');
 		if (!multithread)
-			FATAL("wrong test type supplied %c", argv[1][0]);
+			UT_FATAL("wrong test type supplied %c", argv[1][0]);
 	}
 
 	test_obj.mutexes = CALLOC(NUM_LOCKS, sizeof (PMEMmutex));
@@ -209,9 +209,9 @@ main(int argc, char *argv[])
 		do_tx(&test_obj);
 	}
 
-	ASSERT(test_obj.a == TEST_VALUE_A);
-	ASSERT(test_obj.b == TEST_VALUE_B);
-	ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj.a == TEST_VALUE_A);
+	UT_ASSERT(test_obj.b == TEST_VALUE_B);
+	UT_ASSERT(test_obj.c == TEST_VALUE_C);
 
 	if (multithread) {
 		run_mt_test(do_aborted_tx, &test_obj);
@@ -220,9 +220,9 @@ main(int argc, char *argv[])
 		do_aborted_tx(&test_obj);
 	}
 
-	ASSERT(test_obj.a == TEST_VALUE_A);
-	ASSERT(test_obj.b == TEST_VALUE_B);
-	ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj.a == TEST_VALUE_A);
+	UT_ASSERT(test_obj.b == TEST_VALUE_B);
+	UT_ASSERT(test_obj.c == TEST_VALUE_C);
 
 	if (multithread) {
 		run_mt_test(do_nested_tx, &test_obj);
@@ -231,9 +231,9 @@ main(int argc, char *argv[])
 		do_nested_tx(&test_obj);
 	}
 
-	ASSERT(test_obj.a == TEST_VALUE_A);
-	ASSERT(test_obj.b == TEST_VALUE_B);
-	ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj.a == TEST_VALUE_A);
+	UT_ASSERT(test_obj.b == TEST_VALUE_B);
+	UT_ASSERT(test_obj.c == TEST_VALUE_C);
 
 	if (multithread) {
 		run_mt_test(do_aborted_nested_tx, &test_obj);
@@ -242,9 +242,9 @@ main(int argc, char *argv[])
 		do_aborted_nested_tx(&test_obj);
 	}
 
-	ASSERT(test_obj.a == TEST_VALUE_B);
-	ASSERT(test_obj.b == TEST_VALUE_A);
-	ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj.a == TEST_VALUE_B);
+	UT_ASSERT(test_obj.b == TEST_VALUE_A);
+	UT_ASSERT(test_obj.c == TEST_VALUE_C);
 
 	pmemobj_close(test_obj.pop);
 

--- a/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
+++ b/src/test/obj_tx_locks_abort/obj_tx_locks_abort.c
@@ -98,9 +98,9 @@ do_aborted_nested_tx(PMEMobjpool *pop, TOID(struct obj) oid, int value)
 
 		while (!TOID_IS_NULL(o)) {
 			if (pmemobj_mutex_trylock(pop, &D_RW(o)->lock)) {
-				OUT("trylock failed");
+				UT_OUT("trylock failed");
 			} else {
-				OUT("trylock succeeded");
+				UT_OUT("trylock succeeded");
 				pmemobj_mutex_unlock(pop, &D_RW(o)->lock);
 			}
 			o = D_RO(o)->next;
@@ -115,7 +115,7 @@ static void
 do_check(TOID(struct obj) o)
 {
 	while (!TOID_IS_NULL(o)) {
-		OUT("data = %d", D_RO(o)->data);
+		UT_OUT("data = %d", D_RO(o)->data);
 		o = D_RO(o)->next;
 	}
 }
@@ -128,12 +128,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_locks_abort");
 
 	if (argc > 3)
-		FATAL("usage: %s <file>", argv[0]);
+		UT_FATAL("usage: %s <file>", argv[0]);
 
 	pop = pmemobj_create(argv[1], LAYOUT_NAME,
 			PMEMOBJ_MIN_POOL * 4, S_IWUSR | S_IRUSR);
 	if (pop == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	TOID(struct root_obj) root = POBJ_ROOT(pop, struct root_obj);
 
@@ -153,14 +153,14 @@ main(int argc, char *argv[])
 		TOID_ASSIGN(D_RW(o)->next, OID_NULL);
 	} TX_END;
 
-	OUT("initial state");
+	UT_OUT("initial state");
 	do_check(D_RO(root)->head);
 
-	OUT("nested tx");
+	UT_OUT("nested tx");
 	do_nested_tx(pop, D_RW(root)->head, 200);
 	do_check(D_RO(root)->head);
 
-	OUT("aborted nested tx");
+	UT_OUT("aborted nested tx");
 	do_aborted_nested_tx(pop, D_RW(root)->head, 300);
 	do_check(D_RO(root)->head);
 

--- a/src/test/obj_tx_realloc/obj_tx_realloc.c
+++ b/src/test/obj_tx_realloc/obj_tx_realloc.c
@@ -108,19 +108,19 @@ do_tx_realloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
 			new_size, TYPE_COMMIT));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -136,21 +136,21 @@ do_tx_realloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
 			new_size, TYPE_ABORT));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -166,18 +166,18 @@ do_tx_realloc_huge(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
 			new_size, TYPE_ABORT_HUGE));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_HUGE));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -195,23 +195,23 @@ do_tx_zrealloc_commit_macro(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		obj = TX_ZREALLOC(obj, new_size);
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-		ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+		UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_ZERO_MACRO));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-	ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+	UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -229,24 +229,24 @@ do_tx_zrealloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
 			new_size, TYPE_COMMIT_ZERO));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-		ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+		UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_ZERO));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-	ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+	UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -263,22 +263,22 @@ do_tx_zrealloc_abort_macro(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		obj = TX_ZREALLOC(obj, new_size);
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-		ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+		UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_ZERO_MACRO));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -295,22 +295,22 @@ do_tx_zrealloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
 			new_size, TYPE_ABORT_ZERO));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 		void *new_ptr = (void *)((uintptr_t)D_RW(obj) + old_size);
-		ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
+		UT_ASSERT(util_is_zeroed(new_ptr, new_size - old_size));
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_ZERO));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -328,18 +328,18 @@ do_tx_zrealloc_huge_macro(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		obj = TX_ZREALLOC(obj, PMEMOBJ_MAX_ALLOC_SIZE + 1);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_ZERO_HUGE_MACRO));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -356,18 +356,18 @@ do_tx_zrealloc_huge(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, pmemobj_tx_zrealloc(obj.oid,
 			PMEMOBJ_MAX_ALLOC_SIZE + 1, TYPE_ABORT_ZERO_HUGE));
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_ZERO_HUGE));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) < new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -383,23 +383,23 @@ do_tx_realloc_alloc_commit(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_alloc(pop, TYPE_COMMIT_ALLOC,
 					TEST_VALUE_1));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 		new_size = 2 * pmemobj_alloc_usable_size(obj.oid);
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
 			new_size, TYPE_COMMIT_ALLOC));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_ALLOC));
-	ASSERT(!TOID_IS_NULL(obj));
-	ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
-	ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+	UT_ASSERT(!TOID_IS_NULL(obj));
+	UT_ASSERTeq(D_RO(obj)->value, TEST_VALUE_1);
+	UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 
 	TOID_ASSIGN(obj, POBJ_NEXT_TYPE_NUM(obj.oid));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 /*
@@ -415,20 +415,20 @@ do_tx_realloc_alloc_abort(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		TOID_ASSIGN(obj, do_tx_alloc(pop, TYPE_ABORT_ALLOC,
 					TEST_VALUE_1));
-		ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(!TOID_IS_NULL(obj));
 		new_size = 2 * pmemobj_alloc_usable_size(obj.oid);
 		TOID_ASSIGN(obj, pmemobj_tx_realloc(obj.oid,
 			new_size, TYPE_ABORT_ALLOC));
-		ASSERT(!TOID_IS_NULL(obj));
-		ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
+		UT_ASSERT(!TOID_IS_NULL(obj));
+		UT_ASSERT(pmemobj_alloc_usable_size(obj.oid) >= new_size);
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(obj, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_ALLOC));
-	ASSERT(TOID_IS_NULL(obj));
+	UT_ASSERT(TOID_IS_NULL(obj));
 }
 
 
@@ -440,18 +440,18 @@ do_tx_root_realloc(PMEMobjpool *pop)
 {
 	TX_BEGIN(pop) {
 		PMEMoid root = pmemobj_root(pop, sizeof (struct object));
-		ASSERT(!OID_IS_NULL(root));
-		ASSERT(util_is_zeroed(pmemobj_direct(root),
+		UT_ASSERT(!OID_IS_NULL(root));
+		UT_ASSERT(util_is_zeroed(pmemobj_direct(root),
 				sizeof (struct object)));
-		ASSERTeq(sizeof (struct object), pmemobj_root_size(pop));
+		UT_ASSERTeq(sizeof (struct object), pmemobj_root_size(pop));
 
 		root = pmemobj_root(pop, 2 * sizeof (struct object));
-		ASSERT(!OID_IS_NULL(root));
-		ASSERT(util_is_zeroed(pmemobj_direct(root),
+		UT_ASSERT(!OID_IS_NULL(root));
+		UT_ASSERT(util_is_zeroed(pmemobj_direct(root),
 				2 * sizeof (struct object)));
-		ASSERTeq(2 * sizeof (struct object), pmemobj_root_size(pop));
+		UT_ASSERTeq(2 * sizeof (struct object), pmemobj_root_size(pop));
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 }
 
@@ -461,12 +461,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_realloc");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, 0,
 				S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	do_tx_root_realloc(pop);
 	do_tx_realloc_commit(pop);

--- a/src/test/obj_tx_strdup/obj_tx_strdup.c
+++ b/src/test/obj_tx_strdup/obj_tx_strdup.c
@@ -95,14 +95,14 @@ do_tx_strdup_commit(PMEMobjpool *pop)
 	TOID(char) str;
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str, TEST_STR_1, TYPE_COMMIT);
-		ASSERT(!TOID_IS_NULL(str));
+		UT_ASSERT(!TOID_IS_NULL(str));
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT));
-	ASSERT(!TOID_IS_NULL(str));
-	ASSERTeq(strcmp(TEST_STR_1, D_RO(str)), 0);
+	UT_ASSERT(!TOID_IS_NULL(str));
+	UT_ASSERTeq(strcmp(TEST_STR_1, D_RO(str)), 0);
 }
 
 /*
@@ -114,14 +114,14 @@ do_tx_strdup_abort(PMEMobjpool *pop)
 	TOID(char) str;
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str, TEST_STR_1, TYPE_ABORT);
-		ASSERT(!TOID_IS_NULL(str));
+		UT_ASSERT(!TOID_IS_NULL(str));
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(TOID_IS_NULL(str));
+	UT_ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -133,13 +133,13 @@ do_tx_strdup_null(PMEMobjpool *pop)
 	TOID(char) str;
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str, NULL, TYPE_ABORT);
-		ASSERT(0); /* should not get to this point */
+		UT_ASSERT(0); /* should not get to this point */
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT));
-	ASSERT(TOID_IS_NULL(str));
+	UT_ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -152,15 +152,15 @@ do_tx_strdup_free_commit(PMEMobjpool *pop)
 	TOID(char) str;
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str, TEST_STR_1, TYPE_FREE_COMMIT);
-		ASSERT(!TOID_IS_NULL(str));
+		UT_ASSERT(!TOID_IS_NULL(str));
 		int ret = pmemobj_tx_free(str.oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_COMMIT));
-	ASSERT(TOID_IS_NULL(str));
+	UT_ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -173,16 +173,16 @@ do_tx_strdup_free_abort(PMEMobjpool *pop)
 	TOID(char) str;
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str, TEST_STR_1, TYPE_FREE_ABORT);
-		ASSERT(!TOID_IS_NULL(str));
+		UT_ASSERT(!TOID_IS_NULL(str));
 		int ret = pmemobj_tx_free(str.oid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str, POBJ_FIRST_TYPE_NUM(pop, TYPE_FREE_ABORT));
-	ASSERT(TOID_IS_NULL(str));
+	UT_ASSERT(TOID_IS_NULL(str));
 }
 
 /*
@@ -197,25 +197,25 @@ do_tx_strdup_commit_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str1, TEST_STR_1, TYPE_COMMIT_NESTED1);
-		ASSERT(!TOID_IS_NULL(str1));
+		UT_ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
 			do_tx_strdup[counter](&str2, TEST_STR_2,
 						TYPE_COMMIT_NESTED2);
-			ASSERT(!TOID_IS_NULL(str2));
+			UT_ASSERT(!TOID_IS_NULL(str2));
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONABORT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str1, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_NESTED1));
-	ASSERT(!TOID_IS_NULL(str1));
-	ASSERTeq(strcmp(TEST_STR_1, D_RO(str1)), 0);
+	UT_ASSERT(!TOID_IS_NULL(str1));
+	UT_ASSERTeq(strcmp(TEST_STR_1, D_RO(str1)), 0);
 
 	TOID_ASSIGN(str2, POBJ_FIRST_TYPE_NUM(pop, TYPE_COMMIT_NESTED2));
-	ASSERT(!TOID_IS_NULL(str2));
-	ASSERTeq(strcmp(TEST_STR_2, D_RO(str2)), 0);
+	UT_ASSERT(!TOID_IS_NULL(str2));
+	UT_ASSERTeq(strcmp(TEST_STR_2, D_RO(str2)), 0);
 }
 
 /*
@@ -230,24 +230,24 @@ do_tx_strdup_abort_nested(PMEMobjpool *pop)
 
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str1, TEST_STR_1, TYPE_ABORT_NESTED1);
-		ASSERT(!TOID_IS_NULL(str1));
+		UT_ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
 			do_tx_strdup[counter](&str2, TEST_STR_2,
 							TYPE_ABORT_NESTED2);
-			ASSERT(!TOID_IS_NULL(str2));
+			UT_ASSERT(!TOID_IS_NULL(str2));
 			pmemobj_tx_abort(-1);
 		} TX_ONCOMMIT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str1, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_NESTED1));
-	ASSERT(TOID_IS_NULL(str1));
+	UT_ASSERT(TOID_IS_NULL(str1));
 
 	TOID_ASSIGN(str2, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_NESTED2));
-	ASSERT(TOID_IS_NULL(str2));
+	UT_ASSERT(TOID_IS_NULL(str2));
 }
 
 /*
@@ -263,25 +263,25 @@ do_tx_strdup_abort_after_nested(PMEMobjpool *pop)
 	TX_BEGIN(pop) {
 		do_tx_strdup[counter](&str1, TEST_STR_1,
 						TYPE_ABORT_AFTER_NESTED1);
-		ASSERT(!TOID_IS_NULL(str1));
+		UT_ASSERT(!TOID_IS_NULL(str1));
 		TX_BEGIN(pop) {
 			do_tx_strdup[counter](&str2, TEST_STR_2,
 						TYPE_ABORT_AFTER_NESTED2);
-			ASSERT(!TOID_IS_NULL(str2));
+			UT_ASSERT(!TOID_IS_NULL(str2));
 		} TX_ONABORT {
-			ASSERT(0);
+			UT_ASSERT(0);
 		} TX_END
 
 		pmemobj_tx_abort(-1);
 	} TX_ONCOMMIT {
-		ASSERT(0);
+		UT_ASSERT(0);
 	} TX_END
 
 	TOID_ASSIGN(str1, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_AFTER_NESTED1));
-	ASSERT(TOID_IS_NULL(str1));
+	UT_ASSERT(TOID_IS_NULL(str1));
 
 	TOID_ASSIGN(str2, POBJ_FIRST_TYPE_NUM(pop, TYPE_ABORT_AFTER_NESTED2));
-	ASSERT(TOID_IS_NULL(str2));
+	UT_ASSERT(TOID_IS_NULL(str2));
 }
 
 int
@@ -290,12 +290,12 @@ main(int argc, char *argv[])
 	START(argc, argv, "obj_tx_strdup");
 
 	if (argc != 2)
-		FATAL("usage: %s [file]", argv[0]);
+		UT_FATAL("usage: %s [file]", argv[0]);
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(argv[1], LAYOUT_NAME, PMEMOBJ_MIN_POOL,
 	    S_IWUSR | S_IRUSR)) == NULL)
-		FATAL("!pmemobj_create");
+		UT_FATAL("!pmemobj_create");
 
 	for (counter = 0; counter < MAX_FUNC; counter++) {
 		do_tx_strdup_commit(pop);

--- a/src/test/out_err/out_err.c
+++ b/src/test/out_err/out_err.c
@@ -43,16 +43,6 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include "unittest.h"
-#undef ERR
-#undef FATAL
-#undef ASSERT_rt
-#undef ASSERTinfo_rt
-#undef ASSERTeq_rt
-#undef ASSERTne_rt
-#undef ASSERT
-#undef ASSERTinfo
-#undef ASSERTeq
-#undef ASSERTne
 #include "out.h"
 
 int
@@ -66,25 +56,25 @@ main(int argc, char *argv[])
 
 	errno = 0;
 	ERR("ERR #%d", 1);
-	OUT("%s", out_get_errormsg());
+	UT_OUT("%s", out_get_errormsg());
 
 	errno = 0;
 	ERR("!ERR #%d", 2);
-	OUT("%s", out_get_errormsg());
+	UT_OUT("%s", out_get_errormsg());
 
 	errno = EINVAL;
 	ERR("!ERR #%d", 3);
-	OUT("%s", out_get_errormsg());
+	UT_OUT("%s", out_get_errormsg());
 
 	errno = EBADF;
 	out_err(__FILE__, 100, __func__,
 		"ERR1: %s:%d", strerror(errno), 1234);
-	OUT("%s", out_get_errormsg());
+	UT_OUT("%s", out_get_errormsg());
 
 	errno = EBADF;
 	out_err(NULL, 0, NULL,
 		"ERR2: %s:%d", strerror(errno), 1234);
-	OUT("%s", out_get_errormsg());
+	UT_OUT("%s", out_get_errormsg());
 
 	/* Cleanup */
 	out_fini();

--- a/src/test/out_err_mt/out_err_mt.c
+++ b/src/test/out_err_mt/out_err_mt.c
@@ -46,12 +46,12 @@
 static void
 print_errors(const char *msg)
 {
-	OUT("%s", msg);
-	OUT("PMEM: %s", pmem_errormsg());
-	OUT("PMEMOBJ: %s", pmemobj_errormsg());
-	OUT("PMEMLOG: %s", pmemlog_errormsg());
-	OUT("PMEMBLK: %s", pmemblk_errormsg());
-	OUT("VMEM: %s", vmem_errormsg());
+	UT_OUT("%s", msg);
+	UT_OUT("PMEM: %s", pmem_errormsg());
+	UT_OUT("PMEMOBJ: %s", pmemobj_errormsg());
+	UT_OUT("PMEMLOG: %s", pmemlog_errormsg());
+	UT_OUT("PMEMBLK: %s", pmemblk_errormsg());
+	UT_OUT("VMEM: %s", vmem_errormsg());
 }
 
 static void
@@ -64,37 +64,37 @@ check_errors(int ver)
 	ret = sscanf(pmem_errormsg(),
 		"libpmem major version mismatch (need %d, found %d)",
 		&err_need, &err_found);
-	ASSERTeq(ret, 2);
-	ASSERTeq(err_need, ver);
-	ASSERTeq(err_found, PMEM_MAJOR_VERSION);
+	UT_ASSERTeq(ret, 2);
+	UT_ASSERTeq(err_need, ver);
+	UT_ASSERTeq(err_found, PMEM_MAJOR_VERSION);
 
 	ret = sscanf(pmemobj_errormsg(),
 		"libpmemobj major version mismatch (need %d, found %d)",
 		&err_need, &err_found);
-	ASSERTeq(ret, 2);
-	ASSERTeq(err_need, ver);
-	ASSERTeq(err_found, PMEMOBJ_MAJOR_VERSION);
+	UT_ASSERTeq(ret, 2);
+	UT_ASSERTeq(err_need, ver);
+	UT_ASSERTeq(err_found, PMEMOBJ_MAJOR_VERSION);
 
 	ret = sscanf(pmemlog_errormsg(),
 		"libpmemlog major version mismatch (need %d, found %d)",
 		&err_need, &err_found);
-	ASSERTeq(ret, 2);
-	ASSERTeq(err_need, ver);
-	ASSERTeq(err_found, PMEMLOG_MAJOR_VERSION);
+	UT_ASSERTeq(ret, 2);
+	UT_ASSERTeq(err_need, ver);
+	UT_ASSERTeq(err_found, PMEMLOG_MAJOR_VERSION);
 
 	ret = sscanf(pmemblk_errormsg(),
 		"libpmemblk major version mismatch (need %d, found %d)",
 		&err_need, &err_found);
-	ASSERTeq(ret, 2);
-	ASSERTeq(err_need, ver);
-	ASSERTeq(err_found, PMEMBLK_MAJOR_VERSION);
+	UT_ASSERTeq(ret, 2);
+	UT_ASSERTeq(err_need, ver);
+	UT_ASSERTeq(err_found, PMEMBLK_MAJOR_VERSION);
 
 	ret = sscanf(vmem_errormsg(),
 		"libvmem major version mismatch (need %d, found %d)",
 		&err_need, &err_found);
-	ASSERTeq(ret, 2);
-	ASSERTeq(err_need, ver);
-	ASSERTeq(err_found, VMEM_MAJOR_VERSION);
+	UT_ASSERTeq(ret, 2);
+	UT_ASSERTeq(err_need, ver);
+	UT_ASSERTeq(err_found, VMEM_MAJOR_VERSION);
 }
 
 static void *
@@ -133,7 +133,8 @@ main(int argc, char *argv[])
 	START(argc, argv, "out_err_mt");
 
 	if (argc != 5)
-		FATAL("usage: %s filename1 filename2 filename3 dir", argv[0]);
+		UT_FATAL("usage: %s filename1 filename2 filename3 dir",
+				argv[0]);
 
 	PMEMobjpool *pop = pmemobj_create(argv[1], "test",
 		PMEMOBJ_MIN_POOL, 0666);
@@ -170,7 +171,7 @@ main(int argc, char *argv[])
 	print_errors("pmemblk_set_error");
 
 	VMEM *vmp2 = vmem_create_in_region(NULL, 1);
-	ASSERTeq(vmp2, NULL);
+	UT_ASSERTeq(vmp2, NULL);
 	print_errors("vmem_create_in_region");
 
 	run_mt_test(do_test);

--- a/src/test/pmem_is_pmem/pmem_is_pmem.c
+++ b/src/test/pmem_is_pmem/pmem_is_pmem.c
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_is_pmem");
 
 	if (argc !=  2)
-		FATAL("usage: %s file", argv[0]);
+		UT_FATAL("usage: %s file", argv[0]);
 
 	int fd = OPEN(argv[1], O_RDWR);
 
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
 
 	CLOSE(fd);
 
-	OUT("%d", pmem_is_pmem(addr, stbuf.st_size));
+	UT_OUT("%d", pmem_is_pmem(addr, stbuf.st_size));
 
 	DONE(NULL);
 }

--- a/src/test/pmem_is_pmem_proc/pmem_is_pmem_proc.c
+++ b/src/test/pmem_is_pmem_proc/pmem_is_pmem_proc.c
@@ -55,7 +55,7 @@ fopen(const char *path, const char *mode)
 	static FILE *(*fopen_ptr)(const char *path, const char *mode);
 
 	if (strcmp(path, "/proc/self/smaps") == 0) {
-		OUT("redirecting /proc/self/smaps to %s", Sfile);
+		UT_OUT("redirecting /proc/self/smaps to %s", Sfile);
 		path = Sfile;
 	}
 
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_is_pmem_proc");
 
 	if (argc < 4 || argc % 2)
-		FATAL("usage: %s file addr len [addr len]...", argv[0]);
+		UT_FATAL("usage: %s file addr len [addr len]...", argv[0]);
 
 	Sfile = argv[1];
 
@@ -81,7 +81,8 @@ main(int argc, char *argv[])
 
 		addr = (void *)strtoull(argv[arg], NULL, 16);
 		len = (size_t)strtoull(argv[arg + 1], NULL, 10);
-		OUT("addr %p, len %zu: %d", addr, len, pmem_is_pmem(addr, len));
+		UT_OUT("addr %p, len %zu: %d", addr, len,
+				pmem_is_pmem(addr, len));
 	}
 
 	DONE(NULL);

--- a/src/test/pmem_map/pmem_map.c
+++ b/src/test/pmem_map/pmem_map.c
@@ -51,7 +51,7 @@ sigjmp_buf Jmp;
 int
 posix_fallocate(int fd, off_t offset, off_t len)
 {
-	OUT("posix_fallocate: off %ju len %ju", offset, len);
+	UT_OUT("posix_fallocate: off %ju len %ju", offset, len);
 
 	static int (*posix_fallocate_ptr)(int fd, off_t offset, off_t len);
 
@@ -67,7 +67,7 @@ posix_fallocate(int fd, off_t offset, off_t len)
 int
 ftruncate(int fd, off_t len)
 {
-	OUT("ftruncate: len %ju", len);
+	UT_OUT("ftruncate: len %ju", len);
 
 	static int (*ftruncate_ptr)(int fd, off_t len);
 
@@ -119,7 +119,7 @@ parse_flags(const char *flags_str)
 			ret |= (PMEM_FILE_ALL_FLAGS + 1);
 			break;
 		default:
-			FATAL("unknown flags: %c", *flags_str);
+			UT_FATAL("unknown flags: %c", *flags_str);
 		}
 		flags_str++;
 	};
@@ -147,7 +147,7 @@ do_check(int fd, void *addr, size_t mlen)
 	WRITE(fd, pat, CHECK_BYTES);
 
 	if (memcmp(pat, addr, CHECK_BYTES))
-		OUT("first %d bytes do not match", CHECK_BYTES);
+		UT_OUT("first %d bytes do not match", CHECK_BYTES);
 
 	/* fill up mapped region with new pattern */
 	memset(pat, 0xA5, CHECK_BYTES);
@@ -159,13 +159,13 @@ do_check(int fd, void *addr, size_t mlen)
 		/* same memcpy from above should now fail */
 		memcpy(addr, pat, CHECK_BYTES);
 	} else {
-		OUT("unmap successful");
+		UT_OUT("unmap successful");
 	}
 
 	LSEEK(fd, (off_t)0, SEEK_SET);
 	if (READ(fd, buf, CHECK_BYTES) == CHECK_BYTES) {
 		if (memcmp(pat, buf, CHECK_BYTES))
-			OUT("first %d bytes do not match", CHECK_BYTES);
+			UT_OUT("first %d bytes do not match", CHECK_BYTES);
 	}
 }
 
@@ -188,8 +188,8 @@ main(int argc, char *argv[])
 	int use_is_pmem;
 
 	if (argc < 7)
-		FATAL("usage: %s path len flags mode use_mlen use_is_pmem ...",
-				argv[0]);
+		UT_FATAL("usage: %s path len flags mode use_mlen "
+				"use_is_pmem ...", argv[0]);
 
 	for (int i = 1; i + 5 < argc; i += 6) {
 		path = argv[i];
@@ -210,18 +210,18 @@ main(int argc, char *argv[])
 		else
 			is_pmemp = NULL;
 
-		OUT("%s %lld %s %o %d %d",
+		UT_OUT("%s %lld %s %o %d %d",
 			path, len, argv[i + 2], mode, use_mlen, use_is_pmem);
 
 		addr = pmem_map_file(path, len, flags, mode, mlenp, is_pmemp);
 		if (addr == NULL) {
-			OUT("!pmem_map_file");
+			UT_OUT("!pmem_map_file");
 			continue;
 		}
 
 		if (use_mlen) {
-			ASSERTne(mlen, SIZE_MAX);
-			OUT("mapped_len %zu", mlen);
+			UT_ASSERTne(mlen, SIZE_MAX);
+			UT_OUT("mapped_len %zu", mlen);
 		} else {
 			mlen = len;
 		}
@@ -240,7 +240,8 @@ main(int argc, char *argv[])
 					do_check(fd, addr, mlen);
 					(void) CLOSE(fd);
 				} else {
-					OUT("!cannot open file: %s", argv[i]);
+					UT_OUT("!cannot open file: %s",
+							argv[i]);
 				}
 			} else {
 				pmem_unmap(addr, mlen);

--- a/src/test/pmem_memcpy/pmem_memcpy.c
+++ b/src/test/pmem_memcpy/pmem_memcpy.c
@@ -93,27 +93,27 @@ do_memcpy(int fd, char *dest, int dest_off, char *src, int src_off,
 
 	/* dest == src */
 	ret = pmem_memcpy_persist(dest + dest_off, dest + dest_off, bytes / 2);
-	ASSERTeq(ret, dest + dest_off);
-	ASSERTeq(*(char *)(dest + dest_off), 0);
+	UT_ASSERTeq(ret, dest + dest_off);
+	UT_ASSERTeq(*(char *)(dest + dest_off), 0);
 
 	/* len == 0 */
 	ret = pmem_memcpy_persist(dest + dest_off, src, 0);
-	ASSERTeq(ret, dest + dest_off);
-	ASSERTeq(*(char *)(dest + dest_off), 0);
+	UT_ASSERTeq(ret, dest + dest_off);
+	UT_ASSERTeq(*(char *)(dest + dest_off), 0);
 
 	ret = pmem_memcpy_persist(dest + dest_off, src + src_off, bytes / 2);
-	ASSERTeq(ret, dest + dest_off);
+	UT_ASSERTeq(ret, dest + dest_off);
 
 	/* memcmp will validate that what I expect in memory. */
 	if (memcmp(src + src_off, dest + dest_off, bytes / 2))
-		ERR("%s: first %zu bytes do not match",
+		UT_ERR("%s: first %zu bytes do not match",
 			file_name, bytes / 2);
 
 	/* Now validate the contents of the file */
 	LSEEK(fd, (off_t)dest_off, SEEK_SET);
 	if (READ(fd, buf, bytes / 2) == bytes / 2) {
 		if (memcmp(src + src_off, buf, bytes / 2))
-			ERR("%s: first %zu bytes do not match",
+			UT_ERR("%s: first %zu bytes do not match",
 				file_name, bytes / 2);
 	}
 }
@@ -129,7 +129,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_memcpy");
 
 	if (argc != 5)
-		FATAL("usage: %s file srcoff destoff length", argv[0]);
+		UT_FATAL("usage: %s file srcoff destoff length", argv[0]);
 
 	fd = OPEN(argv[1], O_RDWR);
 	int dest_off = atoi(argv[2]);
@@ -139,7 +139,7 @@ main(int argc, char *argv[])
 	/* src > dst */
 	dest = pmem_map_file(argv[1], 0, 0, 0, &mapped_len, NULL);
 	if (dest == NULL)
-		FATAL("!could not map file: %s", argv[1]);
+		UT_FATAL("!could not map file: %s", argv[1]);
 
 	src = MMAP(dest + mapped_len, mapped_len, PROT_READ|PROT_WRITE,
 		MAP_SHARED|MAP_ANONYMOUS, -1, 0);
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
 	if (src <= dest) {
 		swap_mappings(&dest, &src, mapped_len, fd);
 		if (src <= dest)
-			ERR("cannot map files in memory order");
+			UT_ERR("cannot map files in memory order");
 	}
 
 	memset(dest, 0, (2 * bytes));
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
 	swap_mappings(&dest, &src, mapped_len, fd);
 
 	if (dest <= src) {
-		ERR("cannot map files in memory order");
+		UT_ERR("cannot map files in memory order");
 	}
 
 	do_memcpy(fd, dest, dest_off, src, src_off, bytes, argv[1]);

--- a/src/test/pmem_memset/pmem_memset.c
+++ b/src/test/pmem_memset/pmem_memset.c
@@ -50,13 +50,13 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_memset");
 
 	if (argc != 4)
-		FATAL("usage: %s file offset length", argv[0]);
+		UT_FATAL("usage: %s file offset length", argv[0]);
 
 	fd = OPEN(argv[1], O_RDWR);
 
 	/* open a pmem file and memory map it */
 	if ((dest = pmem_map_file(argv[1], 0, 0, 0, &mapped_len, NULL)) == NULL)
-		FATAL("!Could not mmap %s\n", argv[1]);
+		UT_FATAL("!Could not mmap %s\n", argv[1]);
 
 	int dest_off = atoi(argv[2]);
 	size_t bytes = strtoul(argv[3], NULL, 0);
@@ -78,26 +78,26 @@ main(int argc, char *argv[])
 
 	/* Test the corner cases */
 	ret = pmem_memset_persist(dest + dest_off, 0x5A, 0);
-	ASSERTeq(ret, dest + dest_off);
-	ASSERTeq(*(char *)(dest + dest_off), 0);
+	UT_ASSERTeq(ret, dest + dest_off);
+	UT_ASSERTeq(*(char *)(dest + dest_off), 0);
 
 	/*
 	 * Do the actual memset with persistence.
 	 */
 	ret = pmem_memset_persist(dest + dest_off, 0x5A, bytes / 4);
-	ASSERTeq(ret, dest + dest_off);
+	UT_ASSERTeq(ret, dest + dest_off);
 	ret = pmem_memset_persist(dest + dest_off  + (bytes / 4),
 					0x46, bytes / 4);
-	ASSERTeq(ret, dest + dest_off + (bytes / 4));
+	UT_ASSERTeq(ret, dest + dest_off + (bytes / 4));
 
 	if (memcmp(dest, dest1, bytes / 2))
-		ERR("%s: first %zu bytes do not match",
+		UT_ERR("%s: first %zu bytes do not match",
 			argv[1], bytes / 2);
 
 	LSEEK(fd, (off_t)0, SEEK_SET);
 	if (READ(fd, buf, bytes / 2) == bytes / 2) {
 		if (memcmp(buf, dest, bytes / 2))
-			ERR("%s: first %zu bytes do not match",
+			UT_ERR("%s: first %zu bytes do not match",
 				argv[1], bytes / 2);
 	}
 

--- a/src/test/pmem_movnt/pmem_movnt.c
+++ b/src/test/pmem_movnt/pmem_movnt.c
@@ -56,23 +56,23 @@ main(int argc, char *argv[])
 	for (size_t size = 1; size <= 4096; size *= 2) {
 		memset(dst, 0, 4096);
 		pmem_memcpy_nodrain(dst, src, size);
-		ASSERTeq(memcmp(src, dst, size), 0);
-		ASSERTeq(dst[size], 0);
+		UT_ASSERTeq(memcmp(src, dst, size), 0);
+		UT_ASSERTeq(dst[size], 0);
 	}
 
 	for (size_t size = 1; size <= 4096; size *= 2) {
 		memset(dst, 0, 4096);
 		pmem_memmove_nodrain(dst, src, size);
-		ASSERTeq(memcmp(src, dst, size), 0);
-		ASSERTeq(dst[size], 0);
+		UT_ASSERTeq(memcmp(src, dst, size), 0);
+		UT_ASSERTeq(dst[size], 0);
 	}
 
 	for (size_t size = 1; size <= 4096; size *= 2) {
 		memset(dst, 0, 4096);
 		pmem_memset_nodrain(dst, 0x77, size);
-		ASSERTeq(dst[0], 0x77);
-		ASSERTeq(dst[size - 1], 0x77);
-		ASSERTeq(dst[size], 0);
+		UT_ASSERTeq(dst[0], 0x77);
+		UT_ASSERTeq(dst[size - 1], 0x77);
+		UT_ASSERTeq(dst[size], 0);
 	}
 
 	FREE(dst);

--- a/src/test/pmem_movnt_align/pmem_movnt_align.c
+++ b/src/test/pmem_movnt_align/pmem_movnt_align.c
@@ -66,7 +66,7 @@ check_func(void *dest, void *src, size_t len, mem_fn mem_func)
 	mem_func(dest, src, len);
 
 	if (memcmp(dest, src, len))
-		FATAL("memcpy/memmove failed");
+		UT_FATAL("memcpy/memmove failed");
 }
 
 /*
@@ -99,7 +99,7 @@ check_memset(void *dest, size_t len)
 	pmem_memset_persist(dest, 1, len);
 
 	if (memcmp(dest, buff, len))
-		FATAL("memset failed");
+		UT_FATAL("memset failed");
 }
 
 int
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_movnt_align");
 
 	if (argc != 2)
-		FATAL("usage: %s type", argv[0]);
+		UT_FATAL("usage: %s type", argv[0]);
 
 	char type = argv[1][0];
 
@@ -121,7 +121,7 @@ main(int argc, char *argv[])
 		src = MMAP_ANON_ALIGNED(N_BYTES, 0);
 		dst = MMAP_ANON_ALIGNED(N_BYTES, 0);
 		if (src == NULL || dst == NULL)
-			FATAL("!mmap");
+			UT_FATAL("!mmap");
 
 		/* check memcpy with 0 size */
 		check_memcpy(dst, src, 0);
@@ -147,7 +147,7 @@ main(int argc, char *argv[])
 		src = MMAP_ANON_ALIGNED(2 * N_BYTES - 4096, 0);
 		dst = src + N_BYTES - 4096;
 		if (src == NULL)
-			FATAL("!mmap");
+			UT_FATAL("!mmap");
 
 		/* check memmove in backward direction with 0 size */
 		check_memmove(dst, src, 0);
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
 		dst = MMAP_ANON_ALIGNED(2 * N_BYTES - 4096, 0);
 		src = dst + N_BYTES - 4096;
 		if (src == NULL)
-			FATAL("!mmap");
+			UT_FATAL("!mmap");
 
 		/* check memmove in forward direction with 0 size */
 		check_memmove(dst, src, 0);
@@ -201,7 +201,7 @@ main(int argc, char *argv[])
 		/* mmap with guard pages */
 		dst = MMAP_ANON_ALIGNED(N_BYTES, 0);
 		if (dst == NULL)
-			FATAL("!mmap");
+			UT_FATAL("!mmap");
 
 		/* check memset with 0 size */
 		check_memset(dst, 0);
@@ -222,7 +222,7 @@ main(int argc, char *argv[])
 
 		break;
 	default:
-		FATAL("!wrong type of test");
+		UT_FATAL("!wrong type of test");
 		break;
 	}
 

--- a/src/test/pmem_valgr_simple/pmem_valgr_simple.c
+++ b/src/test/pmem_valgr_simple/pmem_valgr_simple.c
@@ -48,14 +48,14 @@ main(int argc, char *argv[])
 	START(argc, argv, "pmem_valgr_simple");
 
 	if (argc != 4)
-		FATAL("usage: %s file offset length", argv[0]);
+		UT_FATAL("usage: %s file offset length", argv[0]);
 
 	int dest_off = atoi(argv[2]);
 	size_t bytes = strtoul(argv[3], NULL, 0);
 
 	dest = pmem_map_file(argv[1], 0, 0, 0, &mapped_len, &is_pmem);
 	if (dest == NULL)
-		FATAL("!Could not mmap %s\n", argv[1]);
+		UT_FATAL("!Could not mmap %s\n", argv[1]);
 
 	/* these will not be made persistent */
 	*(int *)dest = 4;

--- a/src/test/set_funcs/set_funcs.c
+++ b/src/test/set_funcs/set_funcs.c
@@ -177,31 +177,31 @@ test_obj(const char *path)
 	PMEMoid oid;
 
 	if (pmemobj_alloc(pop, &oid, 10, 0, NULL, NULL))
-		FATAL("!alloc");
+		UT_FATAL("!alloc");
 
 	if (pmemobj_realloc(pop, &oid, 100, 0))
-		FATAL("!realloc");
+		UT_FATAL("!realloc");
 
 	pmemobj_free(&oid);
 
 	pmemobj_close(pop);
 
-	OUT("obj_mallocs: %d", cnt[OBJ].mallocs);
-	OUT("obj_frees: %d", cnt[OBJ].frees);
-	OUT("obj_reallocs: %d", cnt[OBJ].reallocs);
-	OUT("obj_strdups: %d", cnt[OBJ].strdups);
+	UT_OUT("obj_mallocs: %d", cnt[OBJ].mallocs);
+	UT_OUT("obj_frees: %d", cnt[OBJ].frees);
+	UT_OUT("obj_reallocs: %d", cnt[OBJ].reallocs);
+	UT_OUT("obj_strdups: %d", cnt[OBJ].strdups);
 
 	if (cnt[OBJ].mallocs == 0 || cnt[OBJ].frees == 0)
-		FATAL("OBJ mallocs: %d, frees: %d", cnt[OBJ].mallocs,
+		UT_FATAL("OBJ mallocs: %d, frees: %d", cnt[OBJ].mallocs,
 				cnt[OBJ].frees);
 	for (int i = 0; i < 4; ++i) {
 		if (i == OBJ)
 			continue;
 		if (cnt[i].mallocs || cnt[i].frees)
-			FATAL("OBJ allocation used %d functions", i);
+			UT_FATAL("OBJ allocation used %d functions", i);
 	}
 	if (cnt[OBJ].mallocs + cnt[OBJ].strdups != cnt[OBJ].frees)
-		FATAL("OBJ memory leak");
+		UT_FATAL("OBJ memory leak");
 
 	unlink(path);
 }
@@ -216,22 +216,22 @@ test_blk(const char *path)
 	pmemblk_close(blk);
 
 
-	OUT("blk_mallocs: %d", cnt[BLK].mallocs);
-	OUT("blk_frees: %d", cnt[BLK].frees);
-	OUT("blk_reallocs: %d", cnt[BLK].reallocs);
-	OUT("blk_strdups: %d", cnt[BLK].strdups);
+	UT_OUT("blk_mallocs: %d", cnt[BLK].mallocs);
+	UT_OUT("blk_frees: %d", cnt[BLK].frees);
+	UT_OUT("blk_reallocs: %d", cnt[BLK].reallocs);
+	UT_OUT("blk_strdups: %d", cnt[BLK].strdups);
 
 	if (cnt[BLK].mallocs == 0 || cnt[BLK].frees == 0)
-		FATAL("BLK mallocs: %d, frees: %d", cnt[BLK].mallocs,
+		UT_FATAL("BLK mallocs: %d, frees: %d", cnt[BLK].mallocs,
 				cnt[BLK].frees);
 	for (int i = 0; i < 4; ++i) {
 		if (i == BLK)
 			continue;
 		if (cnt[i].mallocs || cnt[i].frees)
-			FATAL("BLK allocation used %d functions", i);
+			UT_FATAL("BLK allocation used %d functions", i);
 	}
 	if (cnt[BLK].mallocs + cnt[BLK].strdups != cnt[BLK].frees)
-		FATAL("BLK memory leak");
+		UT_FATAL("BLK memory leak");
 
 	unlink(path);
 }
@@ -246,22 +246,22 @@ test_log(const char *path)
 	pmemlog_close(log);
 
 
-	OUT("log_mallocs: %d", cnt[LOG].mallocs);
-	OUT("log_frees: %d", cnt[LOG].frees);
-	OUT("log_reallocs: %d", cnt[LOG].reallocs);
-	OUT("log_strdups: %d", cnt[LOG].strdups);
+	UT_OUT("log_mallocs: %d", cnt[LOG].mallocs);
+	UT_OUT("log_frees: %d", cnt[LOG].frees);
+	UT_OUT("log_reallocs: %d", cnt[LOG].reallocs);
+	UT_OUT("log_strdups: %d", cnt[LOG].strdups);
 
 	if (cnt[LOG].mallocs == 0 || cnt[LOG].frees == 0)
-		FATAL("LOG mallocs: %d, frees: %d", cnt[LOG].mallocs,
+		UT_FATAL("LOG mallocs: %d, frees: %d", cnt[LOG].mallocs,
 				cnt[LOG].frees);
 	for (int i = 0; i < 4; ++i) {
 		if (i == LOG)
 			continue;
 		if (cnt[i].mallocs || cnt[i].frees)
-			FATAL("LOG allocation used %d functions", i);
+			UT_FATAL("LOG allocation used %d functions", i);
 	}
 	if (cnt[LOG].mallocs + cnt[LOG].strdups != cnt[LOG].frees)
-		FATAL("LOG memory leak");
+		UT_FATAL("LOG memory leak");
 
 	unlink(path);
 }
@@ -283,22 +283,22 @@ test_vmem(const char *dir)
 	for (int i = 0; i < VMEM_POOLS; i++)
 		vmem_delete(v[i]);
 
-	OUT("vmem_mallocs: %d", cnt[VMEM_].mallocs);
-	OUT("vmem_frees: %d", cnt[VMEM_].frees);
-	OUT("vmem_reallocs: %d", cnt[VMEM_].reallocs);
-	OUT("vmem_strdups: %d", cnt[VMEM_].strdups);
+	UT_OUT("vmem_mallocs: %d", cnt[VMEM_].mallocs);
+	UT_OUT("vmem_frees: %d", cnt[VMEM_].frees);
+	UT_OUT("vmem_reallocs: %d", cnt[VMEM_].reallocs);
+	UT_OUT("vmem_strdups: %d", cnt[VMEM_].strdups);
 
 	if (cnt[VMEM_].mallocs == 0 && cnt[VMEM_].frees == 0)
-		FATAL("VMEM mallocs: %d, frees: %d", cnt[VMEM_].mallocs,
+		UT_FATAL("VMEM mallocs: %d, frees: %d", cnt[VMEM_].mallocs,
 				cnt[VMEM_].frees);
 	for (int i = 0; i < 4; ++i) {
 		if (i == VMEM_)
 			continue;
 		if (cnt[i].mallocs || cnt[i].frees)
-			FATAL("VMEM allocation used %d functions", i);
+			UT_FATAL("VMEM allocation used %d functions", i);
 	}
 	if (cnt[VMEM_].mallocs + cnt[VMEM_].strdups > cnt[VMEM_].frees + 4)
-		FATAL("VMEM memory leak");
+		UT_FATAL("VMEM memory leak");
 }
 
 int
@@ -307,7 +307,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "set_funcs");
 
 	if (argc < 3)
-		FATAL("usage: %s file dir", argv[0]);
+		UT_FATAL("usage: %s file dir", argv[0]);
 
 	pmemobj_set_funcs(obj_malloc, obj_free, obj_realloc, obj_strdup);
 	pmemblk_set_funcs(blk_malloc, blk_free, blk_realloc, blk_strdup);

--- a/src/test/traces/traces.c
+++ b/src/test/traces/traces.c
@@ -43,16 +43,6 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include "out.h"
-#undef ERR
-#undef FATAL
-#undef ASSERT_rt
-#undef ASSERTinfo_rt
-#undef ASSERTeq_rt
-#undef ASSERTne_rt
-#undef ASSERT
-#undef ASSERTinfo
-#undef ASSERTeq
-#undef ASSERTne
 #include "unittest.h"
 
 int

--- a/src/test/traces_custom_function/traces_custom_function.c
+++ b/src/test/traces_custom_function/traces_custom_function.c
@@ -47,16 +47,6 @@
 #include <sys/types.h>
 #include <stdarg.h>
 #include "out.h"
-#undef ERR
-#undef FATAL
-#undef ASSERT_rt
-#undef ASSERTinfo_rt
-#undef ASSERTeq_rt
-#undef ASSERTne_rt
-#undef ASSERT
-#undef ASSERTinfo
-#undef ASSERTeq
-#undef ASSERTne
 #include "unittest.h"
 
 /*
@@ -68,9 +58,9 @@ static void
 print_custom_function(const char *s)
 {
 	if (s) {
-		OUT("CUSTOM_PRINT: %s", s);
+		UT_OUT("CUSTOM_PRINT: %s", s);
 	} else {
-		OUT("CUSTOM_PRINT(NULL)");
+		UT_OUT("CUSTOM_PRINT(NULL)");
 	}
 }
 
@@ -104,7 +94,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "traces_custom_function");
 
 	if (argc != 2)
-		FATAL("usage: %s [v|p]", argv[0]);
+		UT_FATAL("usage: %s [v|p]", argv[0]);
 
 	out_set_print_func(print_custom_function);
 
@@ -131,7 +121,7 @@ main(int argc, char *argv[])
 		LOG(0, "!error");
 		break;
 	default:
-		FATAL("usage: %s [v|p]", argv[0]);
+		UT_FATAL("usage: %s [v|p]", argv[0]);
 	}
 
 	/* Cleanup */

--- a/src/test/traces_pmem/traces_pmem.c
+++ b/src/test/traces_pmem/traces_pmem.c
@@ -41,13 +41,13 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "traces_pmem");
 
-	ASSERT(!pmem_check_version(PMEM_MAJOR_VERSION,
+	UT_ASSERT(!pmem_check_version(PMEM_MAJOR_VERSION,
 				PMEM_MINOR_VERSION));
-	ASSERT(!pmemblk_check_version(PMEMBLK_MAJOR_VERSION,
+	UT_ASSERT(!pmemblk_check_version(PMEMBLK_MAJOR_VERSION,
 				PMEMBLK_MINOR_VERSION));
-	ASSERT(!pmemlog_check_version(PMEMLOG_MAJOR_VERSION,
+	UT_ASSERT(!pmemlog_check_version(PMEMLOG_MAJOR_VERSION,
 				PMEMLOG_MINOR_VERSION));
-	ASSERT(!pmemobj_check_version(PMEMOBJ_MAJOR_VERSION,
+	UT_ASSERT(!pmemobj_check_version(PMEMOBJ_MAJOR_VERSION,
 				PMEMOBJ_MINOR_VERSION));
 
 	DONE(NULL);

--- a/src/test/unittest/README
+++ b/src/test/unittest/README
@@ -23,7 +23,7 @@ function. For example:
     FUNC_MOCK(malloc, void *, size_t size)
 	FUNC_MOCK_RUN_RET_DEFAULT_REAL(malloc, size)
 	FUNC_MOCK_RUN(2) {
-	    ASSERTeq(size, 8);
+	    UT_ASSERTeq(size, 8);
 	    return NULL;
 	}
     FUNC_MOCK_END

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -66,19 +66,19 @@
  * all unit tests should use these exit calls:
  *
  *	DONE("message", ...);
- *	FATAL("message", ...);
+ *	UT_FATAL("message", ...);
  *
  * uniform stderr and stdout messages:
  *
- *	OUT("message", ...);
- *	ERR("message", ...);
+ *	UT_OUT("message", ...);
+ *	UT_ERR("message", ...);
  *
  * in all cases above, the message is printf-like, taking variable args.
  * the message can be NULL.  it can start with "!" in which case the "!" is
  * skipped and the message gets the errno string appended to it, like this:
  *
  *	if (somesyscall(..) < 0)
- *		FATAL("!my message");
+ *		UT_FATAL("!my message");
  */
 
 #ifndef	_UNITTEST_H
@@ -146,15 +146,15 @@ void ut_err(const char *file, int line, const char *func,
     ut_done(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 /* fatal error detected */
-#define	FATAL(...)\
+#define	UT_FATAL(...)\
     ut_fatal(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 /* normal output */
-#define	OUT(...)\
+#define	UT_OUT(...)\
     ut_out(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 /* error output */
-#define	ERR(...)\
+#define	UT_ERR(...)\
     ut_err(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
 
@@ -165,68 +165,69 @@ void ut_err(const char *file, int line, const char *func,
  */
 
 /* assert a condition is true at runtime */
-#define	ASSERT_rt(cnd)\
+#define	UT_ASSERT_rt(cnd)\
 	((void)((cnd) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s", #cnd), 0)))
 
 /* assertion with extra info printed if assertion fails at runtime */
-#define	ASSERTinfo_rt(cnd, info) \
+#define	UT_ASSERTinfo_rt(cnd, info) \
 	((void)((cnd) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (%s = %s)", #cnd, #info, info), 0)))
 
 /* assert two integer values are equal at runtime */
-#define	ASSERTeq_rt(lhs, rhs)\
+#define	UT_ASSERTeq_rt(lhs, rhs)\
 	((void)(((lhs) == (rhs)) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) == %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
 
 /* assert two integer values are not equal at runtime */
-#define	ASSERTne_rt(lhs, rhs)\
+#define	UT_ASSERTne_rt(lhs, rhs)\
 	((void)(((lhs) != (rhs)) || (ut_fatal(__FILE__, __LINE__, __func__,\
 	"assertion failure: %s (0x%llx) != %s (0x%llx)", #lhs,\
 	(unsigned long long)(lhs), #rhs, (unsigned long long)(rhs)), 0)))
 
 /* assert a condition is true */
-#define	ASSERT(cnd)\
+#define	UT_ASSERT(cnd)\
 	do {\
 		/*\
 		 * Detect useless asserts on always true expression. Please use\
-		 * UT_COMPILE_ERROR_ON(!cnd) or ASSERT_rt(cnd) in such cases.\
+		 * UT_COMPILE_ERROR_ON(!cnd) or UT_ASSERT_rt(cnd) in such\
+		 * cases.\
 		 */\
 		if (__builtin_constant_p(cnd))\
 			UT_COMPILE_ERROR_ON(cnd);\
-		ASSERT_rt(cnd);\
+		UT_ASSERT_rt(cnd);\
 	} while (0)
 
 /* assertion with extra info printed if assertion fails */
-#define	ASSERTinfo(cnd, info) \
+#define	UT_ASSERTinfo(cnd, info) \
 	do {\
-		/* See comment in ASSERT. */\
+		/* See comment in UT_ASSERT. */\
 		if (__builtin_constant_p(cnd))\
 			UT_COMPILE_ERROR_ON(cnd);\
-		ASSERTinfo_rt(cnd, info);\
+		UT_ASSERTinfo_rt(cnd, info);\
 	} while (0)
 
 /* assert two integer values are equal */
-#define	ASSERTeq(lhs, rhs)\
+#define	UT_ASSERTeq(lhs, rhs)\
 	do {\
-		/* See comment in ASSERT. */\
+		/* See comment in UT_ASSERT. */\
 		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
 			UT_COMPILE_ERROR_ON((lhs) == (rhs));\
-		ASSERTeq_rt(lhs, rhs);\
+		UT_ASSERTeq_rt(lhs, rhs);\
 	} while (0)
 
 /* assert two integer values are not equal */
-#define	ASSERTne(lhs, rhs)\
+#define	UT_ASSERTne(lhs, rhs)\
 	do {\
-		/* See comment in ASSERT. */\
+		/* See comment in UT_ASSERT. */\
 		if (__builtin_constant_p(lhs) && __builtin_constant_p(rhs))\
 			UT_COMPILE_ERROR_ON((lhs) != (rhs));\
-		ASSERTne_rt(lhs, rhs);\
+		UT_ASSERTne_rt(lhs, rhs);\
 	} while (0)
 
 /* assert pointer is fits range of [start, start + size) */
-#define	ASSERTrange(ptr, start, size)\
+#define	UT_ASSERTrange(ptr, start, size)\
 	((void)(((uintptr_t)(ptr) >= (uintptr_t)(start) &&\
 	(uintptr_t)(ptr) < (uintptr_t)(start) + (uintptr_t)(size)) ||\
 	(ut_fatal(__FILE__, __LINE__, __func__,\

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -180,7 +180,7 @@ open_file_add(struct fd_lut *root, int fdnum, const char *fdfile)
 		root->fdnum = fdnum;
 		root->fdfile = STRDUP(fdfile);
 	} else if (root->fdnum == fdnum)
-		FATAL("duplicate fdnum: %d", fdnum);
+		UT_FATAL("duplicate fdnum: %d", fdnum);
 	else if (root->fdnum < fdnum)
 		root->left = open_file_add(root->left, fdnum, fdfile);
 	else
@@ -197,18 +197,18 @@ static void
 open_file_remove(struct fd_lut *root, int fdnum, const char *fdfile)
 {
 	if (root == NULL) {
-		ERR("unexpected open file: fd %d => \"%s\"", fdnum, fdfile);
+		UT_ERR("unexpected open file: fd %d => \"%s\"", fdnum, fdfile);
 		Fd_errcount++;
 	} else if (root->fdnum == fdnum) {
 		if (root->fdfile == NULL) {
-			ERR("open file dup: fd %d => \"%s\"", fdnum, fdfile);
+			UT_ERR("open file dup: fd %d => \"%s\"", fdnum, fdfile);
 			Fd_errcount++;
 		} else if (strcmp(root->fdfile, fdfile) == 0) {
 			/* found exact match */
 			FREE(root->fdfile);
 			root->fdfile = NULL;
 		} else {
-			ERR("open file changed: fd %d was \"%s\" now \"%s\"",
+			UT_ERR("open file changed: fd %d was \"%s\" now \"%s\"",
 			    fdnum, root->fdfile, fdfile);
 			Fd_errcount++;
 		}
@@ -229,7 +229,7 @@ open_file_walk(struct fd_lut *root)
 	if (root) {
 		open_file_walk(root->left);
 		if (root->fdfile) {
-			ERR("open file missing: fd %d => \"%s\"",
+			UT_ERR("open file missing: fd %d => \"%s\"",
 			    root->fdnum, root->fdfile);
 			Fd_errcount++;
 		}
@@ -264,7 +264,7 @@ record_open_files()
 
 	if ((dirfd = open("/proc/self/fd", O_RDONLY)) < 0 ||
 	    (dirp = fdopendir(dirfd)) == NULL)
-		FATAL("!/proc/self/fd");
+		UT_FATAL("!/proc/self/fd");
 	while ((dp = readdir(dirp)) != NULL) {
 		int fdnum;
 		char fdfile[PATH_MAX];
@@ -273,7 +273,7 @@ record_open_files()
 		if (*dp->d_name == '.')
 			continue;
 		if ((cc = readlinkat(dirfd, dp->d_name, fdfile, PATH_MAX)) < 0)
-		    FATAL("!readlinkat: /proc/self/fd/%s", dp->d_name);
+		    UT_FATAL("!readlinkat: /proc/self/fd/%s", dp->d_name);
 		fdfile[cc] = '\0';
 		fdnum = atoi(dp->d_name);
 		if (dirfd == fdnum)
@@ -295,7 +295,7 @@ check_open_files()
 
 	if ((dirfd = open("/proc/self/fd", O_RDONLY)) < 0 ||
 	    (dirp = fdopendir(dirfd)) == NULL)
-		FATAL("!/proc/self/fd");
+		UT_FATAL("!/proc/self/fd");
 	while ((dp = readdir(dirp)) != NULL) {
 		int fdnum;
 		char fdfile[PATH_MAX];
@@ -304,7 +304,7 @@ check_open_files()
 		if (*dp->d_name == '.')
 			continue;
 		if ((cc = readlinkat(dirfd, dp->d_name, fdfile, PATH_MAX)) < 0)
-		    FATAL("!readlinkat: /proc/self/fd/%s", dp->d_name);
+		    UT_FATAL("!readlinkat: /proc/self/fd/%s", dp->d_name);
 		fdfile[cc] = '\0';
 		fdnum = atoi(dp->d_name);
 		if (dirfd == fdnum)
@@ -314,7 +314,7 @@ check_open_files()
 	closedir(dirp);
 	open_file_walk(Fd_lut);
 	if (Fd_errcount)
-		FATAL("open file list changed between START() and DONE()");
+		UT_FATAL("open file list changed between START() and DONE()");
 	open_file_free(Fd_lut);
 }
 

--- a/src/test/unittest/ut_backtrace.c
+++ b/src/test/unittest/ut_backtrace.c
@@ -63,14 +63,14 @@ ut_dump_backtrace(void)
 	pip.unwind_info = NULL;
 	int ret = unw_getcontext(&context);
 	if (ret) {
-		ERR("unw_getcontext: %s [%d]", unw_strerror(ret), ret);
+		UT_ERR("unw_getcontext: %s [%d]", unw_strerror(ret), ret);
 		return;
 	}
 
 	unw_cursor_t cursor;
 	ret = unw_init_local(&cursor, &context);
 	if (ret) {
-		ERR("unw_init_local: %s [%d]", unw_strerror(ret), ret);
+		UT_ERR("unw_init_local: %s [%d]", unw_strerror(ret), ret);
 		return;
 	}
 
@@ -82,7 +82,7 @@ ut_dump_backtrace(void)
 	while (ret > 0) {
 		ret = unw_get_proc_info(&cursor, &pip);
 		if (ret) {
-			ERR("unw_get_proc_info: %s [%d]", unw_strerror(ret),
+			UT_ERR("unw_get_proc_info: %s [%d]", unw_strerror(ret),
 					ret);
 			break;
 		}
@@ -91,7 +91,7 @@ ut_dump_backtrace(void)
 		ret = unw_get_proc_name(&cursor, procname, PROCNAMELEN, &off);
 		if (ret && ret != -UNW_ENOMEM) {
 			if (ret != -UNW_EUNSPEC) {
-				ERR("unw_get_proc_name: %s [%d]",
+				UT_ERR("unw_get_proc_name: %s [%d]",
 					unw_strerror(ret), ret);
 			}
 
@@ -106,12 +106,12 @@ ut_dump_backtrace(void)
 				*dlinfo.dli_fname)
 			fname = dlinfo.dli_fname;
 
-		ERR("%u: %s (%s%s+0x%lx) [%p]", i++, fname, procname,
+		UT_ERR("%u: %s (%s%s+0x%lx) [%p]", i++, fname, procname,
 				ret == -UNW_ENOMEM ? "..." : "", off, ptr);
 
 		ret = unw_step(&cursor);
 		if (ret < 0)
-			ERR("unw_step: %s [%d]", unw_strerror(ret), ret);
+			UT_ERR("unw_step: %s [%d]", unw_strerror(ret), ret);
 	}
 }
 #else /* USE_LIBUNWIND */
@@ -134,12 +134,12 @@ ut_dump_backtrace(void)
 
 	strings = backtrace_symbols(buffer, nptrs);
 	if (strings == NULL) {
-		ERR("!backtrace_symbols");
+		UT_ERR("!backtrace_symbols");
 		return;
 	}
 
 	for (j = 0; j < nptrs; j++)
-		ERR("%u: %s", j, strings[j]);
+		UT_ERR("%u: %s", j, strings[j]);
 
 	free(strings);
 }
@@ -152,10 +152,10 @@ ut_dump_backtrace(void)
 void
 ut_sighandler(int sig)
 {
-	ERR("\n");
-	ERR("Signal %d, backtrace:", sig);
+	UT_ERR("\n");
+	UT_ERR("Signal %d, backtrace:", sig);
 	ut_dump_backtrace();
-	ERR("\n");
+	UT_ERR("\n");
 	exit(128 + sig);
 }
 

--- a/src/test/util_cpuid/util_cpuid.c
+++ b/src/test/util_cpuid/util_cpuid.c
@@ -67,19 +67,19 @@ parse_cpuinfo(char *line)
 		*nl = ' ';
 
 	int clflush_present = strstr(flags, clflush) != NULL;
-	ASSERTeq(is_cpu_clflush_present(), clflush_present);
+	UT_ASSERTeq(is_cpu_clflush_present(), clflush_present);
 
 	int clflushopt_present = strstr(flags, clflushopt) != NULL;
-	ASSERTeq(is_cpu_clflushopt_present(), clflushopt_present);
+	UT_ASSERTeq(is_cpu_clflushopt_present(), clflushopt_present);
 
 	int clwb_present = strstr(flags, clwb) != NULL;
-	ASSERTeq(is_cpu_clwb_present(), clwb_present);
+	UT_ASSERTeq(is_cpu_clwb_present(), clwb_present);
 
 	int pcommit_present = strstr(flags, pcommit) != NULL;
-	ASSERTeq(is_cpu_pcommit_present(), pcommit_present);
+	UT_ASSERTeq(is_cpu_pcommit_present(), pcommit_present);
 
 	int sse2_present = strstr(flags, sse2) != NULL;
-	ASSERTeq(is_cpu_sse2_present(), sse2_present);
+	UT_ASSERTeq(is_cpu_sse2_present(), sse2_present);
 
 	return 1;
 }
@@ -93,7 +93,7 @@ check_cpuinfo(void)
 	/* detect supported CPU features */
 	FILE *fp;
 	if ((fp = fopen("/proc/cpuinfo", "r")) == NULL) {
-		ERR("!/proc/cpuinfo");
+		UT_ERR("!/proc/cpuinfo");
 	} else {
 		char line[PROCMAXLEN];	/* for fgets() */
 

--- a/src/test/util_file_create/util_file_create.c
+++ b/src/test/util_file_create/util_file_create.c
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "util_file_create");
 
 	if (argc < 3)
-		FATAL("usage: %s minlen len:path...", argv[0]);
+		UT_FATAL("usage: %s minlen len:path...", argv[0]);
 
 	char *fname;
 	size_t minsize = strtoul(argv[1], &fname, 0);
@@ -54,14 +54,14 @@ main(int argc, char *argv[])
 	for (int arg = 2; arg < argc; arg++) {
 		size_t size = strtoul(argv[arg], &fname, 0);
 		if (*fname != ':')
-			FATAL("usage: %s minlen len:path...", argv[0]);
+			UT_FATAL("usage: %s minlen len:path...", argv[0]);
 		fname++;
 
 		int fd;
 		if ((fd = util_file_create(fname, size, minsize)) == -1)
-			OUT("!%s: util_file_create", fname);
+			UT_OUT("!%s: util_file_create", fname);
 		else {
-			OUT("%s: created", fname);
+			UT_OUT("%s: created", fname);
 			close(fd);
 		}
 	}

--- a/src/test/util_file_open/util_file_open.c
+++ b/src/test/util_file_open/util_file_open.c
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "util_file_open");
 
 	if (argc < 3)
-		FATAL("usage: %s minlen path...", argv[0]);
+		UT_FATAL("usage: %s minlen path...", argv[0]);
 
 	char *fname;
 	size_t minsize = strtoul(argv[1], &fname, 0);
@@ -55,9 +55,9 @@ main(int argc, char *argv[])
 		size_t size = 0;
 		int fd = util_file_open(argv[arg], &size, minsize, O_RDWR);
 		if (fd == -1)
-			OUT("!%s: util_file_open", argv[arg]);
+			UT_OUT("!%s: util_file_open", argv[arg]);
 		else {
-			OUT("%s: open, len %zu", argv[arg], size);
+			UT_OUT("%s: open, len %zu", argv[arg], size);
 			close(fd);
 		}
 	}

--- a/src/test/util_is_poolset/util_is_poolset.c
+++ b/src/test/util_is_poolset/util_is_poolset.c
@@ -66,14 +66,14 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc < 2)
-		FATAL("usage: %s file...",
+		UT_FATAL("usage: %s file...",
 			argv[0]);
 
 	for (int i = 1; i < argc; i++) {
 		char *fname = argv[i];
 		int is_poolset = util_is_poolset(fname);
 
-		OUT("util_is_poolset(%s): %d", fname, is_poolset);
+		UT_OUT("util_is_poolset(%s): %d", fname, is_poolset);
 	}
 	out_fini();
 

--- a/src/test/util_map_proc/util_map_proc.c
+++ b/src/test/util_map_proc/util_map_proc.c
@@ -60,7 +60,7 @@ fopen(const char *path, const char *mode)
 	static FILE *(*fopen_ptr)(const char *path, const char *mode);
 
 	if (strcmp(path, "/proc/self/maps") == 0) {
-		OUT("redirecting /proc/self/maps to %s", Sfile);
+		UT_OUT("redirecting /proc/self/maps to %s", Sfile);
 		path = Sfile;
 	}
 
@@ -78,7 +78,7 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc < 3)
-		FATAL("usage: %s maps_file len [len]...", argv[0]);
+		UT_FATAL("usage: %s maps_file len [len]...", argv[0]);
 
 	Sfile = argv[1];
 
@@ -95,10 +95,10 @@ main(int argc, char *argv[])
 			util_map_hint_unused((void *)TERABYTE, len, GIGABYTE);
 		void *h2 = util_map_hint(len, 0);
 		if (h1 != NULL)
-			ASSERTeq((uintptr_t)h1 & (GIGABYTE - 1), 0);
+			UT_ASSERTeq((uintptr_t)h1 & (GIGABYTE - 1), 0);
 		if (h2 != NULL)
-			ASSERTeq((uintptr_t)h2 & (align - 1), 0);
-		OUT("len %zu: %p %p", len, h1, h2);
+			UT_ASSERTeq((uintptr_t)h2 & (align - 1), 0);
+		UT_OUT("len %zu: %p %p", len, h1, h2);
 	}
 
 	DONE(NULL);

--- a/src/test/util_parse_size/util_parse_size.c
+++ b/src/test/util_parse_size/util_parse_size.c
@@ -48,9 +48,9 @@ main(int argc, char *argv[])
 	for (int arg = 1; arg < argc; ++arg) {
 		ret = util_parse_size(argv[arg], &size);
 		if (ret == 0) {
-			OUT("%s - correct %lu", argv[arg], size);
+			UT_OUT("%s - correct %lu", argv[arg], size);
 		} else {
-			OUT("%s - incorrect", argv[arg]);
+			UT_OUT("%s - incorrect", argv[arg]);
 		}
 	}
 

--- a/src/test/util_poolset/mocks.c
+++ b/src/test/util_poolset/mocks.c
@@ -47,7 +47,7 @@ extern size_t Is_pmem_len;
 FUNC_MOCK(open, int, const char *path, int flags, int mode)
 FUNC_MOCK_RUN_DEFAULT {
 	if (strcmp(Open_path, path) == 0) {
-		OUT("mocked open: %s", path);
+		UT_OUT("mocked open: %s", path);
 		errno = EACCES;
 		return -1;
 	}
@@ -62,7 +62,7 @@ FUNC_MOCK_END
 FUNC_MOCK(posix_fallocate, int, int fd, off_t offset, off_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	if (Fallocate_len == len) {
-		OUT("mocked fallocate: %ju", len);
+		UT_OUT("mocked fallocate: %ju", len);
 		return ENOSPC;
 	}
 	return _FUNC_REAL(posix_fallocate)(fd, offset, len);
@@ -76,7 +76,7 @@ FUNC_MOCK_END
 FUNC_MOCK(pmem_is_pmem, int, void *addr, size_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	if (Is_pmem_len == len) {
-		OUT("mocked pmem_is_pmem: %zu", len);
+		UT_OUT("mocked pmem_is_pmem: %zu", len);
 		return 1;
 	}
 	return _FUNC_REAL(pmem_is_pmem)(addr, len);

--- a/src/test/util_poolset_foreach/util_poolset_foreach.c
+++ b/src/test/util_poolset_foreach/util_poolset_foreach.c
@@ -60,7 +60,7 @@ static int
 cb(const char *name, void *arg)
 {
 	char *set_name = (char *)arg;
-	OUT("%s: %s", set_name, name);
+	UT_OUT("%s: %s", set_name, name);
 	return 0;
 }
 
@@ -74,14 +74,14 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc < 2)
-		FATAL("usage: %s file...",
+		UT_FATAL("usage: %s file...",
 			argv[0]);
 
 	for (int i = 1; i < argc; i++) {
 		char *fname = argv[i];
 		int ret = util_poolset_foreach_part(fname, cb, fname);
 
-		OUT("util_poolset_foreach_part(%s): %d", fname, ret);
+		UT_OUT("util_poolset_foreach_part(%s): %d", fname, ret);
 	}
 	out_fini();
 

--- a/src/test/util_poolset_parse/util_poolset_parse.c
+++ b/src/test/util_poolset_parse/util_poolset_parse.c
@@ -64,7 +64,7 @@ main(int argc, char *argv[])
 			MAJOR_VERSION, MINOR_VERSION);
 
 	if (argc < 2)
-		FATAL("usage: %s set-file-name ...", argv[0]);
+		UT_FATAL("usage: %s set-file-name ...", argv[0]);
 
 	struct pool_set *set;
 	int fd;

--- a/src/test/util_poolset_size/util_poolset_size.c
+++ b/src/test/util_poolset_size/util_poolset_size.c
@@ -66,14 +66,14 @@ main(int argc, char *argv[])
 	util_init();
 
 	if (argc < 2)
-		FATAL("usage: %s file...",
+		UT_FATAL("usage: %s file...",
 			argv[0]);
 
 	for (int i = 1; i < argc; i++) {
 		char *fname = argv[i];
 		size_t size = util_poolset_size(fname);
 
-		OUT("util_poolset_size(%s): %lu", fname, size);
+		UT_OUT("util_poolset_size(%s): %lu", fname, size);
 	}
 	out_fini();
 

--- a/src/test/util_uuid_generate/util_uuid_generate.c
+++ b/src/test/util_uuid_generate/util_uuid_generate.c
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
 		 */
 		int fd = OPEN(POOL_HDR_UUID_GEN_FILE, O_RDONLY);
 		ssize_t num = READ(fd, uu, POOL_HDR_UUID_STR_LEN);
-		ASSERTeq(num, POOL_HDR_UUID_STR_LEN);
+		UT_ASSERTeq(num, POOL_HDR_UUID_STR_LEN);
 
 		uu[POOL_HDR_UUID_STR_LEN - 1] = '\0';
 
@@ -71,12 +71,12 @@ main(int argc, char *argv[])
 		 * uuid back to a string and compare strings.
 		 */
 		ret = util_uuid_from_string(uu, (struct uuid *)&uuid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		ret = util_uuid_to_string(uuid, conv_uu);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
-		ASSERT(strncmp(uu, conv_uu, POOL_HDR_UUID_STR_LEN) == 0);
+		UT_ASSERT(strncmp(uu, conv_uu, POOL_HDR_UUID_STR_LEN) == 0);
 
 		/*
 		 * Generate uuid from util_uuid_generate and translate to
@@ -87,14 +87,14 @@ main(int argc, char *argv[])
 		memset(conv_uu, 0, POOL_HDR_UUID_STR_LEN);
 
 		ret = util_uuid_generate(uuid);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		ret = util_uuid_to_string(uuid, uu);
-		ASSERTeq(ret, 0);
+		UT_ASSERTeq(ret, 0);
 
 		ret  = util_uuid_from_string(uu, (struct uuid *)&uuid1);
-		ASSERTeq(ret, 0);
-		ASSERT(memcmp(&uuid, &uuid1, sizeof (uuid_t)) == 0);
+		UT_ASSERTeq(ret, 0);
+		UT_ASSERT(memcmp(&uuid, &uuid1, sizeof (uuid_t)) == 0);
 		CLOSE(fd);
 	} else {
 		/*
@@ -103,15 +103,15 @@ main(int argc, char *argv[])
 		if (strcmp(argv[2], "valid") == 0) {
 			ret = util_uuid_from_string(argv[1],
 				(struct uuid *)&uuid);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 
 			ret = util_uuid_to_string(uuid, conv_uu);
-			ASSERTeq(ret, 0);
+			UT_ASSERTeq(ret, 0);
 		} else {
 			ret = util_uuid_from_string(argv[1],
 				(struct uuid *)&uuid);
-			ASSERT(ret < 0);
-			OUT("util_uuid_generate: invalid uuid string");
+			UT_ASSERT(ret < 0);
+			UT_OUT("util_uuid_generate: invalid uuid string");
 		}
 	}
 	DONE(NULL);

--- a/src/test/vmem_aligned_alloc/vmem_aligned_alloc.c
+++ b/src/test/vmem_aligned_alloc/vmem_aligned_alloc.c
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	/* allocate memory for function vmem_create_in_region() */
@@ -131,11 +131,11 @@ main(int argc, char *argv[])
 			vmp = vmem_create_in_region(mem_pool,
 				VMEM_MIN_POOL);
 			if (vmp == NULL)
-				FATAL("!vmem_create_in_region");
+				UT_FATAL("!vmem_create_in_region");
 		} else {
 			vmp = vmem_create(dir, VMEM_MIN_POOL);
 			if (vmp == NULL)
-				FATAL("!vmem_create");
+				UT_FATAL("!vmem_create");
 		}
 
 		memset(ptrs, 0, MAX_ALLOCS * sizeof (ptrs[0]));
@@ -145,20 +145,20 @@ main(int argc, char *argv[])
 			ptrs[i] = ptr;
 
 			/* at least one allocation must succeed */
-			ASSERT(i != 0 || ptr != NULL);
+			UT_ASSERT(i != 0 || ptr != NULL);
 			if (ptr == NULL)
 				break;
 
 			/* ptr should be usable */
 			*ptr = test_value;
-			ASSERTeq(*ptr, test_value);
+			UT_ASSERTeq(*ptr, test_value);
 
 			/* check for correct address alignment */
-			ASSERTeq((uintptr_t)(ptr) & (alignment - 1), 0);
+			UT_ASSERTeq((uintptr_t)(ptr) & (alignment - 1), 0);
 
 			/* check that pointer came from mem_pool */
 			if (dir == NULL) {
-				ASSERTrange(ptr, mem_pool, VMEM_MIN_POOL);
+				UT_ASSERTrange(ptr, mem_pool, VMEM_MIN_POOL);
 			}
 		}
 
@@ -172,8 +172,8 @@ main(int argc, char *argv[])
 	}
 
 	/* check memory leaks */
-	ASSERTne(custom_alloc_calls, 0);
-	ASSERTeq(custom_allocs, 0);
+	UT_ASSERTne(custom_alloc_calls, 0);
+	UT_ASSERTeq(custom_allocs, 0);
 
 	DONE(NULL);
 }

--- a/src/test/vmem_calloc/vmem_calloc.c
+++ b/src/test/vmem_calloc/vmem_calloc.c
@@ -51,7 +51,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -60,25 +60,25 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	int *test = vmem_calloc(vmp, 1, sizeof (int));
-	ASSERTne(test, NULL);
+	UT_ASSERTne(test, NULL);
 
 	/* pool_calloc should return zeroed memory */
-	ASSERTeq(*test, 0);
+	UT_ASSERTeq(*test, 0);
 
 	*test = test_value;
-	ASSERTeq(*test, test_value);
+	UT_ASSERTeq(*test, test_value);
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
 	}
 
 	vmem_free(vmp, test);

--- a/src/test/vmem_check/vmem_check.c
+++ b/src/test/vmem_check/vmem_check.c
@@ -50,7 +50,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -59,14 +59,14 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
-	ASSERTeq(1, vmem_check(vmp));
+	UT_ASSERTeq(1, vmem_check(vmp));
 
 	/* create pool in this same memory region */
 	if (dir == NULL) {
@@ -77,22 +77,22 @@ main(int argc, char *argv[])
 			VMEM_MIN_POOL);
 
 		if (vmp2 == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 
 		/* detect memory range collision */
-		ASSERTne(1, vmem_check(vmp));
-		ASSERTne(1, vmem_check(vmp2));
+		UT_ASSERTne(1, vmem_check(vmp));
+		UT_ASSERTne(1, vmem_check(vmp2));
 
 		vmem_delete(vmp2);
 
-		ASSERTne(1, vmem_check(vmp2));
+		UT_ASSERTne(1, vmem_check(vmp2));
 	}
 
 	vmem_delete(vmp);
 
 	/* for vmem_create() memory unmapped after delete pool */
 	if (!dir)
-		ASSERTne(1, vmem_check(vmp));
+		UT_ASSERTne(1, vmem_check(vmp));
 
 	DONE(NULL);
 }

--- a/src/test/vmem_check_allocations/vmem_check_allocations.c
+++ b/src/test/vmem_check_allocations/vmem_check_allocations.c
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	size_t object_size;
@@ -71,14 +71,14 @@ main(int argc, char *argv[])
 			vmp = vmem_create_in_region(mem_pool,
 				VMEM_MIN_POOL);
 			if (vmp == NULL)
-				FATAL("!vmem_create_in_region");
+				UT_FATAL("!vmem_create_in_region");
 		} else {
 			vmp = vmem_create(dir, VMEM_MIN_POOL);
 			if (vmp == NULL)
-				FATAL("!vmem_create");
+				UT_FATAL("!vmem_create");
 
 			/* vmem_create should align pool to 4MB */
-			ASSERTeq(((uintptr_t)vmp) & ((4 << 20) - 1), 0);
+			UT_ASSERTeq(((uintptr_t)vmp) & ((4 << 20) - 1), 0);
 		}
 
 		memset(allocs, 0, sizeof (allocs));
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 
 			/* check that pointer came from mem_pool */
 			if (dir == NULL) {
-				ASSERTrange(allocs[i],
+				UT_ASSERTrange(allocs[i],
 					mem_pool, VMEM_MIN_POOL);
 			}
 
@@ -100,14 +100,14 @@ main(int argc, char *argv[])
 			memset(allocs[i], (char)i, object_size);
 		}
 
-		ASSERT((i > 0) && (i + 1 < TEST_MAX_ALLOCATION_SIZE));
+		UT_ASSERT((i > 0) && (i + 1 < TEST_MAX_ALLOCATION_SIZE));
 
 		/* check for unexpected modifications of the data */
 		for (i = 0; i < TEST_ALLOCS_SIZE && allocs[i] != NULL; ++i) {
 			char *buffer = allocs[i];
 			for (j = 0; j < object_size; ++j) {
 				if (buffer[j] != (char)i)
-					FATAL("Content of data object was "
+					UT_FATAL("Content of data object was "
 						"modified unexpectedly for "
 						"object size: %zu, id: %zu",
 						object_size, j);

--- a/src/test/vmem_check_version/vmem_check_version.c
+++ b/src/test/vmem_check_version/vmem_check_version.c
@@ -41,19 +41,19 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "vmem_check_version");
 
-	OUT("compile-time libvmem version is %d.%d",
+	UT_OUT("compile-time libvmem version is %d.%d",
 			VMEM_MAJOR_VERSION, VMEM_MINOR_VERSION);
 
 	const char *errstr = vmem_check_version(VMEM_MAJOR_VERSION,
 			VMEM_MINOR_VERSION);
 
-	ASSERTinfo(errstr == NULL, errstr);
+	UT_ASSERTinfo(errstr == NULL, errstr);
 
 	errstr = vmem_check_version(VMEM_MAJOR_VERSION + 1, VMEM_MINOR_VERSION);
 
-	ASSERT(errstr != NULL);
+	UT_ASSERT(errstr != NULL);
 
-	OUT("for major version %d, vmem_check_version returned: %s",
+	UT_OUT("for major version %d, vmem_check_version returned: %s",
 			VMEM_MAJOR_VERSION + 1, errstr);
 
 	DONE(NULL);

--- a/src/test/vmem_create/vmem_create.c
+++ b/src/test/vmem_create/vmem_create.c
@@ -46,7 +46,7 @@ VMEM *Vmp;
 static void
 signal_handler(int sig)
 {
-	OUT("signal: %s", strsignal(sig));
+	UT_OUT("signal: %s", strsignal(sig));
 
 	vmem_delete(Vmp);
 
@@ -59,24 +59,24 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_create");
 
 	if (argc < 2 || argc > 3)
-		FATAL("usage: %s directory", argv[0]);
+		UT_FATAL("usage: %s directory", argv[0]);
 
 	Vmp = vmem_create(argv[1], VMEM_MIN_POOL);
 
 	if (Vmp == NULL)
-		OUT("!vmem_create");
+		UT_OUT("!vmem_create");
 	else {
 		struct sigaction v;
 		sigemptyset(&v.sa_mask);
 		v.sa_flags = 0;
 		v.sa_handler = signal_handler;
 		if (sigaction(SIGSEGV, &v, NULL) < 0)
-			FATAL("!sigaction");
+			UT_FATAL("!sigaction");
 
 		/* try to dereference the opaque handle */
 		char x = *(char *)Vmp;
-		OUT("x = %c", x);
+		UT_OUT("x = %c", x);
 	}
 
-	FATAL("no signal received");
+	UT_FATAL("no signal received");
 }

--- a/src/test/vmem_create_error/vmem_create_error.c
+++ b/src/test/vmem_create_error/vmem_create_error.c
@@ -48,22 +48,22 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_create_error");
 
 	if (argc > 1)
-		FATAL("usage: %s", argv[0]);
+		UT_FATAL("usage: %s", argv[0]);
 
 	errno = 0;
 	vmp = vmem_create_in_region(mem_pool, 0);
-	ASSERTeq(vmp, NULL);
-	ASSERTeq(errno, EINVAL);
+	UT_ASSERTeq(vmp, NULL);
+	UT_ASSERTeq(errno, EINVAL);
 
 	errno = 0;
 	vmp = vmem_create("./", 0);
-	ASSERTeq(vmp, NULL);
-	ASSERTeq(errno, EINVAL);
+	UT_ASSERTeq(vmp, NULL);
+	UT_ASSERTeq(errno, EINVAL);
 
 	errno = 0;
 	vmp = vmem_create("invalid dir !@#$%^&*()=", VMEM_MIN_POOL);
-	ASSERTeq(vmp, NULL);
-	ASSERTne(errno, 0);
+	UT_ASSERTeq(vmp, NULL);
+	UT_ASSERTne(errno, 0);
 
 	DONE(NULL);
 }

--- a/src/test/vmem_create_in_region/vmem_create_in_region.c
+++ b/src/test/vmem_create_in_region/vmem_create_in_region.c
@@ -51,7 +51,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_create_in_region");
 
 	if (argc > 1)
-		FATAL("usage: %s", argv[0]);
+		UT_FATAL("usage: %s", argv[0]);
 
 	/* allocate memory for function vmem_create_in_region() */
 	void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
@@ -59,15 +59,15 @@ main(int argc, char *argv[])
 	vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 
 	if (vmp == NULL)
-		FATAL("!vmem_create_in_region");
+		UT_FATAL("!vmem_create_in_region");
 
 	for (i = 0; i < TEST_ALLOCATIONS; ++i) {
 		allocs[i] = vmem_malloc(vmp, sizeof (int));
 
-		ASSERTne(allocs[i], NULL);
+		UT_ASSERTne(allocs[i], NULL);
 
 		/* check that pointer came from mem_pool */
-		ASSERTrange(allocs[i], mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(allocs[i], mem_pool, VMEM_MIN_POOL);
 	}
 
 	for (i = 0; i < TEST_ALLOCATIONS; ++i) {

--- a/src/test/vmem_custom_alloc/vmem_custom_alloc.c
+++ b/src/test/vmem_custom_alloc/vmem_custom_alloc.c
@@ -135,21 +135,21 @@ pool_test(const char *dir)
 
 	if (vmp == NULL) {
 		if (dir == NULL) {
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 		} else {
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 		}
 	}
 
 	char *test = vmem_malloc(vmp, strlen(TEST_STRING_VALUE) + 1);
 
 	if (expect_malloc == 0) {
-		ASSERTeq(test, NULL);
+		UT_ASSERTeq(test, NULL);
 	} else {
 		strcpy(test, TEST_STRING_VALUE);
-		ASSERTeq(strcmp(test, TEST_STRING_VALUE), 0);
+		UT_ASSERTeq(strcmp(test, TEST_STRING_VALUE), 0);
 
-		ASSERT(vmem_malloc_usable_size(vmp, test) > 0);
+		UT_ASSERT(vmem_malloc_usable_size(vmp, test) > 0);
 
 		vmem_free(vmp, test);
 	}
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_custom_alloc");
 
 	if (argc < 2 || argc > 3 || strlen(argv[1]) != 1)
-		FATAL("usage: %s (0-2) [directory]", argv[0]);
+		UT_FATAL("usage: %s (0-2) [directory]", argv[0]);
 
 	switch (argv[1][0]) {
 		case '0': {
@@ -191,7 +191,7 @@ main(int argc, char *argv[])
 			break;
 		}
 		default: {
-			FATAL("usage: %s (0-2) [directory]", argv[0]);
+			UT_FATAL("usage: %s (0-2) [directory]", argv[0]);
 			break;
 		}
 	}
@@ -206,12 +206,12 @@ main(int argc, char *argv[])
 	}
 
 	/* check memory leak in custom allocator */
-	ASSERTeq(custom_allocs, 0);
+	UT_ASSERTeq(custom_allocs, 0);
 
 	if (expect_custom_alloc == 0) {
-		ASSERTeq(custom_alloc_calls, 0);
+		UT_ASSERTeq(custom_alloc_calls, 0);
 	} else {
-		ASSERTne(custom_alloc_calls, 0);
+		UT_ASSERTne(custom_alloc_calls, 0);
 	}
 
 	DONE(NULL);

--- a/src/test/vmem_delete/vmem_delete.c
+++ b/src/test/vmem_delete/vmem_delete.c
@@ -49,7 +49,7 @@ sigjmp_buf Jmp;
 static void
 signal_handler(int sig)
 {
-	OUT("\tsignal: %s", strsignal(sig));
+	UT_OUT("\tsignal: %s", strsignal(sig));
 
 	siglongjmp(Jmp, 1);
 }
@@ -63,18 +63,18 @@ main(int argc, char *argv[])
 	void *ptr;
 
 	if (argc < 2)
-		FATAL("usage: %s op:h|f|m|c|r|a|s|d", argv[0]);
+		UT_FATAL("usage: %s op:h|f|m|c|r|a|s|d", argv[0]);
 
 	/* allocate memory for function vmem_create_in_region() */
 	void *mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp == NULL)
-		FATAL("!vmem_create_in_region");
+		UT_FATAL("!vmem_create_in_region");
 
 	ptr = vmem_malloc(vmp, sizeof (long long int));
 	if (ptr == NULL)
-		ERR("!vmem_malloc");
+		UT_ERR("!vmem_malloc");
 	vmem_delete(vmp);
 
 	/* arrange to catch SEGV */
@@ -91,90 +91,91 @@ main(int argc, char *argv[])
 		/* Scan the character of each argument. */
 		if (strchr("hfmcrasd", argv[arg][0]) == NULL ||
 				argv[arg][1] != '\0')
-			FATAL("op must be one of: h, f, m, c, r, a, s, d");
+			UT_FATAL("op must be one of: h, f, m, c, r, a, s, d");
 
 		switch (argv[arg][0]) {
 		case 'h':
-			OUT("Testing vmem_check...");
+			UT_OUT("Testing vmem_check...");
 			if (!sigsetjmp(Jmp, 1)) {
-				OUT("\tvmem_check returned %i",
+				UT_OUT("\tvmem_check returned %i",
 							vmem_check(vmp));
 			}
 			break;
 
 		case 'f':
-			OUT("Testing vmem_free...");
+			UT_OUT("Testing vmem_free...");
 			if (!sigsetjmp(Jmp, 1)) {
 				vmem_free(vmp, ptr);
-				OUT("\tvmem_free succeeded");
+				UT_OUT("\tvmem_free succeeded");
 			}
 			break;
 
 		case 'm':
-			OUT("Testing vmem_malloc...");
+			UT_OUT("Testing vmem_malloc...");
 			if (!sigsetjmp(Jmp, 1)) {
 				ptr = vmem_malloc(vmp, sizeof (long long int));
 				if (ptr != NULL)
-					OUT("\tvmem_malloc succeeded");
+					UT_OUT("\tvmem_malloc succeeded");
 				else
-					OUT("\tvmem_malloc returned NULL");
+					UT_OUT("\tvmem_malloc returned NULL");
 			}
 			break;
 
 		case 'c':
-			OUT("Testing vmem_calloc...");
+			UT_OUT("Testing vmem_calloc...");
 			if (!sigsetjmp(Jmp, 1)) {
 				ptr = vmem_calloc(vmp, 10, sizeof (int));
 				if (ptr != NULL)
-					OUT("\tvmem_calloc succeeded");
+					UT_OUT("\tvmem_calloc succeeded");
 				else
-					OUT("\tvmem_calloc returned NULL");
+					UT_OUT("\tvmem_calloc returned NULL");
 			}
 			break;
 
 		case 'r':
-			OUT("Testing vmem_realloc...");
+			UT_OUT("Testing vmem_realloc...");
 			if (!sigsetjmp(Jmp, 1)) {
 				ptr = vmem_realloc(vmp, ptr, 128);
 				if (ptr != NULL)
-					OUT("\tvmem_realloc succeeded");
+					UT_OUT("\tvmem_realloc succeeded");
 				else
-					OUT("\tvmem_realloc returned NULL");
+					UT_OUT("\tvmem_realloc returned NULL");
 			}
 			break;
 
 		case 'a':
-			OUT("Testing vmem_aligned_alloc...");
+			UT_OUT("Testing vmem_aligned_alloc...");
 			if (!sigsetjmp(Jmp, 1)) {
 				ptr = vmem_aligned_alloc(vmp, 128, 128);
 				if (ptr != NULL)
-					OUT("\tvmem_aligned_alloc succeeded");
+					UT_OUT("\tvmem_aligned_alloc "
+						"succeeded");
 				else
-					OUT("\tvmem_aligned_alloc"
+					UT_OUT("\tvmem_aligned_alloc"
 							" returned NULL");
 			}
 			break;
 
 		case 's':
-			OUT("Testing vmem_strdup...");
+			UT_OUT("Testing vmem_strdup...");
 			if (!sigsetjmp(Jmp, 1)) {
 				ptr = vmem_strdup(vmp, "Test string");
 				if (ptr != NULL)
-					OUT("\tvmem_strdup succeeded");
+					UT_OUT("\tvmem_strdup succeeded");
 				else
-					OUT("\tvmem_strdup returned NULL");
+					UT_OUT("\tvmem_strdup returned NULL");
 			}
 			break;
 
 		case 'd':
-			OUT("Testing vmem_delete...");
+			UT_OUT("Testing vmem_delete...");
 			if (!sigsetjmp(Jmp, 1)) {
 				vmem_delete(vmp);
 				if (errno != 0)
-					OUT("\tvmem_delete failed: %s",
+					UT_OUT("\tvmem_delete failed: %s",
 						vmem_errormsg());
 				else
-					OUT("\tvmem_delete succeeded");
+					UT_OUT("\tvmem_delete succeeded");
 			}
 			break;
 		}

--- a/src/test/vmem_malloc/vmem_malloc.c
+++ b/src/test/vmem_malloc/vmem_malloc.c
@@ -51,7 +51,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -60,21 +60,21 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	int *test = vmem_malloc(vmp, sizeof (int));
-	ASSERTne(test, NULL);
+	UT_ASSERTne(test, NULL);
 	*test = test_value;
-	ASSERTeq(*test, test_value);
+	UT_ASSERTeq(*test, test_value);
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
 	}
 
 	vmem_free(vmp, test);

--- a/src/test/vmem_malloc_usable_size/vmem_malloc_usable_size.c
+++ b/src/test/vmem_malloc_usable_size/vmem_malloc_usable_size.c
@@ -78,7 +78,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -87,23 +87,23 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
-	ASSERTeq(vmem_malloc_usable_size(vmp, NULL), 0);
+	UT_ASSERTeq(vmem_malloc_usable_size(vmp, NULL), 0);
 
 	for (i = 0; i < (sizeof (Check_sizes) / sizeof (Check_sizes[0])); ++i) {
 		size = Check_sizes[i].size;
 		alloc = vmem_malloc(vmp, size);
-		ASSERTne(alloc, NULL);
+		UT_ASSERTne(alloc, NULL);
 		usable_size = vmem_malloc_usable_size(vmp, alloc);
-		ASSERT(usable_size >= size);
+		UT_ASSERT(usable_size >= size);
 		if (usable_size - size > Check_sizes[i].spacing) {
-			FATAL("Size %zu: spacing %zu is bigger"
+			UT_FATAL("Size %zu: spacing %zu is bigger"
 				"than expected: %zu", size,
 				(usable_size - size), Check_sizes[i].spacing);
 		}
@@ -111,7 +111,7 @@ main(int argc, char *argv[])
 		vmem_free(vmp, alloc);
 	}
 
-	ASSERTeq(vmem_check(vmp), 1);
+	UT_ASSERTeq(vmem_check(vmp), 1);
 
 	vmem_delete(vmp);
 

--- a/src/test/vmem_mix_allocations/vmem_mix_allocations.c
+++ b/src/test/vmem_mix_allocations/vmem_mix_allocations.c
@@ -58,7 +58,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -67,11 +67,11 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	obj_size = MAX_SIZE;
@@ -86,11 +86,11 @@ main(int argc, char *argv[])
 
 		/* check that pointer came from mem_pool */
 		if (dir == NULL)
-			ASSERTrange(ptr[i], mem_pool, POOL_SIZE);
+			UT_ASSERTrange(ptr[i], mem_pool, POOL_SIZE);
 	}
 
 	/* allocate more than half of pool size */
-	ASSERT(sum_alloc * 2 > POOL_SIZE);
+	UT_ASSERT(sum_alloc * 2 > POOL_SIZE);
 
 	while (i > 0)
 		vmem_free(vmp, ptr[--i]);

--- a/src/test/vmem_multiple_pools/vmem_multiple_pools.c
+++ b/src/test/vmem_multiple_pools/vmem_multiple_pools.c
@@ -65,19 +65,19 @@ thread_func(void *arg)
 				pools[pool_id] = vmem_create_in_region(
 					mem_pools[pool_id / 2], VMEM_MIN_POOL);
 				if (pools[pool_id] == NULL)
-					FATAL("!vmem_create_in_region");
+					UT_FATAL("!vmem_create_in_region");
 			} else {
 				/* for odd pool_id, create in file */
 				pools[pool_id] = vmem_create(dir,
 					VMEM_MIN_POOL);
 				if (pools[pool_id] == NULL)
-					FATAL("!vmem_create");
+					UT_FATAL("!vmem_create");
 			}
 
 			void *test = vmem_malloc(pools[pool_id],
 				sizeof (void *));
 
-			ASSERTne(test, NULL);
+			UT_ASSERTne(test, NULL);
 			vmem_free(pools[pool_id], test);
 		}
 	}
@@ -91,13 +91,13 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_multiple_pools");
 
 	if (argc < 4)
-		FATAL("usage: %s directory npools nthreads", argv[0]);
+		UT_FATAL("usage: %s directory npools nthreads", argv[0]);
 
 	dir = argv[1];
 	npools = atoi(argv[2]);
 	int nthreads = atoi(argv[3]);
 
-	OUT("create %d pools in %d thread(s)", npools, nthreads);
+	UT_OUT("create %d pools in %d thread(s)", npools, nthreads);
 
 	const unsigned mem_pools_size = (npools / 2 + npools % 2) * nthreads;
 	mem_pools = MALLOC(mem_pools_size * sizeof (char *));

--- a/src/test/vmem_out_of_memory/vmem_out_of_memory.c
+++ b/src/test/vmem_out_of_memory/vmem_out_of_memory.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -58,11 +58,11 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	/* allocate all memory */
@@ -76,14 +76,14 @@ main(int argc, char *argv[])
 
 		/* check that pointer came from mem_pool */
 		if (dir == NULL) {
-			ASSERTrange(next, mem_pool, VMEM_MIN_POOL);
+			UT_ASSERTrange(next, mem_pool, VMEM_MIN_POOL);
 		}
 
 		*next = prev;
 		prev = next;
 	}
 
-	ASSERTne(prev, NULL);
+	UT_ASSERTne(prev, NULL);
 
 	/* free all allocations */
 	while (prev != NULL) {

--- a/src/test/vmem_pages_purging/vmem_pages_purging.c
+++ b/src/test/vmem_pages_purging/vmem_pages_purging.c
@@ -46,7 +46,7 @@
 static void
 usage(char *appname)
 {
-	FATAL("usage: %s [-z - use calloc] directory ", appname);
+	UT_FATAL("usage: %s [-z - use calloc] directory ", appname);
 }
 
 int
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 
 	vmp = vmem_create(dir, VMEM_MIN_POOL);
 	if (vmp == NULL)
-		FATAL("!vmem_create");
+		UT_FATAL("!vmem_create");
 
 	for (i = 0; i < n; i++) {
 		int *test = NULL;
@@ -89,17 +89,17 @@ main(int argc, char *argv[])
 			test = vmem_calloc(vmp, 1, count * sizeof (int));
 		else
 			test = vmem_malloc(vmp, count * sizeof (int));
-		ASSERTne(test, NULL);
+		UT_ASSERTne(test, NULL);
 
 		if (use_calloc) {
 			/* vmem_calloc should return zeroed memory */
 			for (j = 0; j < count; j++)
-				ASSERTeq(test[j], 0);
+				UT_ASSERTeq(test[j], 0);
 		}
 		for (j = 0; j < count; j++)
 			test[j] = test_value;
 		for (j = 0; j < count; j++)
-			ASSERTeq(test[j], test_value);
+			UT_ASSERTeq(test[j], test_value);
 
 		vmem_free(vmp, test);
 	}

--- a/src/test/vmem_realloc/vmem_realloc.c
+++ b/src/test/vmem_realloc/vmem_realloc.c
@@ -51,7 +51,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -60,33 +60,33 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	int *test = vmem_realloc(vmp, NULL, sizeof (int));
-	ASSERTne(test, NULL);
+	UT_ASSERTne(test, NULL);
 
 	test[0] = test_value;
-	ASSERTeq(test[0], test_value);
+	UT_ASSERTeq(test[0], test_value);
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
 	}
 
 	test = vmem_realloc(vmp, test, sizeof (int) * 10);
-	ASSERTne(test, NULL);
-	ASSERTeq(test[0], test_value);
+	UT_ASSERTne(test, NULL);
+	UT_ASSERTeq(test[0], test_value);
 	test[1] = test_value;
 	test[9] = test_value;
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(test, mem_pool, VMEM_MIN_POOL);
 	}
 
 	vmem_free(vmp, test);

--- a/src/test/vmem_realloc_inplace/vmem_realloc_inplace.c
+++ b/src/test/vmem_realloc_inplace/vmem_realloc_inplace.c
@@ -52,7 +52,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -60,27 +60,27 @@ main(int argc, char *argv[])
 		mem_pool = MMAP_ANON_ALIGNED(POOL_SIZE, 4 << 20);
 		vmp = vmem_create_in_region(mem_pool, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, POOL_SIZE);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	int *test1 = vmem_malloc(vmp, 12 * 1024 * 1024);
-	ASSERTne(test1, NULL);
+	UT_ASSERTne(test1, NULL);
 
 	int *test1r = vmem_realloc(vmp, test1, 6 * 1024 * 1024);
-	ASSERTeq(test1r, test1);
+	UT_ASSERTeq(test1r, test1);
 
 	test1r = vmem_realloc(vmp, test1, 12 * 1024 * 1024);
-	ASSERTeq(test1r, test1);
+	UT_ASSERTeq(test1r, test1);
 
 	test1r = vmem_realloc(vmp, test1, 8 * 1024 * 1024);
-	ASSERTeq(test1r, test1);
+	UT_ASSERTeq(test1r, test1);
 
 	int *test2 = vmem_malloc(vmp, 4 * 1024 * 1024);
-	ASSERTne(test2, NULL);
+	UT_ASSERTne(test2, NULL);
 
 	/* 4MB => 16B */
 	int *test2r = vmem_realloc(vmp, test2, 16);
@@ -90,10 +90,10 @@ main(int argc, char *argv[])
 	 * However, we can return the pointer to the original allocation (not
 	 * resized), which is still better than NULL...
 	 */
-	ASSERTeq(test2r, test2);
+	UT_ASSERTeq(test2r, test2);
 
 	/* ... but the usable size is still 4MB. */
-	ASSERTeq(vmem_malloc_usable_size(vmp, test2r), 4 * 1024 * 1024);
+	UT_ASSERTeq(vmem_malloc_usable_size(vmp, test2r), 4 * 1024 * 1024);
 
 	/* 8MB => 16B */
 	test1r = vmem_realloc(vmp, test1, 16);
@@ -103,13 +103,13 @@ main(int argc, char *argv[])
 	 * releasing some space, which makes it possible to do the actual
 	 * shrinking...
 	 */
-	ASSERTne(test1r, NULL);
-	ASSERTne(test1r, test1);
-	ASSERTeq(vmem_malloc_usable_size(vmp, test1r), 16);
+	UT_ASSERTne(test1r, NULL);
+	UT_ASSERTne(test1r, test1);
+	UT_ASSERTeq(vmem_malloc_usable_size(vmp, test1r), 16);
 
 	/* ... and leaves some memory for new allocations. */
 	int *test3 = vmem_malloc(vmp, 4 * 1024 * 1024);
-	ASSERTne(test3, NULL);
+	UT_ASSERTne(test3, NULL);
 
 	vmem_free(vmp, test1r);
 	vmem_free(vmp, test2r);

--- a/src/test/vmem_stats/vmem_stats.c
+++ b/src/test/vmem_stats/vmem_stats.c
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmem_stats");
 
 	if (argc > 3 || argc < 2) {
-		FATAL("usage: %s 0|1 [opts]", argv[0]);
+		UT_FATAL("usage: %s 0|1 [opts]", argv[0]);
 	} else {
 		expect_custom_alloc = atoi(argv[1]);
 		if (argc > 2)
@@ -123,16 +123,16 @@ main(int argc, char *argv[])
 
 	vmp_unused = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp_unused == NULL)
-		FATAL("!vmem_create_in_region");
+		UT_FATAL("!vmem_create_in_region");
 
 	mem_pool = MMAP_ANON_ALIGNED(VMEM_MIN_POOL, 4 << 20);
 
 	vmp_used = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 	if (vmp_used == NULL)
-		FATAL("!vmem_create_in_region");
+		UT_FATAL("!vmem_create_in_region");
 
 	int *test = vmem_malloc(vmp_used, sizeof (int)*100);
-	ASSERTne(test, NULL);
+	UT_ASSERTne(test, NULL);
 
 	vmem_stats_print(vmp_unused, opts);
 	vmem_stats_print(vmp_used, opts);
@@ -143,11 +143,11 @@ main(int argc, char *argv[])
 	vmem_delete(vmp_used);
 
 	/* check memory leak in custom allocator */
-	ASSERTeq(custom_allocs, 0);
+	UT_ASSERTeq(custom_allocs, 0);
 	if (expect_custom_alloc == 0) {
-		ASSERTeq(custom_alloc_calls, 0);
+		UT_ASSERTeq(custom_alloc_calls, 0);
 	} else {
-		ASSERTne(custom_alloc_calls, 0);
+		UT_ASSERTne(custom_alloc_calls, 0);
 	}
 
 	DONE(NULL);

--- a/src/test/vmem_strdup/vmem_strdup.c
+++ b/src/test/vmem_strdup/vmem_strdup.c
@@ -52,7 +52,7 @@ main(int argc, char *argv[])
 	if (argc == 2) {
 		dir = argv[1];
 	} else if (argc > 2) {
-		FATAL("usage: %s [directory]", argv[0]);
+		UT_FATAL("usage: %s [directory]", argv[0]);
 	}
 
 	if (dir == NULL) {
@@ -61,29 +61,29 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	char *str1 = vmem_strdup(vmp, text);
-	ASSERTne(str1, NULL);
-	ASSERTeq(strcmp(text, str1), 0);
+	UT_ASSERTne(str1, NULL);
+	UT_ASSERTeq(strcmp(text, str1), 0);
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(str1, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(str1, mem_pool, VMEM_MIN_POOL);
 	}
 
 	char *str2 = vmem_strdup(vmp, text_empty);
-	ASSERTne(str2, NULL);
-	ASSERTeq(strcmp(text_empty, str2), 0);
+	UT_ASSERTne(str2, NULL);
+	UT_ASSERTeq(strcmp(text_empty, str2), 0);
 
 	/* check that pointer came from mem_pool */
 	if (dir == NULL) {
-		ASSERTrange(str2, mem_pool, VMEM_MIN_POOL);
+		UT_ASSERTrange(str2, mem_pool, VMEM_MIN_POOL);
 	}
 
 	vmem_free(vmp, str1);

--- a/src/test/vmem_valgrind/vmem_valgrind.c
+++ b/src/test/vmem_valgrind/vmem_valgrind.c
@@ -119,14 +119,14 @@ main(int argc, char *argv[])
 	}
 
 	if (test_case < 0)
-		FATAL("usage: %s <test-number from 0 to 9> [directory]",
+		UT_FATAL("usage: %s <test-number from 0 to 9> [directory]",
 			argv[0]);
 
 	if (test_case < 5) {
-		OUT("use default allocator");
+		UT_OUT("use default allocator");
 		expect_custom_alloc = 0;
 	} else {
-		OUT("use custom alloc functions");
+		UT_OUT("use custom alloc functions");
 		test_case -= 5;
 		expect_custom_alloc = 1;
 		vmem_set_funcs(malloc_custom, free_custom,
@@ -139,38 +139,38 @@ main(int argc, char *argv[])
 
 		vmp = vmem_create_in_region(mem_pool, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create_in_region");
+			UT_FATAL("!vmem_create_in_region");
 	} else {
 		vmp = vmem_create(dir, VMEM_MIN_POOL);
 		if (vmp == NULL)
-			FATAL("!vmem_create");
+			UT_FATAL("!vmem_create");
 	}
 
 	switch (test_case) {
 		case 0: {
-			OUT("remove all allocations and delete pool");
+			UT_OUT("remove all allocations and delete pool");
 			ptr = vmem_malloc(vmp, sizeof (int));
 			if (ptr == NULL)
-				FATAL("!vmem_malloc");
+				UT_FATAL("!vmem_malloc");
 
 			vmem_free(vmp, ptr);
 			vmem_delete(vmp);
 			break;
 		}
 		case 1: {
-			OUT("only remove allocations");
+			UT_OUT("only remove allocations");
 			ptr = vmem_malloc(vmp, sizeof (int));
 			if (ptr == NULL)
-				FATAL("!vmem_malloc");
+				UT_FATAL("!vmem_malloc");
 
 			vmem_free(vmp, ptr);
 			break;
 		}
 		case 2: {
-			OUT("only delete pool");
+			UT_OUT("only delete pool");
 			ptr = vmem_malloc(vmp, sizeof (int));
 			if (ptr == NULL)
-				FATAL("!vmem_malloc");
+				UT_FATAL("!vmem_malloc");
 
 			vmem_delete(vmp);
 
@@ -179,20 +179,20 @@ main(int argc, char *argv[])
 			break;
 		}
 		case 3: {
-			OUT("memory leaks");
+			UT_OUT("memory leaks");
 			ptr = vmem_malloc(vmp, sizeof (int));
 			if (ptr == NULL)
-				FATAL("!vmem_malloc");
+				UT_FATAL("!vmem_malloc");
 
 			/* prevent reporting leaked memory as still reachable */
 			ptr = NULL;
 			break;
 		}
 		case 4: {
-			OUT("heap block overrun");
+			UT_OUT("heap block overrun");
 			ptr = vmem_malloc(vmp, 12 * sizeof (int));
 			if (ptr == NULL)
-				FATAL("!vmem_malloc");
+				UT_FATAL("!vmem_malloc");
 
 			/* heap block overrun */
 			ptr[12] = 7;
@@ -202,17 +202,17 @@ main(int argc, char *argv[])
 			break;
 		}
 		default: {
-			FATAL("!unknown test-number");
+			UT_FATAL("!unknown test-number");
 		}
 	}
 
 	/* check memory leak in custom allocator */
-	ASSERTeq(custom_allocs, 0);
+	UT_ASSERTeq(custom_allocs, 0);
 
 	if (expect_custom_alloc == 0) {
-		ASSERTeq(custom_alloc_calls, 0);
+		UT_ASSERTeq(custom_alloc_calls, 0);
 	} else {
-		ASSERTne(custom_alloc_calls, 0);
+		UT_ASSERTne(custom_alloc_calls, 0);
 	}
 
 	DONE(NULL);

--- a/src/test/vmmalloc_calloc/vmmalloc_calloc.c
+++ b/src/test/vmmalloc_calloc/vmmalloc_calloc.c
@@ -56,15 +56,15 @@ main(int argc, char *argv[])
 
 	for (i = 0; i < n; i++) {
 		ptr = calloc(1, count * sizeof (int));
-		ASSERTne(ptr, NULL);
+		UT_ASSERTne(ptr, NULL);
 
 		/* calloc should return zeroed memory */
 		for (j = 0; j < count; j++)
-			ASSERTeq(ptr[j], 0);
+			UT_ASSERTeq(ptr[j], 0);
 		for (j = 0; j < count; j++)
 			ptr[j] = test_value;
 		for (j = 0; j < count; j++)
-			ASSERTeq(ptr[j], test_value);
+			UT_ASSERTeq(ptr[j], test_value);
 
 		cfree(ptr);
 	}

--- a/src/test/vmmalloc_check_allocations/vmmalloc_check_allocations.c
+++ b/src/test/vmmalloc_check_allocations/vmmalloc_check_allocations.c
@@ -55,7 +55,7 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_check_allocations");
 
 	for (size = MAX_SIZE; size >= MIN_SIZE; size /= 2) {
-		OUT("size %zu", size);
+		UT_OUT("size %zu", size);
 
 		memset(allocs, 0, sizeof (allocs));
 
@@ -71,14 +71,14 @@ main(int argc, char *argv[])
 		}
 
 		/* at least one allocation for each size must succeed */
-		ASSERT(i > 0);
+		UT_ASSERT(i > 0);
 
 		/* check for unexpected modifications of the data */
 		for (i = 0; i < MAX_ALLOCS && allocs[i] != NULL; ++i) {
 			char *buffer = allocs[i];
 			for (j = 0; j < size; ++j) {
 				if (buffer[j] != (char)i)
-					FATAL("Content of data object was "
+					UT_FATAL("Content of data object was "
 						"modified unexpectedly for "
 						"object size: %zu, id: %d",
 						size, j);

--- a/src/test/vmmalloc_fork/vmmalloc_fork.c
+++ b/src/test/vmmalloc_fork/vmmalloc_fork.c
@@ -46,19 +46,19 @@ static void *
 do_test(void *arg)
 {
 	int **bufs = malloc(NBUFS * sizeof (void *));
-	ASSERTne(bufs, NULL);
+	UT_ASSERTne(bufs, NULL);
 
 	size_t *sizes = malloc(NBUFS * sizeof (size_t));
-	ASSERTne(sizes, NULL);
+	UT_ASSERTne(sizes, NULL);
 
 	for (int j = 0; j < NBUFS; j++) {
 		sizes[j] = sizeof (int) + 64 * (rand() % 100);
 		bufs[j] = malloc(sizes[j]);
-		ASSERTne(bufs[j], NULL);
+		UT_ASSERTne(bufs[j], NULL);
 	}
 
 	for (int j = 0; j < NBUFS; j++) {
-		ASSERT(malloc_usable_size(bufs[j]) >= sizes[j]);
+		UT_ASSERT(malloc_usable_size(bufs[j]) >= sizes[j]);
 		free(bufs[j]);
 	}
 
@@ -78,27 +78,27 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_fork");
 
 	if (argc < 4)
-		FATAL("usage: %s [c|e] <nfork> <nthread>", argv[0]);
+		UT_FATAL("usage: %s [c|e] <nfork> <nthread>", argv[0]);
 
 	int nfork = atoi(argv[2]);
 	int nthread = atoi(argv[3]);
-	ASSERT(nfork >= 0);
-	ASSERT(nthread >= 0);
+	UT_ASSERT(nfork >= 0);
+	UT_ASSERT(nthread >= 0);
 
 	pthread_t thread[nthread];
 	int first_child = 0;
 
 	int **bufs = malloc(nfork * NBUFS * sizeof (void *));
-	ASSERTne(bufs, NULL);
+	UT_ASSERTne(bufs, NULL);
 
 	size_t *sizes = malloc(nfork * NBUFS * sizeof (size_t));
-	ASSERTne(sizes, NULL);
+	UT_ASSERTne(sizes, NULL);
 
 	int *pids1 = malloc(nfork * sizeof (pid_t));
-	ASSERTne(pids1, NULL);
+	UT_ASSERTne(pids1, NULL);
 
 	int *pids2 = malloc(nfork * sizeof (pid_t));
-	ASSERTne(pids2, NULL);
+	UT_ASSERTne(pids2, NULL);
 
 	for (int i = 0; i < nfork; i++) {
 		for (int j = 0; j < NBUFS; j++) {
@@ -106,8 +106,8 @@ main(int argc, char *argv[])
 
 			sizes[idx] = sizeof (int) + 64 * (rand() % 100);
 			bufs[idx] = malloc(sizes[idx]);
-			ASSERTne(bufs[idx], NULL);
-			ASSERT(malloc_usable_size(bufs[idx]) >= sizes[idx]);
+			UT_ASSERTne(bufs[idx], NULL);
+			UT_ASSERT(malloc_usable_size(bufs[idx]) >= sizes[idx]);
 		}
 
 		for (int t = 0; t < nthread; ++t) {
@@ -116,13 +116,13 @@ main(int argc, char *argv[])
 
 		pids1[i] = fork();
 		if (pids1[i] == -1)
-			OUT("fork failed");
-		ASSERTne(pids1[i], -1);
+			UT_OUT("fork failed");
+		UT_ASSERTne(pids1[i], -1);
 
 		if (pids1[i] == 0 && argv[1][0] == 'e' && i == nfork - 1) {
 			int fd = open("/dev/null", O_RDWR, S_IWUSR);
 			int res = dup2(fd, 1);
-			ASSERTne(res, -1);
+			UT_ASSERTne(res, -1);
 			close(fd);
 			execl("/bin/echo", "/bin/echo", "Hello world!", NULL);
 		}
@@ -145,7 +145,7 @@ main(int argc, char *argv[])
 
 		for (int ii = 0; ii < i; ii++) {
 			for (int j = 0; j < NBUFS; j++) {
-				ASSERTeq(*bufs[ii * NBUFS + j],
+				UT_ASSERTeq(*bufs[ii * NBUFS + j],
 					((unsigned)pids2[ii] << 16) + j);
 			}
 		}
@@ -154,8 +154,8 @@ main(int argc, char *argv[])
 	for (int i = first_child; i < nfork; i++) {
 		int status;
 		waitpid(pids1[i], &status, 0);
-		ASSERT(WIFEXITED(status));
-		ASSERTeq(WEXITSTATUS(status), 0);
+		UT_ASSERT(WIFEXITED(status));
+		UT_ASSERTeq(WEXITSTATUS(status), 0);
 	}
 
 	free(pids1);
@@ -165,7 +165,7 @@ main(int argc, char *argv[])
 		for (int j = 0; j < NBUFS; j++) {
 			int idx = i * NBUFS + j;
 
-			ASSERT(malloc_usable_size(bufs[idx]) >= sizes[idx]);
+			UT_ASSERT(malloc_usable_size(bufs[idx]) >= sizes[idx]);
 			free(bufs[idx]);
 		}
 	}

--- a/src/test/vmmalloc_init/vmmalloc_init.c
+++ b/src/test/vmmalloc_init/vmmalloc_init.c
@@ -51,29 +51,29 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_init");
 
 	if (argc > 2)
-		FATAL("usage: %s [d|l]", argv[0]);
+		UT_FATAL("usage: %s [d|l]", argv[0]);
 
 	if (argc == 2) {
 		switch (argv[1][0]) {
 		case 'd':
-			OUT("deep binding");
+			UT_OUT("deep binding");
 			handle = dlopen("./libtest.so",
 				RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
 			break;
 		case 'l':
-			OUT("lazy binding");
+			UT_OUT("lazy binding");
 			handle = dlopen("./libtest.so", RTLD_LAZY);
 			break;
 		default:
-			FATAL("usage: %s [d|l]", argv[0]);
+			UT_FATAL("usage: %s [d|l]", argv[0]);
 		}
 
 		if (handle == NULL)
-			OUT("dlopen: %s", dlerror());
-		ASSERTne(handle, NULL);
+			UT_OUT("dlopen: %s", dlerror());
+		UT_ASSERTne(handle, NULL);
 
 		Falloc = dlsym(handle, "falloc");
-		ASSERTne(Falloc, NULL);
+		UT_ASSERTne(Falloc, NULL);
 	}
 
 	ptr = malloc(4321);

--- a/src/test/vmmalloc_malloc/vmmalloc_malloc.c
+++ b/src/test/vmmalloc_malloc/vmmalloc_malloc.c
@@ -61,17 +61,17 @@ main(int argc, char *argv[])
 			continue;
 
 		*ptr[i] = test_value;
-		ASSERTeq(*ptr[i], test_value);
+		UT_ASSERTeq(*ptr[i], test_value);
 
 		sum_alloc += size;
 		i++;
 	}
 
 	/* at least one allocation for each size must succeed */
-	ASSERTeq(size, MIN_SIZE);
+	UT_ASSERTeq(size, MIN_SIZE);
 
 	/* allocate more than half of pool size */
-	ASSERT(sum_alloc * 2 > VMEM_MIN_POOL);
+	UT_ASSERT(sum_alloc * 2 > VMEM_MIN_POOL);
 
 	while (i > 0)
 		free(ptr[--i]);

--- a/src/test/vmmalloc_malloc_hooks/vmmalloc_malloc_hooks.c
+++ b/src/test/vmmalloc_malloc_hooks/vmmalloc_malloc_hooks.c
@@ -138,7 +138,7 @@ main(int argc, char *argv[])
 	ptr = memalign(16, 4321);
 	free(ptr);
 
-	OUT("malloc %d realloc %d memalign %d free %d",
+	UT_OUT("malloc %d realloc %d memalign %d free %d",
 			malloc_cnt, realloc_cnt, memalign_cnt, free_cnt);
 
 	DONE(NULL);

--- a/src/test/vmmalloc_malloc_usable_size/vmmalloc_malloc_usable_size.c
+++ b/src/test/vmmalloc_malloc_usable_size/vmmalloc_malloc_usable_size.c
@@ -72,26 +72,26 @@ main(int argc, char *argv[])
 
 	START(argc, argv, "vmmalloc_malloc_usable_size");
 
-	ASSERTeq(malloc_usable_size(NULL), 0);
+	UT_ASSERTeq(malloc_usable_size(NULL), 0);
 
 	for (i = 0; i < (sizeof (Check_sizes) / sizeof (Check_sizes[0])); ++i) {
 		size = Check_sizes[i].size;
-		OUT("size %zu", size);
+		UT_OUT("size %zu", size);
 
 		ptr = malloc(size);
-		ASSERTne(ptr, NULL);
+		UT_ASSERTne(ptr, NULL);
 
 		usable_size = malloc_usable_size(ptr);
-		ASSERT(usable_size >= size);
+		UT_ASSERT(usable_size >= size);
 
 		if (usable_size - size > Check_sizes[i].spacing) {
-			FATAL("Size %zu: spacing %zu is bigger"
+			UT_FATAL("Size %zu: spacing %zu is bigger"
 				"than expected: %zu", size,
 				(usable_size - size), Check_sizes[i].spacing);
 		}
 
 		memset(ptr, 0xEE, usable_size);
-		ASSERTeq(*(unsigned char *)ptr, 0xEE);
+		UT_ASSERTeq(*(unsigned char *)ptr, 0xEE);
 
 		free(ptr);
 	}

--- a/src/test/vmmalloc_memalign/vmmalloc_memalign.c
+++ b/src/test/vmmalloc_memalign/vmmalloc_memalign.c
@@ -64,7 +64,7 @@ posix_memalign_wrap(size_t alignment, size_t size)
 	if (err) {
 		ptr = NULL;
 		if (err != ENOMEM)
-			OUT("posix_memalign: %s", strerror(err));
+			UT_OUT("posix_memalign: %s", strerror(err));
 	}
 	return ptr;
 }
@@ -79,28 +79,28 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_memalign");
 
 	if (argc != 2)
-		FATAL(USAGE, argv[0]);
+		UT_FATAL(USAGE, argv[0]);
 
 	switch (argv[1][0]) {
 	case 'm':
-		OUT("testing memalign");
+		UT_OUT("testing memalign");
 		Aalloc = memalign;
 		break;
 	case 'p':
-		OUT("testing posix_memalign");
+		UT_OUT("testing posix_memalign");
 		Aalloc = posix_memalign_wrap;
 		break;
 	case 'a':
-		OUT("testing aligned_alloc");
+		UT_OUT("testing aligned_alloc");
 		Aalloc = aligned_alloc;
 		break;
 	default:
-		FATAL(USAGE, argv[0]);
+		UT_FATAL(USAGE, argv[0]);
 	}
 
 	/* test with address alignment from 2B to 4MB */
 	for (alignment = MAX_ALIGN; alignment >= MIN_ALIGN; alignment /= 2) {
-		OUT("alignment %zu", alignment);
+		UT_OUT("alignment %zu", alignment);
 
 		memset(allocs, 0, sizeof (allocs));
 
@@ -112,14 +112,15 @@ main(int argc, char *argv[])
 
 			/* ptr should be usable */
 			*allocs[i] = test_value;
-			ASSERTeq(*allocs[i], test_value);
+			UT_ASSERTeq(*allocs[i], test_value);
 
 			/* check for correct address alignment */
-			ASSERTeq((uintptr_t)(allocs[i]) & (alignment - 1), 0);
+			UT_ASSERTeq(
+				(uintptr_t)(allocs[i]) & (alignment - 1), 0);
 		}
 
 		/* at least one allocation must succeed */
-		ASSERT(i > 0);
+		UT_ASSERT(i > 0);
 
 		for (i = 0; i < MAX_ALLOCS && allocs[i] != NULL; ++i)
 			free(allocs[i]);

--- a/src/test/vmmalloc_out_of_memory/vmmalloc_out_of_memory.c
+++ b/src/test/vmmalloc_out_of_memory/vmmalloc_out_of_memory.c
@@ -56,7 +56,7 @@ main(int argc, char *argv[])
 		prev = next;
 	}
 
-	ASSERTne(prev, NULL);
+	UT_ASSERTne(prev, NULL);
 
 	/* free all allocations */
 	while (prev != NULL) {

--- a/src/test/vmmalloc_realloc/vmmalloc_realloc.c
+++ b/src/test/vmmalloc_realloc/vmmalloc_realloc.c
@@ -46,14 +46,14 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_realloc");
 
 	int *test = realloc(NULL, sizeof (int));
-	ASSERTne(test, NULL);
+	UT_ASSERTne(test, NULL);
 
 	test[0] = test_value;
-	ASSERTeq(test[0], test_value);
+	UT_ASSERTeq(test[0], test_value);
 
 	test = realloc(test, sizeof (int) * 10);
-	ASSERTne(test, NULL);
-	ASSERTeq(test[0], test_value);
+	UT_ASSERTne(test, NULL);
+	UT_ASSERTeq(test[0], test_value);
 	test[1] = test_value;
 	test[9] = test_value;
 

--- a/src/test/vmmalloc_valgrind/vmmalloc_valgrind.c
+++ b/src/test/vmmalloc_valgrind/vmmalloc_valgrind.c
@@ -49,34 +49,34 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_valgrind");
 
 	if ((argc != 2) || (test_case = atoi(argv[1])) > 2)
-		FATAL("usage: %s <test-number from 0 to 2>",
+		UT_FATAL("usage: %s <test-number from 0 to 2>",
 			argv[0]);
 
 	switch (test_case) {
 		case 0: {
-			OUT("remove all allocations");
+			UT_OUT("remove all allocations");
 			ptr = malloc(sizeof (int));
 			if (ptr == NULL)
-				FATAL("!malloc");
+				UT_FATAL("!malloc");
 
 			free(ptr);
 			break;
 		}
 		case 1: {
-			OUT("memory leaks");
+			UT_OUT("memory leaks");
 			ptr = malloc(sizeof (int));
 			if (ptr == NULL)
-				FATAL("!malloc");
+				UT_FATAL("!malloc");
 
 			/* prevent reporting leaked memory as still reachable */
 			ptr = NULL;
 			break;
 		}
 		case 2: {
-			OUT("heap block overrun");
+			UT_OUT("heap block overrun");
 			ptr = malloc(12 * sizeof (int));
 			if (ptr == NULL)
-				FATAL("!malloc");
+				UT_FATAL("!malloc");
 
 			/* heap block overrun */
 			ptr[12] = 7;
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
 			break;
 		}
 		default: {
-			FATAL("!unknown test-number");
+			UT_FATAL("!unknown test-number");
 		}
 	}
 

--- a/src/test/vmmalloc_valloc/vmmalloc_valloc.c
+++ b/src/test/vmmalloc_valloc/vmmalloc_valloc.c
@@ -55,40 +55,40 @@ main(int argc, char *argv[])
 	START(argc, argv, "vmmalloc_valloc");
 
 	if (argc != 2)
-		FATAL("usage: %s [v|p]", argv[0]);
+		UT_FATAL("usage: %s [v|p]", argv[0]);
 
 	switch (argv[1][0]) {
 	case 'v':
-		OUT("testing valloc");
+		UT_OUT("testing valloc");
 		Valloc = valloc;
 		break;
 	case 'p':
-		OUT("testing pvalloc");
+		UT_OUT("testing pvalloc");
 		Valloc = pvalloc;
 		break;
 	default:
-		FATAL("usage: %s [v|p]", argv[0]);
+		UT_FATAL("usage: %s [v|p]", argv[0]);
 	}
 
 	for (size = min_size; size < max_size; size *= 2) {
 		ptr = Valloc(size);
 
 		/* at least one allocation must succeed */
-		ASSERT(ptr != NULL);
+		UT_ASSERT(ptr != NULL);
 		if (ptr == NULL)
 			break;
 
 		/* ptr should be usable */
 		*ptr = test_value;
-		ASSERTeq(*ptr, test_value);
+		UT_ASSERTeq(*ptr, test_value);
 
 		/* check for correct address alignment */
-		ASSERTeq((uintptr_t)(ptr) & (pagesize - 1), 0);
+		UT_ASSERTeq((uintptr_t)(ptr) & (pagesize - 1), 0);
 
 		if (Valloc == pvalloc) {
 			/* check for correct allocation size */
 			size_t usable = malloc_usable_size(ptr);
-			ASSERTeq(usable, roundup(size, pagesize));
+			UT_ASSERTeq(usable, roundup(size, pagesize));
 		}
 
 		free(ptr);


### PR DESCRIPTION
Add UT_ prefix to some of macros from unittest.h to make it possible to
include both unittest.h and out.h header files. This is required bu
some tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/707)
<!-- Reviewable:end -->
