### PR TITLE
common: util.c refactoring

### DIFF
--- a/platform/README
+++ b/platform/README
@@ -1,0 +1,11 @@
+Linux NVM Library
+
+This is platform/README.
+
+This directory contains the platform-specific files for the NVM Library.
+
+For each platform (i.e. "linux", "windows", etc.) there is a subdirectory
+containing all the platform-specific source files, scripts, etc.
+
+The structure of "*/src" subdirectories is the same as for "src"
+subdirectory in the main directory of the NVML source tree.

--- a/platform/linux/src/common/util_platform.c
+++ b/platform/linux/src/common/util_platform.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2014-2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * util_platform.c -- general utilities with platform-specific implementation
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <endian.h>
+#include <errno.h>
+#include <stddef.h>
+#include <elf.h>
+#include <link.h>
+
+#include "util.h"
+#include "out.h"
+
+#define	PROCMAXLEN 2048 /* maximum expected line length in /proc files */
+
+#define	MEGABYTE ((uintptr_t)1 << 20)
+#define	GIGABYTE ((uintptr_t)1 << 30)
+
+extern int Mmap_no_random;
+extern void *Mmap_hint;
+
+/*
+ * util_map_hint_unused -- use /proc to determine a hint address for mmap()
+ *
+ * This is a helper function for util_map_hint().
+ * It opens up /proc/self/maps and looks for the first unused address
+ * in the process address space that is:
+ * - greater or equal 'minaddr' argument,
+ * - large enough to hold range of given length,
+ * - aligned to the specified unit.
+ *
+ * Asking for aligned address like this will allow the DAX code to use large
+ * mappings.  It is not an error if mmap() ignores the hint and chooses
+ * different address.
+ */
+char *
+util_map_hint_unused(void *minaddr, size_t len, size_t align)
+{
+	LOG(3, "minaddr %p len %zu align %zu", minaddr, len, align);
+
+	ASSERT(align > 0);
+
+	FILE *fp;
+	if ((fp = fopen("/proc/self/maps", "r")) == NULL) {
+		ERR("!/proc/self/maps");
+		return NULL;
+	}
+
+	char line[PROCMAXLEN];	/* for fgets() */
+	char *lo = NULL;	/* beginning of current range in maps file */
+	char *hi = NULL;	/* end of current range in maps file */
+	char *raddr = minaddr;	/* ignore regions below 'minaddr' */
+
+	if (raddr == NULL)
+		raddr += Pagesize;
+
+	raddr = (char *)roundup((uintptr_t)raddr, align);
+
+	while (fgets(line, PROCMAXLEN, fp) != NULL) {
+		/* check for range line */
+		if (sscanf(line, "%p-%p", &lo, &hi) == 2) {
+			LOG(4, "%p-%p", lo, hi);
+			if (lo > raddr) {
+				if ((uintptr_t)(lo - raddr) >= len) {
+					LOG(4, "unused region of size %zu "
+							"found at %p",
+							lo - raddr, raddr);
+					break;
+				} else {
+					LOG(4, "region is too small: %zu < %zu",
+							lo - raddr, len);
+				}
+			}
+
+			if (hi > raddr) {
+				raddr = (char *)roundup((uintptr_t)hi, align);
+				LOG(4, "nearest aligned addr %p", raddr);
+			}
+
+			if (raddr == 0) {
+				LOG(4, "end of address space reached");
+				break;
+			}
+		}
+	}
+
+	/*
+	 * Check for a case when this is the last unused range in the address
+	 * space, but is not large enough. (very unlikely)
+	 */
+	if ((raddr != NULL) && (UINTPTR_MAX - (uintptr_t)raddr < len)) {
+		LOG(4, "end of address space reached");
+		raddr = NULL;
+	}
+
+	fclose(fp);
+
+	LOG(3, "returning %p", raddr);
+	return raddr;
+}
+
+/*
+ * util_map_hint -- determine hint address for mmap()
+ *
+ * If PMEM_MMAP_HINT environment variable is not set, we let the system to pick
+ * the randomized mapping address.  Otherwise, a user-defined hint address
+ * is used.
+ *
+ * ALSR in 64-bit Linux kernel uses 28-bit of randomness for mmap
+ * (bit positions 12-39), which means the base mapping address is randomized
+ * within [0..1024GB] range, with 4KB granularity.  Assuming additional
+ * 1GB alignment, it results in 1024 possible locations.
+ *
+ * Configuring the hint address via PMEM_MMAP_HINT environment variable
+ * disables address randomization.  In such case, the function will search for
+ * the first unused, properly aligned region of given size, above the specified
+ * address.
+ */
+char *
+util_map_hint(size_t len, size_t req_align)
+{
+	LOG(3, "len %zu req_align %zu", len, req_align);
+
+	char *addr;
+
+	/*
+	 * Choose the desired alignment based on the requested length.
+	 * Use 2MB/1GB page alignment only if the mapping length is at least
+	 * twice as big as the page size.
+	 */
+	size_t align = Pagesize;
+	if (req_align)
+		align = req_align;
+	else if (len >= 2 * GIGABYTE)
+		align = GIGABYTE;
+	else if (len >= 4 * MEGABYTE)
+		align = 2 * MEGABYTE;
+
+	if (Mmap_no_random) {
+		LOG(4, "user-defined hint %p", (void *)Mmap_hint);
+		addr = util_map_hint_unused((void *)Mmap_hint, len, align);
+	} else {
+		/*
+		 * Create dummy mapping to find an unused region of given size.
+		 * Request for increased size for later address alignment.
+		 * Use MAP_PRIVATE with read-only access to simulate
+		 * zero cost for overcommit accounting.  Note: MAP_NORESERVE
+		 * flag is ignored if overcommit is disabled (mode 2).
+		 */
+		addr = mmap(NULL, len + align, PROT_READ,
+					MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+		if (addr == MAP_FAILED) {
+			addr = NULL;
+		} else {
+			LOG(4, "system choice %p", addr);
+			munmap(addr, len + align);
+			addr = (char *)roundup((uintptr_t)addr, align);
+		}
+	}
+	LOG(4, "hint %p", addr);
+
+	return addr;
+}
+
+/*
+ * util_tmpfile --  (internal) create the temporary file
+ */
+int
+util_tmpfile(const char *dir, const char *templ)
+{
+	LOG(3, "dir \"%s\" template \"%s\"", dir, templ);
+
+	int oerrno;
+	int fd = -1;
+
+	char *fullname = alloca(strlen(dir) + sizeof (templ));
+
+	(void) strcpy(fullname, dir);
+	(void) strcat(fullname, templ);
+
+	sigset_t set, oldset;
+	sigfillset(&set);
+	(void) sigprocmask(SIG_BLOCK, &set, &oldset);
+
+	mode_t prev_umask = umask(S_IRWXG | S_IRWXO);
+
+	fd = mkstemp(fullname);
+
+	umask(prev_umask);
+
+	if (fd < 0) {
+		ERR("!mkstemp");
+		goto err;
+	}
+
+	(void) unlink(fullname);
+	(void) sigprocmask(SIG_SETMASK, &oldset, NULL);
+	LOG(3, "unlinked file is \"%s\"", fullname);
+
+	return fd;
+
+err:
+	oerrno = errno;
+	(void) sigprocmask(SIG_SETMASK, &oldset, NULL);
+	if (fd != -1)
+		(void) close(fd);
+	errno = oerrno;
+	return -1;
+}
+
+/*
+ * util_get_arch_flags -- get architecture identification flags
+ */
+int
+util_get_arch_flags(struct arch_flags *arch_flags)
+{
+	char *path = "/proc/self/exe";
+	int fd;
+	ElfW(Ehdr) elf;
+	int ret = 0;
+
+	memset(arch_flags, 0, sizeof (*arch_flags));
+
+	if ((fd = open(path, O_RDONLY)) < 0) {
+		ERR("!open %s", path);
+		ret = -1;
+		goto out;
+	}
+
+	if (read(fd, &elf, sizeof (elf)) != sizeof (elf)) {
+		ERR("!read %s", path);
+		ret = -1;
+		goto out_close;
+	}
+
+	if (elf.e_ident[EI_MAG0] != ELFMAG0 ||
+	    elf.e_ident[EI_MAG1] != ELFMAG1 ||
+	    elf.e_ident[EI_MAG2] != ELFMAG2 ||
+	    elf.e_ident[EI_MAG3] != ELFMAG3) {
+		ERR("invalid ELF magic");
+		ret = -1;
+		goto out_close;
+	}
+
+	arch_flags->e_machine = elf.e_machine;
+	arch_flags->ei_class = elf.e_ident[EI_CLASS];
+	arch_flags->ei_data = elf.e_ident[EI_DATA];
+	arch_flags->alignment_desc = alignment_desc();
+
+out_close:
+	close(fd);
+out:
+	return ret;
+}

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -32,12 +32,15 @@
 #
 
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
+PLATFORM = ../../platform/linux
+
 include $(TOP)/src/common.inc
 
-INCLUDE = ../include
+INCLUDE = $(TOP)/src/include
 
-COMMON = ../common
+COMMON = $(TOP)/src/common
 vpath %.c $(COMMON)
+vpath %.c $(PLATFORM)/src/common
 
 INCS += -I../include -I../common/
 

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -34,15 +34,18 @@
 # src/benchmarks/Makefile -- build all benchmarks
 #
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
+PLATFORM = $(TOP)/platform/linux
+
 include $(TOP)/src/common.inc
 
-vpath %.c ../examples/libpmemobj/tree_map
-vpath %.c ../examples/libpmemobj/map
-vpath %.c ../examples/libpmemobj/hashmap
+vpath %.c $(TOP)/src/examples/libpmemobj/tree_map
+vpath %.c $(TOP)/src/examples/libpmemobj/map
+vpath %.c $(TOP)/src/examples/libpmemobj/hashmap
 
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
 
-vpath %.c ../libpmemobj
-vpath %.c ../common
+vpath %.c $(PLATFORM)/src/common
 
 BENCHMARK = pmembench
 
@@ -60,6 +63,7 @@ SRC=pmembench.c\
     benchmark_time.c\
     benchmark_worker.c\
     util.c\
+    util_platform.c\
     out.c\
     set.c\
     clo.c\

--- a/src/common.inc
+++ b/src/common.inc
@@ -32,6 +32,7 @@
 #
 
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
+PLATFORM = $(TOP)/platform/linux
 
 LN = ln
 OBJCOPY = objcopy

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -36,6 +36,8 @@
 
 extern unsigned long Pagesize;
 
+extern int Mmap_no_random;
+extern void *Mmap_hint;
 
 /*
  * overridable names for malloc & friends used by this library
@@ -281,3 +283,23 @@ static inline void util_setbit(uint8_t *b, uint32_t i)
 #define	unlikely(x) (!!(x))
 #endif
 #endif
+
+
+/*
+ * set of macros for determining the alignment descriptor
+ */
+#define	DESC_MASK		((1 << ALIGNMENT_DESC_BITS) - 1)
+#define	alignment_of(t)		offsetof(struct { char c; t x; }, x)
+#define	alignment_desc_of(t)	(((uint64_t)alignment_of(t) - 1) & DESC_MASK)
+#define	alignment_desc()\
+(alignment_desc_of(char)	<<  0 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(short)	<<  1 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(int)		<<  2 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(long)	<<  3 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(long long)	<<  4 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(size_t)	<<  5 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(off_t)	<<  6 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(float)	<<  7 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(double)	<<  8 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(long double)	<<  9 * ALIGNMENT_DESC_BITS) |\
+(alignment_desc_of(void *)	<< 10 * ALIGNMENT_DESC_BITS)

--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -35,7 +35,8 @@
 LIBRARY_NAME = pmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = libpmem.c pmem.c $(COMMON)/util.c $(COMMON)/out.c $(COMMON)/cpu.c
+SOURCE = libpmem.c pmem.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/out.c $(COMMON)/cpu.c
 
 include ../Makefile.inc
 

--- a/src/libpmemblk/Makefile
+++ b/src/libpmemblk/Makefile
@@ -35,8 +35,8 @@
 LIBRARY_NAME = pmemblk
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+SOURCE = libpmemblk.c blk.c btt.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/set.c $(COMMON)/out.c
 
 include ../Makefile.inc
 

--- a/src/libpmemlog/Makefile
+++ b/src/libpmemlog/Makefile
@@ -35,7 +35,8 @@
 LIBRARY_NAME = pmemlog
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = libpmemlog.c log.c $(COMMON)/util.c $(COMMON)/set.c $(COMMON)/out.c
+SOURCE = libpmemlog.c log.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/set.c $(COMMON)/out.c
 
 include ../Makefile.inc
 

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -36,8 +36,8 @@ LIBRARY_NAME = pmemobj
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
 SOURCE = libpmemobj.c obj.c redo.c pmalloc.c lane.c list.c ctree.c bucket.c\
-	heap.c cuckoo.c sync.c tx.c memops.c $(COMMON)/util.c $(COMMON)/set.c\
-	$(COMMON)/out.c
+	heap.c cuckoo.c sync.c tx.c memops.c $(COMMON)/util.c\
+	$(COMMON)/util_platform.c $(COMMON)/set.c $(COMMON)/out.c
 
 include ../Makefile.inc
 

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -35,6 +35,7 @@
 LIBRARY_NAME = rpmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = librpmem.c rpmem.c $(COMMON)/util.c $(COMMON)/out.c
+SOURCE = librpmem.c rpmem.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/out.c
 
 include ../Makefile.inc

--- a/src/libvmem/Makefile
+++ b/src/libvmem/Makefile
@@ -35,7 +35,8 @@
 LIBRARY_NAME = vmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = libvmem.c vmem.c $(COMMON)/util.c $(COMMON)/out.c
+SOURCE = libvmem.c vmem.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/out.c
 
 default: all
 

--- a/src/libvmmalloc/Makefile
+++ b/src/libvmmalloc/Makefile
@@ -35,7 +35,8 @@
 LIBRARY_NAME = vmmalloc
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE = libvmmalloc.c $(COMMON)/util.c $(COMMON)/out.c
+SOURCE = libvmmalloc.c $(COMMON)/util.c $(COMMON)/util_platform.c\
+	$(COMMON)/out.c
 
 default: all
 

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -38,12 +38,13 @@
 #
 
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
+PLATFORM = $(TOP)/platform/linux
 
 include $(TOP)/src/common.inc
 
-LIBS_DIR=../..
+LIBS_DIR=$(TOP)/src
 
-EXAMPLES_DIR=../../examples
+EXAMPLES_DIR=$(TOP)/src/examples
 EX_LIBPMEM=$(EXAMPLES_DIR)/libpmem
 EX_LIBPMEMBLK=$(EXAMPLES_DIR)/libpmemblk
 EX_LIBPMEMLOG=$(EXAMPLES_DIR)/libpmemlog
@@ -114,7 +115,7 @@ extract_funcs = $(shell \
     grep -Po '($(WRAPPER_FUNCS))\$(PAREN)\K[^,]*' $(1) | \
     awk '{print "-Wl,--wrap="$$0}')
 
-INCS = -I../unittest -I../../include
+INCS = -I../unittest -I$(TOP)/src/include
 
 COMMON_FLAGS  = -ggdb
 COMMON_FLAGS += -Wall

--- a/src/test/arch_flags/Makefile
+++ b/src/test/arch_flags/Makefile
@@ -33,13 +33,18 @@
 #
 # src/test/arch_flags/Makefile -- build arch_flags unit test
 #
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = arch_flags
-OBJS = arch_flags.o util.o out.o
+OBJS = arch_flags.o util.o util_platform.o out.o
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common
 LDFLAGS += -Wl,--wrap=open
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG

--- a/src/test/checksum/Makefile
+++ b/src/test/checksum/Makefile
@@ -33,14 +33,17 @@
 #
 # src/test/checksum/Makefile -- build checksum unit test
 #
-vpath %.c ../../common
-vpath %.h ../.. ../../include
-vpath %.h ../.. ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = checksum
-OBJS = checksum.o util.o out.o
+OBJS = checksum.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 
 include ../Makefile.inc
-INCS += -I../../include -I../../common/
+INCS += -I$(TOP)/src/include -I$(TOP)/src/common/

--- a/src/test/obj_bucket/Makefile
+++ b/src/test/obj_bucket/Makefile
@@ -33,12 +33,17 @@
 #
 # src/test/obj_bucket/Makefile -- build bucket unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_bucket
 OBJS = obj_bucket.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
-    util.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o libpmemobj.o
+    util.o util_platform.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o\
+    libpmemobj.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -48,4 +53,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_bucket.c)
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_ctree/Makefile
+++ b/src/test/obj_ctree/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_ctree/Makefile -- build crit-bit tree unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_ctree
-OBJS = obj_ctree.o ctree.o util.o out.o
+OBJS = obj_ctree.o ctree.o util.o util_platform.o out.o
 
 LIBPMEM=y
 
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_ctree.c)
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_cuckoo/Makefile
+++ b/src/test/obj_cuckoo/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_cuckoo/Makefile -- build obj_cuckoo unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_cuckoo
-OBJS = obj_cuckoo.o cuckoo.o util.o out.o
+OBJS = obj_cuckoo.o cuckoo.o util.o util_platform.o out.o
 
 LIBPMEM=y
 
