### PR TITLE
cpp: add missing tests

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -130,7 +130,9 @@ CHRONO_TESTS = \
 	obj_cpp_mutex\
 	obj_cpp_shared_mutex\
 	obj_cpp_cond_var\
-	obj_cpp_cond_var_posix
+	obj_cpp_cond_var_posix\
+	obj_cpp_timed_mtx\
+	obj_cpp_timed_mtx_posix
 
 OTHER_TESTS = \
        arch_flags\


### PR DESCRIPTION
Add two tests for timed_mutex missing from the Makefile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/774)
<!-- Reviewable:end -->
