### PR TITLE
test: fix require binary in obj_cpp_timed_mtx test

### DIFF
--- a/src/test/obj_cpp_timed_mtx/TEST0
+++ b/src/test/obj_cpp_timed_mtx/TEST0
@@ -38,7 +38,7 @@ export UNITTEST_NUM=0
 . ../unittest/unittest.sh
 
 require_cxx11
-require_binary
+require_binary ./obj_cpp_timed_mtx$EXESUFFIX
 
 setup
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -810,7 +810,11 @@ function require_no_asan() {
 # In case of conditional compilation, skip this test.
 #
 function require_binary() {
-	if [ ! -x $1 ]; then
+	if [ -z "$1" ]; then
+		echo "require_binary: error: binary not provided" >&2
+		exit 1
+	fi
+	if [ ! -x "$1" ]; then
 		echo "$UNITTEST_NAME: SKIP no binary found"
 		exit 0
 	fi


### PR DESCRIPTION
... it was missing the binary name. Additionally add reporting an error
if binary is not provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/730)
<!-- Reviewable:end -->