@@ -47,4 +51,4 @@ include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_cuckoo.c)
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_heap/Makefile
+++ b/src/test/obj_heap/Makefile
@@ -33,12 +33,17 @@
 #
 # src/test/obj_heap/Makefile -- build heap unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_heap
 OBJS = obj_heap.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
-    util.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o libpmemobj.o
+    util.o util_platform.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o\
+    libpmemobj.o
 
 LIBPMEM=y
 
@@ -47,4 +52,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_heap.c)
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_lane/Makefile
+++ b/src/test/obj_lane/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_lane/Makefile -- build obj_lane unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_lane
-OBJS = obj_lane.o cuckoo.o lane.o util.o out.o
+OBJS = obj_lane.o cuckoo.o lane.o util.o util_platform.o out.o
 
 LIBPMEM=y
 
@@ -45,4 +49,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_list/Makefile
+++ b/src/test/obj_list/Makefile
@@ -33,17 +33,21 @@
 #
 # src/test/obj_list/Makefile -- build obj_list test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_list
-OBJS = obj_list.o list.o redo.o util.o out.o cuckoo.o lane.o sync.o
+OBJS = obj_list.o list.o redo.o util.o util_platform.o out.o cuckoo.o lane.o sync.o
 
 LIBPMEM=y
 
 include ../Makefile.inc
 CFLAGS += -g -DDEBUG
 LDFLAGS += $(call extract_funcs, obj_list.c)
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"

