### PR TITLE
vmmalloc: avoid using je_vmem_memalign()

### DIFF
--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -214,7 +214,7 @@ aligned_alloc(size_t alignment, size_t size)
 
 	if (Vmp == NULL) {
 		ASSERT(size <= HUGE);
-		return je_vmem_memalign(alignment, size);
+		return je_vmem_aligned_alloc(alignment, size);
 	}
 	LOG(4, "alignment %zu  size %zu", alignment, size);
 	return je_vmem_pool_aligned_alloc(
@@ -235,11 +235,7 @@ posix_memalign(void **memptr, size_t alignment, size_t size)
 	int oerrno = errno;
 	if (Vmp == NULL) {
 		ASSERT(size <= HUGE);
-		*memptr = je_vmem_memalign(alignment, size);
-		if (*memptr == NULL)
-			ret = errno;
-		errno = oerrno;
-		return ret;
+		return je_vmem_posix_memalign(memptr, alignment, size);
 	}
 	LOG(4, "alignment %zu  size %zu", alignment, size);
 	*memptr = je_vmem_pool_aligned_alloc(


### PR DESCRIPTION
Modify posix_memalign() and aligned_alloc() implementation to avoid
using je_vmem_memalign().
The use of je_vmem_memalign() causes problems on platforms that don't
include that legacy API.  The jemalloc configure logic doesn't export
that function unless the platform already provides memalign().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/776)
<!-- Reviewable:end -->
