### PR TITLE
Allow "make install prefix=<...> to work without error"

### DIFF
--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -71,7 +71,8 @@ LDFLAGS += -Wl,-z,relro -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS) 
 TOOLSDIR=$(prefix)/bin
 TARGET_DIR=$(DESTDIR)$(TOOLSDIR)
 BASH_COMP_FILES ?=
-BASH_COMP_DIR =$(DESTDIR)/etc/bash_completion.d/
+BASH_COMP_ROOT_DIR=$(DESTDIR)$(prefix)
+BASH_COMP_DIR =$(BASH_COMP_ROOT_DIR)/etc/bash_completion.d/
 CSTYLE=$(TOP)/utils/cstyle
 
 TARGET_STATIC_NONDEBUG=$(TARGET).static-nondebug


### PR DESCRIPTION
When running "make install prefix=<...>" the install would fail trying to install the bash completion files to /etc, even though a prefix was specified ("make install DESTDIR=<...>" worked fine).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/718)
<!-- Reviewable:end -->