--- a/src/test/obj_persist_count/Makefile
+++ b/src/test/obj_persist_count/Makefile
@@ -33,13 +33,18 @@
 #
 # src/test/obj_persist_count/Makefile -- build obj_persist_count unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_persist_count
 
 OBJS = obj_persist_count.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
-    util.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o libpmemobj.o
+    util.o util_platform.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o memops.o\
+    libpmemobj.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -49,4 +54,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_persist_count.c)
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_pmalloc_basic/Makefile
+++ b/src/test/obj_pmalloc_basic/Makefile
@@ -33,12 +33,16 @@
 #
 # src/test/obj_pmalloc_basic/Makefile -- build obj_pmalloc_basic unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_pmalloc_basic
 OBJS = obj_pmalloc_basic.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
-    util.o set.o out.o obj.o cuckoo.o list.o sync.o memops.o tx.o
+    util.o util_platform.o set.o out.o obj.o cuckoo.o list.o sync.o memops.o tx.o
 
 LIBPMEM=y
 
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_pmalloc_mt/Makefile
+++ b/src/test/obj_pmalloc_mt/Makefile
@@ -33,12 +33,17 @@
 #
 # src/test/obj_pmalloc_mt/Makefile -- build obj_pmalloc_mt unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_pmalloc_mt
 OBJS = obj_pmalloc_mt.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
