### PR TITLE
obj: fix nasty tx corruption bug

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -685,14 +685,12 @@ tx_post_commit_set(PMEMobjpool *pop, struct lane_tx_layout *layout)
 #endif
 
 	struct list_head *head = &layout->undo_set_cache;
-	PMEMoid obj = head->pe_first; /* first cache object */
+	PMEMoid obj;
+	PMEMoid last = oob_list_last(pop, head);
 
 	/* clear all the undo log caches except for the last one */
-	while (head->pe_first.off != oob_list_last(pop, head).off) {
-		obj = head->pe_first;
-
+	while ((obj = head->pe_first).off != last.off)
 		list_remove_free_oob(pop, head, &obj);
-	}
 
 	if (!OID_IS_NULL(obj)) {
 		/* zero the cache, will be useful later on */


### PR DESCRIPTION
When one transaction issued more than 127 small (less than 32 bytes)
tx_adds and committed, tx_abort in the next transaction could restore
some memory from the 1st transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/708)
<!-- Reviewable:end -->
