### PR TITLE
common: substitute "off_t" with "long long/size_t"

### DIFF
--- a/doc/libpmemblk.3
+++ b/doc/libpmemblk.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemblk.3
 .\"
-.TH libpmemblk 3 "pmemblk API version 1.0.0" "NVM Library"
+.TH libpmemblk 3 "pmemblk API version 1.0.1" "NVM Library"
 .SH NAME
 libpmemblk \- persistent memory resident array of blocks
 .SH SYNOPSIS
@@ -54,10 +54,10 @@ libpmemblk \- persistent memory resident array of blocks
 .BI "void pmemblk_close(PMEMblkpool *" pbp );
 .BI "size_t pmemblk_bsize(PMEMblkpool *" pbp );
 .BI "size_t pmemblk_nblock(PMEMblkpool *" pbp );
-.BI "int pmemblk_read(PMEMblkpool *" pbp ", void *" buf ", off_t " blockno );
-.BI "int pmemblk_write(PMEMblkpool *" pbp ", const void *" buf ", off_t " blockno );
-.BI "int pmemblk_set_zero(PMEMblkpool *" pbp ", off_t " blockno );
-.BI "int pmemblk_set_error(PMEMblkpool *" pbp ", off_t " blockno );
+.BI "int pmemblk_read(PMEMblkpool *" pbp ", void *" buf ", size_t " blockno );
+.BI "int pmemblk_write(PMEMblkpool *" pbp ", const void *" buf ", size_t " blockno );
+.BI "int pmemblk_set_zero(PMEMblkpool *" pbp ", size_t " blockno );
+.BI "int pmemblk_set_error(PMEMblkpool *" pbp ", size_t " blockno );
 .sp
 .B Library API versioning:
 .sp
@@ -377,7 +377,7 @@ must be a block memory pool handle as returned by
 or
 .BR pmemblk_create ().
 .PP
-.BI "int pmemblk_read(PMEMblkpool *" pbp ", void *" buf ", off_t " blockno );
+.BI "int pmemblk_read(PMEMblkpool *" pbp ", void *" buf ", size_t " blockno );
 .IP
 The
 .BR pmemblk_read ()
@@ -392,7 +392,7 @@ Reading a block that has never been written by
 .BR pmemblk_write ()
 will return a block of zeroes.
 .PP
-.BI "int pmemblk_write(PMEMblkpool *" pbp ", const void *" buf ", off_t " blockno );
+.BI "int pmemblk_write(PMEMblkpool *" pbp ", const void *" buf ", size_t " blockno );
 .IP
 The
 .BR pmemblk_write ()
@@ -408,7 +408,7 @@ the block is guaranteed to contain either the old data or the new data,
 never a mixture of both.
 On success, zero is returned.  On error, -1 is returned and errno is set.
 .PP
-.BI "int pmemblk_set_zero(PMEMblkpool *" pbp ", off_t " blockno );
+.BI "int pmemblk_set_zero(PMEMblkpool *" pbp ", size_t " blockno );
 .IP
 The
 .BR pmemblk_set_zero ()
@@ -422,7 +422,7 @@ since
 uses metadata to indicate the block should read back as zero.
 On success, zero is returned.  On error, -1 is returned and errno is set.
 .PP
-.BI "int pmemblk_set_error(PMEMblkpool *" pbp ", off_t " blockno );
+.BI "int pmemblk_set_error(PMEMblkpool *" pbp ", size_t " blockno );
 .IP
 The
 .BR pmemblk_set_error ()
@@ -636,7 +636,7 @@ API is used.
 #include <libpmemblk.h>
 
 /* size of the pmemblk pool -- 1 GB */
-#define POOL_SIZE ((off_t)(1 << 30))
+#define POOL_SIZE ((size_t)(1 << 30))
 
 /* size of each element in the pmem pool */
 #define ELEMENT_SIZE 1024

--- a/doc/libpmemlog.3
+++ b/doc/libpmemlog.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemlog.3
 .\"
-.TH libpmemlog 3 "pmemlog API version 1.0.0" "NVM Library"
+.TH libpmemlog 3 "pmemlog API version 1.0.1" "NVM Library"
 .SH NAME
 libpmemlog \- persistent memory resident log file
 .SH SYNOPSIS