-    util.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o  memops.o libpmemobj.o
+    util.o util_platform.o set.o out.o obj.o cuckoo.o list.o sync.o tx.o  memops.o\
+    libpmemobj.o
 
 LIBPMEM=y
 
@@ -46,4 +51,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_realloc/Makefile
+++ b/src/test/obj_realloc/Makefile
@@ -33,10 +33,14 @@
 #
 # src/test/obj_realloc/Makefile -- build obj_realloc unit test
 #
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_realloc
-OBJS = obj_realloc.o util.o out.o
+OBJS = obj_realloc.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -45,5 +49,5 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-CFLAGS += -I../../libpmemobj
-CFLAGS += -I../../common
+CFLAGS += -I$(TOP)/src/libpmemobj
+CFLAGS += -I$(TOP)/src/common

--- a/src/test/obj_redo_log/Makefile
+++ b/src/test/obj_redo_log/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_redo_log/Makefile -- build obj_redo_log unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_redo_log
-OBJS = obj_redo_log.o redo.o util.o out.o
+OBJS = obj_redo_log.o redo.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
@@ -45,4 +49,4 @@ LIBPMEM=y
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_sync/Makefile
+++ b/src/test/obj_sync/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_sync/Makefile -- build obj_sync unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_sync
-OBJS = obj_sync.o sync.o util.o out.o
+OBJS = obj_sync.o sync.o util.o util_platform.o out.o
 LIBS = -lrt
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
@@ -48,4 +52,4 @@ include ../Makefile.inc
 
 LDFLAGS += $(call extract_funcs, obj_sync.c)
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_tx_add_range/Makefile
+++ b/src/test/obj_tx_add_range/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_tx_add_range/Makefile -- build obj_tx_add_range unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_tx_add_range
-OBJS = obj_tx_add_range.o util.o out.o
+OBJS = obj_tx_add_range.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_tx_add_range_direct/Makefile
+++ b/src/test/obj_tx_add_range_direct/Makefile
@@ -34,11 +34,15 @@
 # src/test/obj_tx_add_range_direct/Makefile -- build obj_tx_add_range_direct
 # unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_tx_add_range_direct
