### PR TITLE
Supply missing references to USE_VG_DRD macro

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -251,6 +251,11 @@ out_init(const char *log_prefix, const char *log_level_var,
 			"compiled with support for Valgrind memcheck";
 	LOG(1, "%s", memcheck_msg);
 #endif /* USE_VG_MEMCHECK */
+#ifdef USE_VG_DRD
+	static __attribute__((used)) const char *drd_msg =
+			"compiled with support for Valgrind drd";
+	LOG(1, "%s", drd_msg);
+#endif /* USE_VG_DRD */
 
 	Last_errormsg_key_alloc();
 }

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -103,7 +103,7 @@ Zalloc(size_t sz)
 }
 
 #if defined(USE_VG_PMEMCHECK) || defined(USE_VG_HELGRIND) ||\
-	defined(USE_VG_MEMCHECK)
+	defined(USE_VG_MEMCHECK) || defined(USE_VG_DRD)
 /* initialized to true if the process is running inside Valgrind */
 unsigned _On_valgrind;
 #endif
@@ -143,7 +143,7 @@ util_init(void)
 	}
 
 #if defined(USE_VG_PMEMCHECK) || defined(USE_VG_HELGRIND) ||\
-	defined(USE_VG_MEMCHECK)
+	defined(USE_VG_MEMCHECK) || defined(USE_VG_DRD)
 	_On_valgrind = RUNNING_ON_VALGRIND;
 #endif
 }

