### PR TITLE
obj: fix heap not properly using the last chunk

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -184,7 +184,7 @@ get_zone_size_idx(uint32_t zone_id, unsigned max_zone, size_t heap_size)
 {
 	ASSERT(max_zone > 0);
 	if (zone_id < max_zone - 1)
-		return MAX_CHUNK - 1;
+		return MAX_CHUNK;
 
 	ASSERT(heap_size >= zone_id * ZONE_MAX_SIZE);
 	size_t zone_raw_size = heap_size - zone_id * ZONE_MAX_SIZE;


### PR DESCRIPTION
The function to calculate zone size index didn't do it properly for
all zones except for the last one, this resulted in an off-by-one
error in heap structures where the zone was one chunk smaller than
it really was.

pmem/issues#137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/724)
<!-- Reviewable:end -->