-OBJS = obj_tx_add_range_direct.o util.o out.o
+OBJS = obj_tx_add_range_direct.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -47,4 +51,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_tx_alloc/Makefile
+++ b/src/test/obj_tx_alloc/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_tx_alloc/Makefile -- build obj_tx_alloc unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_tx_alloc
-OBJS = obj_tx_alloc.o util.o out.o
+OBJS = obj_tx_alloc.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_tx_free/Makefile
+++ b/src/test/obj_tx_free/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_tx_free/Makefile -- build obj_tx_free unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_tx_free
-OBJS = obj_tx_free.o util.o out.o
+OBJS = obj_tx_free.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/obj_tx_realloc/Makefile
+++ b/src/test/obj_tx_realloc/Makefile
@@ -33,11 +33,15 @@
 #
 # src/test/obj_tx_realloc/Makefile -- build obj_tx_realloc unit test
 #
-vpath %.c ../../libpmemobj
-vpath %.c ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/libpmemobj
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = obj_tx_realloc
-OBJS = obj_tx_realloc.o util.o out.o
+OBJS = obj_tx_realloc.o util.o util_platform.o out.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y
@@ -46,4 +50,4 @@ out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
-INCS += -I../../libpmemobj/ -I../../common/
+INCS += -I$(TOP)/src/libpmemobj/ -I$(TOP)/src/common/

