### PR TITLE
common: use physical paths in check-headers script

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -37,7 +37,7 @@ SH_FILE="utils\/check_license\/check-headers\.sh"
 BIN_FILE="utils\/check_license\/check-license"
 LIC_FILE="LICENSE"
 
-PWD=`pwd`
+PWD=`pwd -P`
 SELF_FULL=`echo "$PWD/$0" | sed "s/\/\.\//\//g" `
 NVML=`echo $SELF_FULL | sed "s/$SH_FILE//g" `
 LICENSE=`echo $SELF_FULL | sed "s/$SH_FILE/$LIC_FILE/g" `


### PR DESCRIPTION
"git log" may not work correctly, if PWD contains symlinks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/798)
<!-- Reviewable:end -->
