### PR TITLE
obj: fix a pfree bug that could cause corruption

### DIFF
--- a/src/libpmemobj/memops.h
+++ b/src/libpmemobj/memops.h
@@ -74,6 +74,9 @@ void operation_init(PMEMobjpool *pop, struct operation_context *ctx,
 	struct redo_log *redo);
 void operation_add_entry(struct operation_context *ctx,
 	void *ptr, uint64_t value, enum operation_type type);
+void operation_add_typed_entry(struct operation_context *ctx,
+	void *ptr, uint64_t value,
+	enum operation_type type, enum operation_entry_type en_type);
 void operation_add_entries(struct operation_context *ctx,
 	struct operation_entry *entries, size_t nentries);
 void operation_process(struct operation_context *ctx);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -73,6 +73,7 @@ OBJ_TESTS = \
 	obj_direct\
 	obj_first_next\
 	obj_heap\
+	obj_heap_interrupt\
 	obj_heap_state\
 	obj_lane\
 	obj_list_insert\

--- a/src/test/obj_heap_interrupt/.gitignore
+++ b/src/test/obj_heap_interrupt/.gitignore
@@ -1,0 +1,1 @@
+obj_heap_interrupt

--- a/src/test/obj_heap_interrupt/Makefile
+++ b/src/test/obj_heap_interrupt/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_heap_interrupt/Makefile -- build obj_heap_interrupt unit test
+#
+vpath %.c ../../libpmemobj
+vpath %.c ../../common
+
+TARGET = obj_heap_interrupt
+OBJS = obj_heap_interrupt.o pmalloc.o bucket.o redo.o heap.o lane.o ctree.o\
+    util.o util_linux.o set.o set_linux.o out.o obj.o cuckoo.o\
+    list.o sync.o tx.o memops.o memblock.o libpmemobj.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+out.o: CFLAGS += -DSRCVERSION=\"utversion\"
+
+EXTRA_CFLAGS += -DDEBUG
+
+include ../Makefile.inc
+
+LDFLAGS += $(call extract_funcs, obj_heap_interrupt.c)
+INCS += -I../../libpmemobj/ -I../../common/

--- a/src/test/obj_heap_interrupt/TEST0
+++ b/src/test/obj_heap_interrupt/TEST0
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_heap_interrupt/TEST0 -- unit test for pool heap interruption
+#
+export UNITTEST_NAME=obj_heap_interrupt/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+setup
+
+# exits in the middle of transaction, so pool cannot be closed
+export MEMCHECK_DONT_CHECK_LEAKS=1
+
+create_holey_file 16 $DIR/testfile
+
+expect_normal_exit ./obj_heap_interrupt$EXESUFFIX $DIR/testfile c 0
+expect_normal_exit ./obj_heap_interrupt$EXESUFFIX $DIR/testfile o 0
+
+pass

--- a/src/test/obj_heap_interrupt/obj_heap_interrupt.c
+++ b/src/test/obj_heap_interrupt/obj_heap_interrupt.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_heap_interrupt.c -- unit test for pool heap interruption
+ */
+#include "unittest.h"
+#include "redo.h"
+#include "memops.h"
+#include "pmalloc.h"
+#include "util.h"
+#include "lane.h"
+#include "list.h"
+#include "obj.h"
+#include "heap_layout.h"
+
+POBJ_LAYOUT_BEGIN(heap_interrupt);
+POBJ_LAYOUT_END(heap_interrupt);
+
+
+static int exit_on_process = 0;
+FUNC_MOCK(operation_process, void, struct operation_context *ctx)
+	FUNC_MOCK_RUN_DEFAULT {
+		if (exit_on_process)
+			exit(0);
+		else
+			_FUNC_REAL(operation_process)(ctx);
+	}
+FUNC_MOCK_END
+
+static void
+sc0_create(PMEMobjpool *pop)
+{
+	PMEMoid oids[3];
+	TX_BEGIN(pop) {
+		oids[0] = pmemobj_tx_alloc(CHUNKSIZE - 100, 0);
+		oids[1] = pmemobj_tx_alloc(CHUNKSIZE - 100, 0);
+		oids[2] = pmemobj_tx_alloc(CHUNKSIZE - 100, 0);
+	} TX_END
+
+	pmemobj_free(&oids[0]);
+
+	exit_on_process = 1;
+	pmemobj_free(&oids[1]);
+}
+
+/*
+ * noop_verify -- used in cases in which a successful open means that the test
+ *	have passed successfully.
+ */
+static void
+noop_verify(PMEMobjpool *pop)
+{
+}
+
+typedef void (*scenario_func)(PMEMobjpool *pop);
+
+struct {
+	scenario_func create;
+	scenario_func verify;
+} scenarios[] = {
+	{sc0_create, noop_verify},
+};
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "heap_interrupt");
+
+	if (argc != 4)
+		UT_FATAL("usage: %s file [cmd: c/o] [scenario]", argv[0]);
+
+	const char *path = argv[1];
+
+	PMEMobjpool *pop = NULL;
+	int exists = argv[2][0] == 'o';
+	int scenario = atoi(argv[3]);
+
+	if (!exists) {
+		if ((pop = pmemobj_create(path,
+			POBJ_LAYOUT_NAME(heap_interrupt),
+			0, S_IWUSR | S_IRUSR)) == NULL) {
+			UT_FATAL("failed to create pool\n");
+		}
+		scenarios[scenario].create(pop);
+	} else {
+		if ((pop = pmemobj_open(path,
+			POBJ_LAYOUT_NAME(heap_interrupt)))
+						== NULL) {
+			UT_FATAL("failed to open pool\n");
+		}
+		scenarios[scenario].verify(pop);
+	}
+
+	pmemobj_close(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_memblock/obj_memblock.c
+++ b/src/test/obj_memblock/obj_memblock.c
@@ -49,8 +49,9 @@
 
 static PMEMobjpool *pop;
 
-FUNC_MOCK(operation_add_entry, void, struct operation_context *ctx, void *ptr,
-	uint64_t value, enum operation_type type)
+FUNC_MOCK(operation_add_typed_entry, void, struct operation_context *ctx,
+	void *ptr, uint64_t value,
+	enum operation_type type, enum operation_entry_type en_type)
 	FUNC_MOCK_RUN_DEFAULT {
 		uint64_t *pval = ptr;
 		switch (type) {
@@ -66,6 +67,15 @@ FUNC_MOCK(operation_add_entry, void, struct operation_context *ctx, void *ptr,
 			default:
 				UT_ASSERT(0);
 		}
+	}
+FUNC_MOCK_END
+
+FUNC_MOCK(operation_add_entry, void, struct operation_context *ctx, void *ptr,
+	uint64_t value, enum operation_type type)
+	FUNC_MOCK_RUN_DEFAULT {
+		/* just call the mock above - the entry type doesn't matter */
+		operation_add_typed_entry(ctx, ptr, value, type,
+			ENTRY_TRANSIENT);
 	}
 FUNC_MOCK_END
 


### PR DESCRIPTION
This patches addresses an issue in the way pfree handled coalescing of
chunks that, when interrupted at a specific moment, would result in an
inconsistent state of the persistent heap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/816)
<!-- Reviewable:end -->