--- a/src/test/out_err/Makefile
+++ b/src/test/out_err/Makefile
@@ -33,15 +33,18 @@
 #
 # src/test/out_err/Makefile -- build unit test for out_err()
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = out_err
-OBJS = out_err.o out.o util.o
+OBJS = out_err.o out.o util.o util_platform.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
 #Test debug output
-CFLAGS += -DDEBUG -I../../common
+CFLAGS += -DDEBUG -I$(TOP)/src/common

--- a/src/test/out_err_mt/Makefile
+++ b/src/test/out_err_mt/Makefile
@@ -33,11 +33,14 @@
 #
 # src/test/out_err_mt/Makefile -- build unit test for error messages
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = out_err_mt
-OBJS = out_err_mt.o util.o out.o
+OBJS = out_err_mt.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
@@ -49,4 +52,4 @@ LIBVMEM=y
 
 include ../Makefile.inc
 
-INCS += -I../../common/
+INCS += -I$(TOP)/src/common/

--- a/src/test/tools/bttcreate/Makefile
+++ b/src/test/tools/bttcreate/Makefile
@@ -31,11 +31,14 @@
 # Makefile -- Makefile for bttcreate tool
 #
 TOP = ../../../..
+PLATFORM = $(TOP)/platform/linux
+
 vpath %.c $(TOP)/src/libpmemblk/
 vpath %.c $(TOP)/src/common/
