### PR TITLE
obj: fix error handling in pmemobj_tx_add*

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1453,10 +1453,13 @@ pmemobj_tx_add_common(struct tx_add_range_args *args)
 		if (ret != 0)
 			break;
 
-
-		if (ctree_insert_unlocked(runtime->ranges,
-			nargs.offset, nargs.size) != 0)
+		ret = ctree_insert_unlocked(runtime->ranges, nargs.offset,
+				nargs.size);
+		if (ret != 0) {
+			if (ret == EEXIST)
+				FATAL("invalid state of ranges tree");
 			break;
+		}
 	}
 
 	if (ret != 0) {


### PR DESCRIPTION
ctree_insert error interrupted the surrounding loop, but didn't set
return value, so function returned success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/752)
<!-- Reviewable:end -->
