### PR TITLE
obj: fix range cache size to match alloc class

### DIFF
--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -55,8 +55,13 @@
 #define	OBJ_LANES_OFFSET	8192	/* lanes offset (8kB) */
 #define	OBJ_NLANES		1024	/* number of lanes */
 
+/*
+ * To make sure that the range cache does not needlessly waste memory in the
+ * allocator, the values set here must very closesly match allocation class
+ * sizes. A good value to aim for is multiples of 1024 bytes.
+ */
 #define	MAX_CACHED_RANGE_SIZE 32
-#define	MAX_CACHED_RANGES 127 /* calculated to be exactly 8192 bytes */
+#define	MAX_CACHED_RANGES 169
 
 #define	OBJ_OOB_SIZE		(sizeof (struct oob_header))
 #define	OBJ_OFF_TO_PTR(pop, off) ((void *)((uintptr_t)(pop) + (off)))


### PR DESCRIPTION
For quite some time the range cache structure size was mis-aligned
with the internal heap allocation class sizes and caused some
unnecessary fragmentation to occur.

pmem/issues#159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/714)
<!-- Reviewable:end -->