@@ -56,7 +56,7 @@ libpmemlog \- persistent memory resident log file
 .BI "int pmemlog_append(PMEMlogpool *" plp ", const void *" buf ", size_t " count );
 .BI "int pmemlog_appendv(PMEMlogpool *" plp ,
 .BI "    const struct iovec *" iov ", int " iovcnt );
-.BI "off_t pmemlog_tell(PMEMlogpool *" plp );
+.BI "long long pmemlog_tell(PMEMlogpool *" plp );
 .BI "void pmemlog_rewind(PMEMlogpool *" plp );
 .BI "void pmemlog_walk(PMEMlogpool *" plp ", size_t " chunksize ,
 .BI "    int (*" process_chunk ")(const void *" buf ", size_t " len ", void *" arg ),
@@ -380,7 +380,7 @@ are not practical in the library's implementation of
 No attempt is made to detect NULL or incorrect pointers,
 or illegal count values, for example.
 .PP
-.BI "off_t pmemlog_tell(PMEMlogpool *" plp );
+.BI "long long pmemlog_tell(PMEMlogpool *" plp );
 .IP
 The
 .BR pmemlog_tell ()
@@ -633,7 +633,7 @@ API is used.
 #include <libpmemlog.h>
 
 /* size of the pmemlog pool -- 1 GB */
-#define POOL_SIZE ((off_t)(1 << 30))
+#define POOL_SIZE ((size_t)(1 << 30))
 
 /*
  * printit -- log processing callback for use with pmemlog_walk()

--- a/src/examples/libpmemblk/assetdb/asset_checkin.c
+++ b/src/examples/libpmemblk/assetdb/asset_checkin.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	}
 
 	/* read a required element in */
