### PR TITLE
tools: build pmemobj before tools

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,7 +77,7 @@ benchmarks: examples
 custom_build = $(DEBUG)$(OBJDIR)
 
 libvmmalloc libvmem: jemalloc
-tools: libpmem libpmemblk libpmemlog
+tools: libpmem libpmemblk libpmemlog libpmemobj
 libpmemblk libpmemlog libpmemobj: libpmem
 
 pkg-config: $(PKG_CONFIG_FILES)


### PR DESCRIPTION
Pmempool depends on libpmemobj.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/739)
<!-- Reviewable:end -->
