### PR TITLE
obj: report timedlock error in obj_sync unit test

### DIFF
--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -265,7 +265,8 @@ timed_check_worker(void *arg)
 		UT_ASSERT(t_diff.tv_sec * NANO_PER_ONE +
 				t_diff.tv_nsec >= TIMEOUT);
 	} else {
-		UT_ERR("pmemobj_mutex_timedlock");
+		errno = ret;
+		UT_ERR("!pmemobj_mutex_timedlock");
 	}
 
 	return NULL;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/711)
<!-- Reviewable:end -->