-	if (pmemblk_read(pbp, &asset, (off_t)assetid) < 0) {
+	if (pmemblk_read(pbp, &asset, assetid) < 0) {
 		perror("pmemblk_read");
 		exit(1);
 	}
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
 	asset.user[0] = '\0';
 	asset.time = 0;
 
-	if (pmemblk_write(pbp, &asset, (off_t)assetid) < 0) {
+	if (pmemblk_write(pbp, &asset, assetid) < 0) {
 		perror("pmemblk_write");
 		exit(1);
 	}

--- a/src/examples/libpmemblk/assetdb/asset_checkout.c
+++ b/src/examples/libpmemblk/assetdb/asset_checkout.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	}
 
 	/* read a required element in */
-	if (pmemblk_read(pbp, &asset, (off_t)assetid) < 0) {
+	if (pmemblk_read(pbp, &asset, assetid) < 0) {
 		perror("pmemblk_read");
 		exit(1);
 	}

--- a/src/examples/libpmemblk/assetdb/asset_list.c
+++ b/src/examples/libpmemblk/assetdb/asset_list.c
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
 
 	/* print out all the elements that contain assets data */
 	for (assetid = 0; assetid < nelements; ++assetid) {
-		if (pmemblk_read(pbp, &asset, (off_t)assetid) < 0) {
+		if (pmemblk_read(pbp, &asset, assetid) < 0) {
 			perror("pmemblk_read");
 			exit(1);
 		}

--- a/src/examples/libpmemblk/assetdb/asset_load.c
+++ b/src/examples/libpmemblk/assetdb/asset_load.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
 		strncpy(asset.name, line, ASSET_NAME_MAX - 1);
 		asset.name[ASSET_NAME_MAX - 1] = '\0';
 
-		if (pmemblk_write(pbp, &asset, (off_t)assetid) < 0) {
+		if (pmemblk_write(pbp, &asset, assetid) < 0) {
 			perror("pmemblk_write");
 			exit(1);
 		}

--- a/src/examples/libpmemblk/manpage.c
+++ b/src/examples/libpmemblk/manpage.c
@@ -43,7 +43,7 @@
 #include <libpmemblk.h>
 
 /* size of the pmemblk pool -- 1 GB */
-#define	POOL_SIZE ((off_t)(1 << 30))
+#define	POOL_SIZE ((size_t)(1 << 30))
 
 /* size of each element in the pmem pool */
 #define	ELEMENT_SIZE 1024

--- a/src/examples/libpmemlog/manpage.c
+++ b/src/examples/libpmemlog/manpage.c
@@ -43,7 +43,7 @@
 #include <libpmemlog.h>
 
 /* size of the pmemlog pool -- 1 GB */
-#define	POOL_SIZE ((off_t)(1 << 30))
+#define	POOL_SIZE ((size_t)(1 << 30))
 
 /*
  * printit -- log processing callback for use with pmemlog_walk()

--- a/src/examples/libpmemobj/manpage.c
+++ b/src/examples/libpmemobj/manpage.c
@@ -44,7 +44,7 @@
 #include <libpmemobj.h>
 
 /* size of the pmemobj pool -- 1 GB */
-#define	POOL_SIZE ((off_t)(1 << 30))
+#define	POOL_SIZE ((size_t)(1 << 30))
 
 /* name of our layout in the pool */
 #define	LAYOUT_NAME "example_layout"

--- a/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
+++ b/src/examples/libpmemobj/pmemblk/obj_pmemblk.c
@@ -179,7 +179,7 @@ pmemblk_check(const char *path, size_t bsize)
  * pmemblk_set_error -- not available in this implementation
  */
 int
-pmemblk_set_error(PMEMblkpool *pbp, off_t blockno)
+pmemblk_set_error(PMEMblkpool *pbp, size_t blockno)
 {
 	/* N/A */
 	return 0;
@@ -200,7 +200,7 @@ pmemblk_nblock(PMEMblkpool *pbp)
  * pmemblk_read -- read a block in a block memory pool
  */
 int
-pmemblk_read(PMEMblkpool *pbp, void *buf, off_t blockno)
+pmemblk_read(PMEMblkpool *pbp, void *buf, size_t blockno)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)pbp;
 	TOID(struct base) bp;
@@ -222,7 +222,7 @@ pmemblk_read(PMEMblkpool *pbp, void *buf, off_t blockno)
  * pmemblk_write -- write a block (atomically) in a block memory pool
  */
 int
-pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno)
+pmemblk_write(PMEMblkpool *pbp, const void *buf, size_t blockno)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)pbp;
 	int retval = 0;
@@ -250,7 +250,7 @@ pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno)
  * pmemblk_set_zero -- zero a block in a block memory pool
  */
 int
-pmemblk_set_zero(PMEMblkpool *pbp, off_t blockno)
+pmemblk_set_zero(PMEMblkpool *pbp, size_t blockno)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)pbp;
 	int retval = 0;

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog.c
@@ -239,7 +239,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 /*
  * pmemlog_tell -- returns the current write point for the log
  */
-off_t
+long long
 pmemlog_tell(PMEMlogpool *plp)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
@@ -249,7 +249,7 @@ pmemlog_tell(PMEMlogpool *plp)
 	if (pmemobj_rwlock_rdlock(pop, &bp->rwlock) != 0)
 		return 0;
 
-	off_t bytes_written = bp->bytes_written;
+	long long bytes_written = bp->bytes_written;
 
 	pmemobj_rwlock_unlock(pop, &bp->rwlock);
 
@@ -431,7 +431,7 @@ main(int argc, char *argv[])
 				break;
 			}
 			case 't': {
-				printf("offset: %ld\n", pmemlog_tell(plp));
+				printf("offset: %lld\n", pmemlog_tell(plp));
 				break;
 			}
 			default: {

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_macros.c
@@ -219,7 +219,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 /*
  * pmemlog_tell -- returns the current write point for the log
  */
-off_t
+long long
 pmemlog_tell(PMEMlogpool *plp)
 {
 	TOID(struct base) bp;
@@ -394,7 +394,7 @@ main(int argc, char *argv[])
 				break;
 			}
 			case 't': {
-				printf("offset: %ld\n", pmemlog_tell(plp));
+				printf("offset: %lld\n", pmemlog_tell(plp));
 				break;
 			}
 			default: {

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_minimal.c
@@ -176,7 +176,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 /*
  * pmemlog_tell -- not available in this implementation
  */
-off_t
+long long
 pmemlog_tell(PMEMlogpool *plp)
 {
 	/* N/A */
@@ -331,7 +331,7 @@ main(int argc, char *argv[])
 				break;
 			}
 			case 't': {
-				printf("offset: %ld\n", pmemlog_tell(plp));
+				printf("offset: %lld\n", pmemlog_tell(plp));
 				break;
 			}
 			default: {

--- a/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
+++ b/src/examples/libpmemobj/pmemlog/obj_pmemlog_simple.c
@@ -71,7 +71,7 @@ POBJ_LAYOUT_END(obj_pmemlog_simple);
 
 /* log entry header */
 struct log_hdr {
-	off_t write_offset;	/* data write offset */
+	uint64_t write_offset;	/* data write offset */
 	size_t data_size;	/* size available for data */
 };
 
@@ -264,7 +264,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 /*
  * pmemlog_tell -- return current write point in a log memory pool
  */
-off_t
+long long
 pmemlog_tell(PMEMlogpool *plp)
 {
 	PMEMobjpool *pop = (PMEMobjpool *)plp;
@@ -447,7 +447,7 @@ main(int argc, char *argv[])
 				break;
 			}
 			case 't': {
-				printf("offset: %ld\n", pmemlog_tell(plp));
+				printf("offset: %lld\n", pmemlog_tell(plp));
 				break;
 			}
 			default: {

--- a/src/include/libpmemblk.h
+++ b/src/include/libpmemblk.h
@@ -78,10 +78,10 @@ void pmemblk_close(PMEMblkpool *pbp);
 int pmemblk_check(const char *path, size_t bsize);
 size_t pmemblk_bsize(PMEMblkpool *pbp);
 size_t pmemblk_nblock(PMEMblkpool *pbp);
-int pmemblk_read(PMEMblkpool *pbp, void *buf, off_t blockno);
-int pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno);
-int pmemblk_set_zero(PMEMblkpool *pbp, off_t blockno);
-int pmemblk_set_error(PMEMblkpool *pbp, off_t blockno);
+int pmemblk_read(PMEMblkpool *pbp, void *buf, size_t blockno);
+int pmemblk_write(PMEMblkpool *pbp, const void *buf, size_t blockno);
+int pmemblk_set_zero(PMEMblkpool *pbp, size_t blockno);
+int pmemblk_set_error(PMEMblkpool *pbp, size_t blockno);
 
 /*
  * Passing NULL to pmemblk_set_funcs() tells libpmemblk to continue to use the

--- a/src/include/libpmemlog.h
+++ b/src/include/libpmemlog.h
@@ -80,7 +80,7 @@ int pmemlog_check(const char *path);
 size_t pmemlog_nbyte(PMEMlogpool *plp);
 int pmemlog_append(PMEMlogpool *plp, const void *buf, size_t count);
 int pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt);
-off_t pmemlog_tell(PMEMlogpool *plp);
+long long pmemlog_tell(PMEMlogpool *plp);
 void pmemlog_rewind(PMEMlogpool *plp);
 void pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 	int (*process_chunk)(const void *buf, size_t len, void *arg),

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -600,15 +600,9 @@ pmemblk_nblock(PMEMblkpool *pbp)
  * pmemblk_read -- read a block in a block memory pool
  */
 int
-pmemblk_read(PMEMblkpool *pbp, void *buf, off_t blockno)
+pmemblk_read(PMEMblkpool *pbp, void *buf, size_t blockno)
 {
-	LOG(3, "pbp %p buf %p blockno %lld", pbp, buf, (long long)blockno);
-
-	if (blockno < 0) {
-		ERR("negative block number");
-		errno = EINVAL;
-		return -1;
-	}
+	LOG(3, "pbp %p buf %p blockno %zu", pbp, buf, blockno);
 
 	unsigned lane;
 
@@ -625,19 +619,13 @@ pmemblk_read(PMEMblkpool *pbp, void *buf, off_t blockno)
  * pmemblk_write -- write a block (atomically) in a block memory pool
  */
 int
-pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno)
+pmemblk_write(PMEMblkpool *pbp, const void *buf, size_t blockno)
 {
-	LOG(3, "pbp %p buf %p blockno %lld", pbp, buf, (long long)blockno);
+	LOG(3, "pbp %p buf %p blockno %zu", pbp, buf, blockno);
 
 	if (pbp->rdonly) {
 		ERR("EROFS (pool is read-only)");
 		errno = EROFS;
-		return -1;
-	}
-
-	if (blockno < 0) {
-		ERR("negative block number");
-		errno = EINVAL;
 		return -1;
 	}
 
@@ -656,19 +644,13 @@ pmemblk_write(PMEMblkpool *pbp, const void *buf, off_t blockno)
  * pmemblk_set_zero -- zero a block in a block memory pool
  */
 int
-pmemblk_set_zero(PMEMblkpool *pbp, off_t blockno)
+pmemblk_set_zero(PMEMblkpool *pbp, size_t blockno)
 {
-	LOG(3, "pbp %p blockno %lld", pbp, (long long)blockno);
+	LOG(3, "pbp %p blockno %zu", pbp, blockno);
 
 	if (pbp->rdonly) {
 		ERR("EROFS (pool is read-only)");
 		errno = EROFS;
-		return -1;
-	}
-
-	if (blockno < 0) {
-		ERR("negative block number");
-		errno = EINVAL;
 		return -1;
 	}
 
@@ -687,19 +669,13 @@ pmemblk_set_zero(PMEMblkpool *pbp, off_t blockno)
  * pmemblk_set_error -- set the error state on a block in a block memory pool
  */
 int
-pmemblk_set_error(PMEMblkpool *pbp, off_t blockno)
+pmemblk_set_error(PMEMblkpool *pbp, size_t blockno)
 {
-	LOG(3, "pbp %p blockno %lld", pbp, (long long)blockno);
+	LOG(3, "pbp %p blockno %zu", pbp, blockno);
 
 	if (pbp->rdonly) {
 		ERR("EROFS (pool is read-only)");
 		errno = EROFS;
-		return -1;
-	}
-
-	if (blockno < 0) {
-		ERR("negative block number");
-		errno = EINVAL;
 		return -1;
 	}
 

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -534,7 +534,7 @@ pmemlog_appendv(PMEMlogpool *plp, const struct iovec *iov, int iovcnt)
 /*
  * pmemlog_tell -- return current write point in a log memory pool
  */
-off_t
+long long
 pmemlog_tell(PMEMlogpool *plp)
 {
 	LOG(3, "plp %p", plp);
@@ -545,10 +545,10 @@ pmemlog_tell(PMEMlogpool *plp)
 	}
 
 	ASSERT(le64toh(plp->write_offset) >= le64toh(plp->start_offset));
-	off_t wp = (off_t)(le64toh(plp->write_offset) -
+	long long wp = (long long)(le64toh(plp->write_offset) -
 			le64toh(plp->start_offset));
 
-	LOG(4, "write offset %lld", (long long)wp);
+	LOG(4, "write offset %lld", wp);
 
 	util_rwlock_unlock(plp->rwlockp);
 

--- a/src/test/tools/pmemwrite/write.c
+++ b/src/test/tools/pmemwrite/write.c
@@ -127,11 +127,11 @@ pmemwrite_blk(struct pmemwrite *pwp)
 	}
 
 	for (i = 0; i < pwp->nargs; i++) {
-		int64_t blockno;
+		size_t blockno;
 		char *buff = NULL;
 		char flag;
 		/* <blockno>:w:<string> - write string to <blockno> */
-		if (sscanf(pwp->args[i], "%" SCNi64 ":w:%m[^:]",
+		if (sscanf(pwp->args[i], "%zu:w:%m[^:]",
 					&blockno, &buff) == 2) {
 			memset(blk, 0, blksize);
 			size_t bufflen = strlen(buff);

--- a/src/tools/pmempool/dump.c
+++ b/src/tools/pmempool/dump.c
@@ -251,16 +251,16 @@ pmempool_dump_blk(struct pmempool_dump *pdp)
 
 	int ret = 0;
 
-	uint64_t i;
+	size_t i;
 	struct range *curp = NULL;
 	assert((off_t)entire.last >= 0);
 	LIST_FOREACH(curp, &pdp->ranges.head, next) {
 		assert((off_t)curp->last >= 0);
 		for (i = curp->first;
 				i <= curp->last && i <= entire.last; i++) {
-			if (pmemblk_read(pbp, buff, (off_t)i)) {
+			if (pmemblk_read(pbp, buff, i)) {
 				ret = -1;
-				outv_err("reading block number %lu "
+				outv_err("reading block number %zu "
 					"failed\n", i);
 				break;
 			}


### PR DESCRIPTION
Modify libpmemlog and libpmemblk API to not use "off_t" type for
function arguments or returned value.

This modification is dictated by incompatible "off_t" definitions on
64-bit Linux and Windows operating systems.  On Windows, "off_t" is
always 32-bit long, which is not enough to hold offsets of large (>4GB)
pmem pool files.
To avoid potential problems with redefining "off_t" or with adding
additional typedefs, seems like the best choice is to use "long long"
or "size_t" types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/735)
<!-- Reviewable:end -->