+vpath %.c $(PLATFORM)/src/common/
 
 TARGET = bttcreate
-OBJS = bttcreate.o btt.o util.o set.o out.o
+OBJS = bttcreate.o btt.o util.o util_platform.o set.o out.o
 
 LIBPMEM=y
 

--- a/src/test/traces/Makefile
+++ b/src/test/traces/Makefile
@@ -33,15 +33,18 @@
 #
 # src/test/traces/Makefile -- build traces unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = traces
-OBJS = traces.o out.o util.o
+OBJS = traces.o out.o util.o util_platform.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
 #Test debug output
-CFLAGS += -DDEBUG -I../../common
+CFLAGS += -DDEBUG -I$(TOP)/src/common

--- a/src/test/traces_custom_function/Makefile
+++ b/src/test/traces_custom_function/Makefile
@@ -33,15 +33,18 @@
 #
 # src/test/traces_custom_function/Makefile -- build traces unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = traces_custom_function
-OBJS = traces_custom_function.o out.o util.o
+OBJS = traces_custom_function.o out.o util.o util_platform.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
 
 #Test debug output
-CFLAGS += -DDEBUG -I../../common
+CFLAGS += -DDEBUG -I$(TOP)/src/common

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -39,7 +39,7 @@ include $(TOP)/src/common.inc
 
 TARGET = libut.a
 OBJS = ut.o ut_alloc.o ut_file.o ut_pthread.o ut_signal.o ut_backtrace.o
-CFLAGS = -I../../include
+CFLAGS = -I$(TOP)/src/include
 CFLAGS += -std=gnu99
 CFLAGS += -ggdb
 CFLAGS += -Wall

--- a/src/test/util_file_create/Makefile
+++ b/src/test/util_file_create/Makefile
@@ -33,12 +33,16 @@
 #
 # src/test/util_file_create/Makefile -- build util_file_create unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_file_create
-OBJS = util_file_create.o util.o out.o
+OBJS = util_file_create.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_file_open/Makefile
+++ b/src/test/util_file_open/Makefile
@@ -33,12 +33,16 @@
 #
 # src/test/util_file_open/Makefile -- build util_file_open unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_file_open
-OBJS = util_file_open.o util.o out.o
+OBJS = util_file_open.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_is_poolset/Makefile
+++ b/src/test/util_is_poolset/Makefile
@@ -34,17 +34,20 @@
 # src/test/util_is_poolset/Makefile -- build util_is_poolset unit test
 #
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = util_is_poolset
-OBJS = util_is_poolset.o util.o set.o out.o
+OBJS = util_is_poolset.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_map_proc/Makefile
+++ b/src/test/util_map_proc/Makefile
@@ -33,13 +33,17 @@
 #
 # src/test/util_map_proc/Makefile -- build util_map_proc unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_map_proc
-OBJS = util_map_proc.o util.o out.o
+OBJS = util_map_proc.o util.o util_platform.o out.o
 
 out.o: CFLAGS += -DSRCVERSION=\"utversion\"
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common
 LIBS += -ldl

--- a/src/test/util_parse_size/Makefile
+++ b/src/test/util_parse_size/Makefile
@@ -33,16 +33,20 @@
 #
 # src/test/util_parse_size/Makefile -- check parsing results
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_parse_size
-OBJS = util_parse_size.o util.o set.o out.o
+OBJS = util_parse_size.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 include ../Makefile.inc
 
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_poolset/Makefile
+++ b/src/test/util_poolset/Makefile
@@ -33,13 +33,17 @@
 #
 # src/test/util_poolset/Makefile -- build util_poolset unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_poolset
