### PR TITLE
all: enable some optimizations in debug builds

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -67,7 +67,12 @@ CFLAGS += -Wmissing-variable-declarations
 endif
 
 ifeq ($(DEBUG),1)
-CFLAGS += -O0 -ggdb -DDEBUG $(EXTRA_CFLAGS_DEBUG)
+ifeq ($(call check_flag, -Og), y)
+CFLAGS += -Og -fno-omit-frame-pointer
+else
+CFLAGS += -O0
+endif
+CFLAGS += -ggdb -DDEBUG $(EXTRA_CFLAGS_DEBUG)
 LIB_SUBDIR = /nvml_debug
 OBJDIR = debug
 else


### PR DESCRIPTION
From gcc manpage:
"-Og enables optimizations that do not interfere with debugging. It
should be the optimization level of choice for the standard
edit-compile-debug cycle, offering a reasonable level of optimization
while maintaining fast compilation and a good debugging experience."

Available since gcc 4.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/780)
<!-- Reviewable:end -->
