### PR TITLE
obj: fix mismatch in alloc redo log size defines

### DIFF
--- a/src/libpmemobj/heap_layout.h
+++ b/src/libpmemobj/heap_layout.h
@@ -46,7 +46,14 @@
 #define ZONE_MIN_SIZE (sizeof(struct zone) + sizeof(struct chunk))
 #define ZONE_MAX_SIZE (sizeof(struct zone) + sizeof(struct chunk) * MAX_CHUNK)
 #define HEAP_MIN_SIZE (sizeof(struct heap_layout) + ZONE_MIN_SIZE)
-#define REDO_LOG_SIZE 4
+
+/*
+ * The maximum number of entries in redo log used by the allocator. The common
+ * case is to use two, one for modification of the object destination memory
+ * location and the second for applying the chunk metadata modifications.
+ */
+#define ALLOC_REDO_LOG_SIZE 10
+
 #define BITS_PER_VALUE 64U
 #define MAX_CACHELINE_ALIGNMENT 40 /* run alignment, 5 cachelines */
 #define RUN_METASIZE (MAX_CACHELINE_ALIGNMENT * 8)
@@ -126,5 +133,5 @@ struct allocation_header {
 };
 
 struct allocator_lane_section {
-	struct redo_log redo[REDO_LOG_SIZE];
+	struct redo_log redo[ALLOC_REDO_LOG_SIZE];
 };

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -57,13 +57,6 @@
 #include "valgrind_internal.h"
 
 /*
- * The maximum number of entries in redo log used by the allocator. The common
- * case is to use two, one for modification of the object destination memory
- * location and the second for applying the chunk metadata modifications.
- */
-#define MAX_ALLOC_OP_REDO 10
-
-/*
  * Number of bytes between end of allocation header and beginning of user data.
  */
 #define DATA_OFF OBJ_OOB_SIZE
@@ -697,7 +690,7 @@ lane_allocator_recovery(PMEMobjpool *pop, struct lane_section_layout *section)
 	struct allocator_lane_section *sec =
 		(struct allocator_lane_section *)section;
 
-	redo_log_recover(pop, sec->redo, MAX_ALLOC_OP_REDO);
+	redo_log_recover(pop, sec->redo, ALLOC_REDO_LOG_SIZE);
 
 	return 0;
 }
@@ -714,7 +707,7 @@ lane_allocator_check(PMEMobjpool *pop, struct lane_section_layout *section)
 		(struct allocator_lane_section *)section;
 
 	int ret;
-	if ((ret = redo_log_check(pop, sec->redo, MAX_ALLOC_OP_REDO)) != 0)
+	if ((ret = redo_log_check(pop, sec->redo, ALLOC_REDO_LOG_SIZE)) != 0)
 		ERR("allocator lane: redo log check failed");
 
 	return ret;

--- a/src/test/pmempool_info/out14.log.match
+++ b/src/test/pmempool_info/out14.log.match
@@ -29,11 +29,17 @@ Root offset              : $(*)
 Lane:
 
  Lane section             : allocator
-  Redo log entries         : 4
+  Redo log entries         : 10
   0000000000: Offset: $(*) Value: $(*) Finish flag: 0
   0000000001: Offset: $(*) Value: $(*) Finish flag: 0
   0000000002: Offset: $(*) Value: $(*) Finish flag: 0
   0000000003: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000004: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000005: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000006: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000007: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000008: Offset: $(*) Value: $(*) Finish flag: 0
+  0000000009: Offset: $(*) Value: $(*) Finish flag: 0
 
  Lane section             : list
   Object offset            : $(*)

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -1148,7 +1148,8 @@ pmemspoil_process_sec_allocator(struct pmemspoil *psp,
 	struct pmemspoil_list *pfp, struct allocator_lane_section *sec)
 {
 	PROCESS_BEGIN(psp, pfp) {
-		PROCESS(redo_log, &sec->redo[PROCESS_INDEX], REDO_LOG_SIZE);
+		PROCESS(redo_log, &sec->redo[PROCESS_INDEX],
+			ALLOC_REDO_LOG_SIZE);
 	} PROCESS_END
 
 	return PROCESS_RET;

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -99,7 +99,7 @@ lane_need_recovery_alloc(struct pmem_info *pip,
 		(struct allocator_lane_section *)layout;
 
 	/* there is just a redo log */
-	return lane_need_recovery_redo(&section->redo[0], REDO_LOG_SIZE);
+	return lane_need_recovery_redo(&section->redo[0], ALLOC_REDO_LOG_SIZE);
 }
 
 /*
@@ -288,7 +288,7 @@ info_obj_lane_alloc(int v, struct lane_section_layout *layout)
 {
 	struct allocator_lane_section *section =
 		(struct allocator_lane_section *)layout;
-	info_obj_redo(v, &section->redo[0], REDO_LOG_SIZE);
+	info_obj_redo(v, &section->redo[0], ALLOC_REDO_LOG_SIZE);
 }
 
 /*


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/832)
<!-- Reviewable:end -->