-OBJS = util_poolset.o mocks.o util.o set.o out.o
+OBJS = util_poolset.o mocks.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
@@ -48,4 +52,4 @@ USE_PMEMSPOIL=y
 
 include ../Makefile.inc
 LDFLAGS += $(call extract_funcs, mocks.c)
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_poolset_foreach/Makefile
+++ b/src/test/util_poolset_foreach/Makefile
@@ -34,17 +34,20 @@
 # src/test/util_poolset_foreach/Makefile -- build util_poolset_foreach test
 #
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = util_poolset_foreach
-OBJS = util_poolset_foreach.o util.o set.o out.o
+OBJS = util_poolset_foreach.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_poolset_parse/Makefile
+++ b/src/test/util_poolset_parse/Makefile
@@ -33,21 +33,20 @@
 #
 # src/test/util_poolset_parse/Makefile -- build util_poolset_parse unit test
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_poolset_parse
-OBJS = util_poolset_parse.o util.o set.o out.o
+OBJS = util_poolset_parse.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 
 include ../Makefile.inc
-INCS += -I../../common
-
-util_poolset_parse.o: util_poolset_parse.c util.h
-util.o: util.c util.h
-set.o: set.c util.h
-out.o: out.c out.h
+INCS += -I$(TOP)/src/common

--- a/src/test/util_poolset_size/Makefile
+++ b/src/test/util_poolset_size/Makefile
@@ -34,17 +34,20 @@
 # src/test/util_poolset_size/Makefile -- build util_poolset_size
 #
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
 
 TARGET = util_poolset_size
-OBJS = util_poolset_size.o util.o set.o out.o
+OBJS = util_poolset_size.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 
 include ../Makefile.inc
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/test/util_uuid_generate/Makefile
+++ b/src/test/util_uuid_generate/Makefile
@@ -33,16 +33,20 @@
 #
 # src/test/util_uuid_generate/Makefile -- create a uuid and verify it
 #
-vpath %.c ../../common
-vpath %.h ../../common
+TOP = ../../..
+PLATFORM = $(TOP)/platform/linux
+
+vpath %.c $(TOP)/src/common
+vpath %.c $(PLATFORM)/src/common
+
 TARGET = util_uuid_generate
-OBJS = util_uuid_generate.o util.o set.o out.o
+OBJS = util_uuid_generate.o util.o util_platform.o set.o out.o
 
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-util.o: CFLAGS += -DDEBUG
+util.o util_platform.o: CFLAGS += -DDEBUG
 set.o: CFLAGS += -DDEBUG
 
 LIBPMEM=y
 include ../Makefile.inc
 
-INCS += -I../../common
+INCS += -I$(TOP)/src/common

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -32,6 +32,8 @@
 #
 
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
+PLATFORM = $(TOP)/platform/linux
+
 include $(TOP)/src/common.inc
 
 INSTALL_TARGET ?= y
@@ -125,8 +127,9 @@ endif
 ifeq ($(TOOLS_COMMON), y)
 vpath %.c $(TOP)/src/common
 vpath %.c $(TOP)/src/tools/pmempool
+vpath %.c $(PLATFORM)/src/common
 
-OBJS += common.o output.o util.o set.o
+OBJS += common.o output.o util.o util_platform.o set.o
 CFLAGS += -I$(TOP)/src/common
 CFLAGS += -I$(TOP)/src/libpmemlog
 CFLAGS += -I$(TOP)/src/libpmemblk


### PR DESCRIPTION
Move platform-specific utilities to util_platform.c.  When compiling
NVML for Linux or Windows, a platform-specific variant of this file will
be compiled/linked.

Files with platform-specific implementation are located in 'platform'
subdirectory.  The structure of this directory is the same as for the
main directory of the source tree.

This is a preparation for NVML for Windows support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/773)
<!-- Reviewable:end -->
