### PR TITLE
win: fix windows UT broken by recent error code change

### DIFF
--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -225,12 +225,16 @@ function runtest {
                     Write-Host "(in ./$testName) TEST=$testtype FS=$fs BUILD=$build .\$runscript"
                 } ElseIf ($use_timeout -And $testtype -eq "check") {
                     # execute with timeout
-                    $p = Start-Process -NoNewWindow -Wait -PassThru -FilePath powershell.exe -ArgumentList ".\$runscript"
+                    $p = Start-Process -NoNewWindow -PassThru -FilePath powershell.exe -ArgumentList ".\$runscript"
+                    sv -Name msg "FAILED"
                     try {
                         $p | Wait-Process -Timeout $time -ErrorAction Stop
                     } catch {
-                        Write-Error -Message "RUNTESTS: stopping: testName/$runscript TIMED OUT, will now be killed"
                         $p | Stop-Process -Force
+                        sv -Name msg "TIMED OUT"
+                    }
+                    if ($p.ExitCode -ne 0) {
+                        Write-Error "RUNTESTS: stopping: testName/$runscript $msg, TEST=$testtype FS=$fs BUILD=$build"
                         cd ..
                         exit $p.ExitCode
                     }

--- a/src/test/blk_nblock/out0w.log.match
+++ b/src/test/blk_nblock/out0w.log.match
@@ -2,7 +2,7 @@ blk_nblock$(nW)TEST0w: START: blk_nblock
  $(nW)blk_nblock$(nW) 512:$(nW)testfile1 512:$(nW)testfile2.512 4096:$(nW)testfile2.512 520:$(nW)testfile2.520 528:$(nW)testfile2.528 4096:$(nW)testfile2.4096 4160:$(nW)testfile2.4160
 $(nW)testfile1: pmemblk_create: Invalid argument
 $(nW)testfile2.512: block size 512 usable blocks: 4161462
-$(nW)testfile2.512: pmemblk_create: Invalid argument
+$(nW)testfile2.512: pmemblk_create: File exists
 $(nW)testfile2.520: block size 520 usable blocks: 2781410
 $(nW)testfile2.528: block size 528 usable blocks: 2781410
 $(nW)testfile2.4096: block size 4096 usable blocks: 523511


### PR DESCRIPTION
An error code change in pull request #836 resulted in different
output on the windows side requiring different match text.  Also
fix an issue where RUNTESTS.PS1 wouldn't stop on a timed out test.

Note: change was from EINVAL to EEXIST in util_header_create()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/838)
<!-- Reviewable:end -->
