### PR TITLE
pmemobjcli: handle null oids in pmemobj_type_num wrapper

### DIFF
--- a/src/test/tools/pmemobjcli/pmemobjcli.c
+++ b/src/test/tools/pmemobjcli/pmemobjcli.c
@@ -355,7 +355,7 @@ pocli_pmemobj_type_num(struct pocli_ctx *ctx, struct pocli_args *args)
 	if (ret)
 		return ret;
 
-	if (oidp == NULL)
+	if (oidp == NULL || oidp->off == 0)
 		return pocli_err(ctx, POCLI_ERR_ARGS,
 			"invalid object -- '%s'\n", args->argv[1]);
 


### PR DESCRIPTION
Before commit cafc94809b7d9ee886b66367a5eda6ba8042fae0 pmemobj_type_num
could handle invalid oids, because type numbers had a maximum value.
After this commit type numbers can have arbitrary values, so there's no
way to return an error.

Handle null oids at the caller side instead of crashing in the library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/741)
<!-- Reviewable:end -->