--- a/src/test/arch_flags/log0.log.match
+++ b/src/test/arch_flags/log0.log.match
@@ -4,6 +4,7 @@
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind pmemcheck
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind helgrind
 $(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind memcheck
+$(OPT)<arch_flags>: <1> [$(nW) out_init]$(W)compiled with support for Valgrind drd
 <arch_flags>: <1> [$(nW) util_get_arch_flags]$(W)open /proc/self/exe: $(*)
 <arch_flags>: <1> [$(nW) util_get_arch_flags]$(W)read /proc/self/exe: $(*)
 <arch_flags>: <1> [$(nW) util_get_arch_flags]$(W)invalid ELF magic

--- a/src/test/obj_cpp_cond_var_posix/TEST1
+++ b/src/test/obj_cpp_cond_var_posix/TEST1
@@ -46,6 +46,7 @@ setup
 
 expect_normal_exit\
     valgrind --tool=helgrind --log-file=valgrind$UNITTEST_NUM.log\
+	--suppressions=../out_fputs.supp \
     ./obj_cpp_cond_var_posix$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/obj_cpp_mutex_posix/TEST1
+++ b/src/test/obj_cpp_mutex_posix/TEST1
@@ -45,6 +45,7 @@ setup
 
 expect_normal_exit\
     valgrind --tool=helgrind --log-file=valgrind$UNITTEST_NUM.log\
+	--suppressions=../out_fputs.supp \
     ./obj_cpp_mutex_posix$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/obj_cpp_shared_mutex_posix/TEST1
+++ b/src/test/obj_cpp_shared_mutex_posix/TEST1
@@ -45,6 +45,7 @@ setup
 
 expect_normal_exit\
     valgrind --tool=helgrind --log-file=valgrind$UNITTEST_NUM.log\
+    --suppressions=../out_fputs.supp \
     ./obj_cpp_shared_mutex_posix$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/obj_cpp_timed_mtx_posix/TEST1
+++ b/src/test/obj_cpp_timed_mtx_posix/TEST1
@@ -45,6 +45,7 @@ setup
 
 expect_normal_exit\
     valgrind --tool=helgrind --log-file=valgrind$UNITTEST_NUM.log\
+	--suppressions=../out_fputs.supp \
     ./obj_cpp_timed_mtx_posix$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/obj_locks/TEST2
+++ b/src/test/obj_locks/TEST2
@@ -46,6 +46,7 @@ require_valgrind_dev_3_10
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_locks$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -52,6 +52,7 @@ expect_normal_exit\
 	PMEM_IS_PMEM_FORCE=1\
 	valgrind --tool=helgrind\
 	--log-file=valgrind$UNITTEST_NUM.log\
+	--suppressions=../out_fputs.supp \
 	./obj_pmalloc_mt$EXESUFFIX\ $DIR/testfile
 
 rm -f $DIR/testfile

--- a/src/test/obj_sync/TEST2
+++ b/src/test/obj_sync/TEST2
@@ -48,6 +48,7 @@ require_valgrind_helgrind
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_sync$EXESUFFIX m 10 50
 
 check

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -48,6 +48,7 @@ require_valgrind_helgrind
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_sync$EXESUFFIX r 10 50
 
 check

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -48,6 +48,7 @@ require_valgrind_helgrind
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_sync$EXESUFFIX c 10 50
 
 check

--- a/src/test/obj_tx_locks/TEST2
+++ b/src/test/obj_tx_locks/TEST2
@@ -52,6 +52,7 @@ require_valgrind_dev_3_10
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_tx_locks$EXESUFFIX $DIR/testfile1 m
 
 check

--- a/src/test/obj_tx_locks_abort/TEST2
+++ b/src/test/obj_tx_locks_abort/TEST2
@@ -52,6 +52,7 @@ require_valgrind_dev_3_10
 setup
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log\
+ --suppressions=../out_fputs.supp \
  --tool=helgrind ./obj_tx_locks_abort$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -4,6 +4,7 @@
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind pmemcheck
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind helgrind
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
+$(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
 <trace>: <1> [out_err.c:$(N) main]$(W)ERR #1
 <trace>: <1> [out_err.c:$(N) main]$(W)ERR #2: Success
 <trace>: <1> [out_err.c:$(N) main]$(W)ERR #3: Invalid argument

--- a/src/test/out_err_mt/TEST2
+++ b/src/test/out_err_mt/TEST2
@@ -58,6 +58,7 @@ unset PMEMOBJ_LOG_FILE
 unset VMEM_LOG_FILE
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=helgrind\
+	--suppressions=../out_fputs.supp \
     ./out_err_mt$EXESUFFIX $DIR/testfile1 $DIR/testfile2 $DIR/testfile3 $DIR
 
 check

--- a/src/test/out_fputs.supp
+++ b/src/test/out_fputs.supp
@@ -1,0 +1,7 @@
+{
+   out_print_func_puts
+   Helgrind:Race
+   ...
+   fun:fputs
+   fun:out_print_func
+}

--- a/src/test/traces/custom_file.log.match
+++ b/src/test/traces/custom_file.log.match
@@ -4,6 +4,7 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 $(*)Log level NONE
 $(*)Log level ERROR
 $(*)Log level WARNING

--- a/src/test/traces/redir_stderr2.log.match
+++ b/src/test/traces/redir_stderr2.log.match
@@ -4,5 +4,6 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 $(*)Log level NONE
 $(*)Log level ERROR

--- a/src/test/traces/redir_stderr3.log.match
+++ b/src/test/traces/redir_stderr3.log.match
@@ -4,6 +4,7 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 $(*)Log level NONE
 $(*)Log level ERROR
 $(*)Log level WARNING

--- a/src/test/traces/redir_stderr4.log.match
+++ b/src/test/traces/redir_stderr4.log.match
@@ -4,6 +4,7 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 $(*)Log level NONE
 $(*)Log level ERROR
 $(*)Log level WARNING

--- a/src/test/traces/redir_stderr5.log.match
+++ b/src/test/traces/redir_stderr5.log.match
@@ -4,6 +4,7 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 $(*)Log level NONE
 $(*)Log level ERROR
 $(*)Log level WARNING

--- a/src/test/traces/redir_stderr6.log.match
+++ b/src/test/traces/redir_stderr6.log.match
@@ -4,6 +4,7 @@ $(*)
 $(OPT)$(*) compiled with support for Valgrind pmemcheck
 $(OPT)$(*) compiled with support for Valgrind helgrind
 $(OPT)$(*) compiled with support for Valgrind memcheck
+$(OPT)$(*) compiled with support for Valgrind drd
 <trace>: <0> [traces.c:$(*) main]$(W)Log level NONE
 <trace>: <1> [traces.c:$(*) main]$(W)Log level ERROR
 <trace>: <2> [traces.c:$(*) main]$(W)Log level WARNING

--- a/src/test/traces_custom_function/out0.log.match
+++ b/src/test/traces_custom_function/out0.log.match
@@ -12,6 +12,8 @@ $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with sup
 $(OPT)
 $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind drd
+$(OPT)
 CUSTOM_PRINT: <trace_func>: <0> [$(nW):$(N) main]$(W)Log level NONE
 
 CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) main]$(W)Log level ERROR

