### PR TITLE
all: always append EXTRA_CFLAGS after our CFLAGS

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -55,7 +55,6 @@ CFLAGS += -Wconversion
 endif
 CFLAGS += -pthread
 CFLAGS += -fno-common
-CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -DSRCVERSION=\"$(SRCVERSION)\"
 ifeq ($(call check_flag, -Wunreachable-code-return), y)
 CFLAGS += -Wunreachable-code-return
@@ -63,6 +62,18 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
+
+ifeq ($(DEBUG),1)
+CFLAGS += -O0 -ggdb -DDEBUG $(EXTRA_CFLAGS_DEBUG)
+LIB_SUBDIR = /nvml_debug
+OBJDIR = debug
+else
+CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $(EXTRA_CFLAGS_RELEASE)
+LIB_SUBDIR =
+OBJDIR = nondebug
+endif
+
+CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS += -Wl,-z,relro -Wl,--fatal-warnings -Wl,--warn-common $(EXTRA_LDFLAGS)
 
@@ -84,16 +95,6 @@ endif
 LP64 := $(shell $(CC) $(CFLAGS) -dM -E -x c /dev/null | grep -Ec "__SIZEOF_LONG__.+8|__SIZEOF_POINTER__.+8" )
 ifneq ($(LP64), 2)
 $(error $(arch32_error_msg))
-endif
-
-ifeq ($(DEBUG),1)
-CFLAGS += -O0 -ggdb -DDEBUG
-LIB_SUBDIR = /nvml_debug
-OBJDIR = debug
-else
-CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
-LIB_SUBDIR =
-OBJDIR = nondebug
 endif
 
 LIBS_DESTDIR = $(DESTDIR)$(libdir)$(LIB_SUBDIR)

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -108,7 +108,6 @@ CFLAGS += -Wmissing-prototypes
 CFLAGS += -Wpointer-arith
 CFLAGS += -Wunused-macros
 CFLAGS += -pthread
-CFLAGS += $(EXTRA_CFLAGS)
 CFLAGS += -I../include
 CFLAGS += -I../libpmemobj
 CFLAGS += -I../common
@@ -139,6 +138,8 @@ GLIB_SILENCE := $(shell printf $(GLIB_TEST_PROG) |\
 ifeq ($(GLIB_SILENCE), y)
 CFLAGS += -Wno-unknown-attributes
 endif
+
+CFLAGS += $(EXTRA_CFLAGS)
 
 objdir=.
 

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -55,7 +55,6 @@ CFLAGS += -Wconversion
 endif
 CFLAGS += -pthread
 CFLAGS += -fno-common
-CFLAGS += $(EXTRA_CFLAGS)
 ifeq ($(call check_flag, -Wunreachable-code-return), y)
 CFLAGS += -Wunreachable-code-return
 endif
@@ -71,6 +70,8 @@ endif
 
 CFLAGS += -DUSE_LIBUNWIND
 endif
+
+CFLAGS += $(EXTRA_CFLAGS)
 
 all test: $(TARGET)
 

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -51,13 +51,6 @@ ifeq ($(call check_Wconversion), y)
 CFLAGS += -Wconversion
 endif
 CFLAGS += -fno-common
-CFLAGS += $(EXTRA_CFLAGS)
-
-ifeq ($(DEBUG),)
-CFLAGS += -O2 -D_FORTIFY_SOURCE=2
-else
-CFLAGS += -ggdb
-endif
 
 CFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
 ifeq ($(call check_flag, -Wunreachable-code-return), y)
@@ -66,6 +59,14 @@ endif
 ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
+
+ifeq ($(DEBUG),1)
+CFLAGS += -ggdb $(EXTRA_CFLAGS_DEBUG)
+else
+CFLAGS += -O2 -D_FORTIFY_SOURCE=2 $(EXTRA_CFLAGS_RELEASE)
+endif
+
+CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS += -Wl,-z,relro -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS) -L$(TOP)/src/nondebug
 TARGET_DIR=$(DESTDIR)$(bindir)


### PR DESCRIPTION
...and add support for EXTRA_CFLAGS_DEBUG and EXTRA_CFLAGS_RELEASE.


Without appending EXTRA_CFLAGS at the end it's not possible to disable some warnings.
EXTRA_CFLAGS_RELEASE allows overriding eg optimization flags in release mode without also enabling them for debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/749)
<!-- Reviewable:end -->
