### PR TITLE
common: fix creating pkg-config scripts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -80,10 +80,8 @@ libvmmalloc libvmem: jemalloc
 tools: libpmem libpmemblk libpmemlog libpmemobj
 libpmemblk libpmemlog libpmemobj: libpmem
 
-pkg-config: $(PKG_CONFIG_FILES)
-
-$(PKG_CONFIG_FILES): $(MAKE_PKG_CONFIG)
-	@$(MAKE_PKG_CONFIG) "$(prefix)" "$(DESTDIR)$(LIBDIR)" "$(SRCVERSION)"
+pkg-config:
+	@$(MAKE_PKG_CONFIG) "$(prefix)" "$(libdir)" "$(SRCVERSION)"
 
 %-install: %
 	$(MAKE) -C $* install
@@ -155,4 +153,5 @@ clean:
 .NOTPARALLEL: libvmem libvmmalloc
 
 .PHONY: all install uninstall clean clobber cstyle test check pcheck\
-	jemalloc jemalloc-clean jemalloc-test jemalloc-check cscope $(ALL_TARGETS)
+	jemalloc jemalloc-clean jemalloc-test jemalloc-check cscope $(ALL_TARGETS)\
+	pkg-config

--- a/utils/make-pkg-config.sh
+++ b/utils/make-pkg-config.sh
@@ -54,7 +54,7 @@ Name: libpmem
 Description: libpmem library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private:
+Requires:
 Libs: -L\${libdir} -lpmem
 Cflags: -I\${includedir}
 EOF
@@ -69,7 +69,7 @@ Name: libpmemobj
 Description: libpmemobj library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private: pmem
+Requires: libpmem
 Libs: -L\${libdir} -lpmemobj
 Cflags: -I\${includedir}
 EOF
@@ -84,7 +84,7 @@ Name: libpmemblk
 Description: libpmemblk library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private: pmem
+Requires: libpmem
 Libs: -L\${libdir} -lpmemblk
 Cflags: -I\${includedir}
 EOF
@@ -99,7 +99,7 @@ Name: libpmemlog
 Description: libpmemlog library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private: pmem
+Requires: libpmem
 Libs: -L\${libdir} -lpmemlog
 Cflags: -I\${includedir}
 EOF
@@ -114,7 +114,7 @@ Name: libvmem
 Description: libvmem library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private:
+Requires:
 Libs: -L\${libdir} -lvmem
 Cflags: -I\${includedir}
 EOF
@@ -129,7 +129,7 @@ Name: libvmmalloc
 Description: libvmmalloc library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires.private: vmem
-Libs: -L\${libdir} -lvmem
+Requires:
+Libs: -L\${libdir} -lvmmalloc
 Cflags: -I\${includedir}
 EOF


### PR DESCRIPTION
Fix passing appropriate libdir variable to make-pkg-config.sh.
Fix dependency for libpmem.

Ref: pmem/issues#165

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/761)
<!-- Reviewable:end -->