--- a/src/test/traces_custom_function/out1.log.match
+++ b/src/test/traces_custom_function/out1.log.match
@@ -12,6 +12,8 @@ $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with sup
 $(OPT)
 $(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)
+$(OPT)CUSTOM_PRINT: <trace_func>: <1> [$(nW):$(N) out_init]$(W)compiled with support for Valgrind drd
+$(OPT)
 CUSTOM_PRINT: <trace_func>: <3> [$(nW):$(N) out_set_vsnprintf_func]$(W)vsnprintf 0x$(X)
 
 CUSTOM_PRINT: <@@trace_func>: <@@0> [@@$(nW):@@$(N) @@main]$(W)no format@@@@@@

--- a/src/test/util_poolset/grep0.log.match
+++ b/src/test/util_poolset/grep0.log.match
@@ -4,6 +4,7 @@ src version SRCVERSION:utversion
 $(OPT)compiled with support for Valgrind pmemcheck
 $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
+$(OPT)compiled with support for Valgrind drd
 open $(nW)/testset0: No such file or directory
 size 12288 smaller than 32768
 size 16384 smaller than 32768

--- a/src/test/util_poolset/grep1.log.match
+++ b/src/test/util_poolset/grep1.log.match
@@ -4,6 +4,7 @@ src version SRCVERSION:utversion
 $(OPT)compiled with support for Valgrind pmemcheck
 $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
+$(OPT)compiled with support for Valgrind drd
 open $(nW)/testset0: No such file or directory
 invalid major version (0)
 open $(nW)/testset2: Permission denied

--- a/src/test/util_poolset/grep2.log.match
+++ b/src/test/util_poolset/grep2.log.match
@@ -4,6 +4,7 @@ src version SRCVERSION:utversion
 $(OPT)compiled with support for Valgrind pmemcheck
 $(OPT)compiled with support for Valgrind helgrind
 $(OPT)compiled with support for Valgrind memcheck
+$(OPT)compiled with support for Valgrind drd
 invalid checksum of pool header
 wrong pool type: "ERRORXX"
 pool version 99 (library expects 1)

--- a/src/test/vmem_multiple_pools/TEST2
+++ b/src/test/vmem_multiple_pools/TEST2
@@ -49,6 +49,7 @@ setup
 export VMEM_LOG_LEVEL=0
 
 expect_normal_exit valgrind --log-file=valgrind$UNITTEST_NUM.log --tool=helgrind\
+	--suppressions=../out_fputs.supp \
 	./vmem_multiple_pools$EXESUFFIX $DIR 2 4
 
 check


### PR DESCRIPTION
Not checking for the USE_VG_DRD macro in src/common/util.c can cause a
naive developers build using -DUSE_VG_DRD to fail.
Since src/common/out.c refers to the variable _On_valgrind when
USE_VG_DRD is defined, the said variable shall be defined in util.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/758)
<!-- Reviewable:end -->
