### PR TITLE
test: fix remote poolset files

### DIFF
--- a/src/test/remote_obj_basic/TEST0
+++ b/src/test/remote_obj_basic/TEST0
@@ -45,8 +45,18 @@ setup
 # how much remote nodes are required
 require_nodes 1
 
-# list of required files that should be copied to the remote nodes
-copy_files_to_node 0 ./pool$UNITTEST_NUM.set
+# create a unique name for pool file
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+
+# create poolset file
+POOLSET_FILE=pool$UNITTEST_NUM.set
+create_poolset $POOLSET_FILE 10M:$POOL_FILE:x
+
+# copy required files to remote nodes
+copy_files_to_node 0 $POOLSET_FILE
+
+# remove local poolset file
+rm -f $POOLSET_FILE
 
 #
 # Run commands on remote nodes
@@ -55,8 +65,8 @@ copy_files_to_node 0 ./pool$UNITTEST_NUM.set
 # LD_LIBRARY_PATH for the n-th remote node can be provided
 # in the array NODE_LD_LIBRARY_PATH[n].
 #
-expect_normal_exit run_on_node 0 ./pmempool rm -f -s pool$UNITTEST_NUM.set
-expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX create pool$UNITTEST_NUM.set
+expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX create $POOLSET_FILE
+expect_normal_exit run_on_node 0 rm -f $POOL_FILE
 
 check
 

--- a/src/test/remote_obj_basic/TEST1
+++ b/src/test/remote_obj_basic/TEST1
@@ -45,8 +45,18 @@ setup
 # how much remote nodes are required
 require_nodes 1
 
-# list of required files that should be copied to the remote nodes
-copy_files_to_node 0 ./pool$UNITTEST_NUM.set
+# create a unique name for pool file
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+
+# create poolset file
+POOLSET_FILE=pool$UNITTEST_NUM.set
+create_poolset $POOLSET_FILE 10M:$POOL_FILE:x
+
+# copy required files to remote nodes
+copy_files_to_node 0 $POOLSET_FILE
+
+# remove local poolset file
+rm -f $POOLSET_FILE
 
 #
 # Run commands on remote nodes
@@ -55,9 +65,9 @@ copy_files_to_node 0 ./pool$UNITTEST_NUM.set
 # LD_LIBRARY_PATH for the n-th remote node can be provided
 # in the array NODE_LD_LIBRARY_PATH[n].
 #
-expect_normal_exit run_on_node 0 ./pmempool rm -f -s pool$UNITTEST_NUM.set
-expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX create pool$UNITTEST_NUM.set
-expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX open pool$UNITTEST_NUM.set
+expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX create $POOLSET_FILE
+expect_normal_exit run_on_node 0 ./remote_obj_basic$EXESUFFIX open $POOLSET_FILE
+expect_normal_exit run_on_node 0 rm -f $POOL_FILE
 
 check
 

--- a/src/test/remote_obj_basic/TEST2
+++ b/src/test/remote_obj_basic/TEST2
@@ -48,8 +48,18 @@ setup
 # how much remote nodes are required
 require_nodes 1
 
-# list of required files that should be copied to the remote nodes
-copy_files_to_node 0 ./pool$UNITTEST_NUM.set
+# create a unique name for pool file
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+
+# create poolset file
+POOLSET_FILE=pool$UNITTEST_NUM.set
+create_poolset $POOLSET_FILE 10M:$POOL_FILE:x
+
+# copy required files to remote nodes
+copy_files_to_node 0 $POOLSET_FILE
+
+# remove local poolset file
+rm -f $POOLSET_FILE
 
 # PID file name for remote test run in background
 PID_FILE="./pid-file-$$.txt"
@@ -64,9 +74,9 @@ clean_remote_node 0 $PID_FILE
 # LD_LIBRARY_PATH for the n-th remote node can be provided
 # in the array NODE_LD_LIBRARY_PATH[n].
 #
-expect_normal_exit run_on_node 0 ./pmempool rm -f -s pool$UNITTEST_NUM.set
-expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX create pool$UNITTEST_NUM.set
+expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX create $POOLSET_FILE
 expect_normal_exit wait_on_node 0 $PID_FILE $TIMEOUT
+expect_normal_exit run_on_node 0 rm -f $POOL_FILE
 
 check
 

--- a/src/test/remote_obj_basic/TEST3
+++ b/src/test/remote_obj_basic/TEST3
@@ -48,8 +48,18 @@ setup
 # how much remote nodes are required
 require_nodes 1
 
-# list of required files that should be copied to the remote nodes
-copy_files_to_node 0 ./pool$UNITTEST_NUM.set
+# create a unique name for pool file
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+
+# create poolset file
+POOLSET_FILE=pool$UNITTEST_NUM.set
+create_poolset $POOLSET_FILE 10M:$POOL_FILE:x
+
+# copy required files to remote nodes
+copy_files_to_node 0 $POOLSET_FILE
+
+# remove local poolset file
+rm -f $POOLSET_FILE
 
 # PID file name for remote test run in background
 PID_FILE="./pid-file-$$.txt"
@@ -64,11 +74,11 @@ clean_remote_node 0 $PID_FILE
 # LD_LIBRARY_PATH for the n-th remote node can be provided
 # in the array NODE_LD_LIBRARY_PATH[n].
 #
-expect_normal_exit run_on_node 0 ./pmempool rm -f -s pool$UNITTEST_NUM.set
-expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX create pool$UNITTEST_NUM.set
+expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX create $POOLSET_FILE
 expect_normal_exit wait_on_node 0 $PID_FILE $TIMEOUT
-expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX open pool$UNITTEST_NUM.set
+expect_normal_exit run_on_node_background 0 $PID_FILE ./remote_obj_basic$EXESUFFIX open $POOLSET_FILE
 expect_normal_exit wait_on_node 0 $PID_FILE $TIMEOUT
+expect_normal_exit run_on_node 0 rm -f $POOL_FILE
 
 check
 

--- a/src/test/remote_obj_basic/pool0.set
+++ b/src/test/remote_obj_basic/pool0.set
@@ -1,2 +1,0 @@
-PMEMPOOLSET
-10M /tmp/pool0.dat

--- a/src/test/remote_obj_basic/pool1.set
+++ b/src/test/remote_obj_basic/pool1.set
@@ -1,2 +1,0 @@
-PMEMPOOLSET
-10M /tmp/pool1.dat

--- a/src/test/remote_obj_basic/pool2.set
+++ b/src/test/remote_obj_basic/pool2.set
@@ -1,2 +1,0 @@
-PMEMPOOLSET
-10M /tmp/pool2.dat

--- a/src/test/remote_obj_basic/pool3.set
+++ b/src/test/remote_obj_basic/pool3.set
@@ -1,2 +1,0 @@
-PMEMPOOLSET
-10M /tmp/pool3.dat


### PR DESCRIPTION
Pool files have to have unique names
in order to enable running parallel tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/775)
<!-- Reviewable:end -->
