### PR TITLE
test: fix confusing message if no valgrind

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -651,7 +651,7 @@ function configure_valgrind() {
 function require_valgrind() {
 	require_no_asan
 	VALGRINDEXE=`which valgrind 2>/dev/null` && return
-	echo "error: $UNITTEST_NAME: SKIP valgrind package required"
+	echo "$UNITTEST_NAME: SKIP valgrind package required"
 	exit 0
 }
 


### PR DESCRIPTION
Get rid of 'error: ' message if valgrind is not available when running
tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/765)
<!-- Reviewable:end -->
