### PR TITLE
win: enable test directory override for unit tests

### DIFF
--- a/src/test/blk_nblock/TEST0w.ps1
+++ b/src/test/blk_nblock/TEST0w.ps1
@@ -31,6 +31,14 @@
 #
 # src/test/blk_nblock/TEST0 -- unit test for pmemblk_nblock
 #
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_nblock\TEST0w"
 $Env:UNITTEST_NUM = "0w"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -38,7 +46,6 @@ $Env:UNITTEST_NUM = "0w"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_nblock/TEST1.ps1
+++ b/src/test/blk_nblock/TEST1.ps1
@@ -31,6 +31,15 @@
 #
 # src\test\blk_nblock\TEST1 -- unit test for pmemblk_nblock
 #
+
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_nblock\TEST1"
 $Env:UNITTEST_NUM = "1"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -38,7 +47,6 @@ $Env:UNITTEST_NUM = "1"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_nblock/TEST2w.ps1
+++ b/src/test/blk_nblock/TEST2w.ps1
@@ -31,6 +31,14 @@
 #
 # src/test/blk_nblock/TEST2 -- unit test for pmemblk_nblock
 #
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_nblock\TEST2w"
 $Env:UNITTEST_NUM = "2w"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -38,7 +46,6 @@ $Env:UNITTEST_NUM = "2w"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST0.ps1
+++ b/src/test/blk_non_zero/TEST0.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST0 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST0"
 $Env:UNITTEST_NUM = "0"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "0"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST1.ps1
+++ b/src/test/blk_non_zero/TEST1.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST1 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST1"
 $Env:UNITTEST_NUM = "1"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "1"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST2.ps1
+++ b/src/test/blk_non_zero/TEST2.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST2 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST2"
 $Env:UNITTEST_NUM = "2"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "2"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST3.ps1
+++ b/src/test/blk_non_zero/TEST3.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST2 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST3"
 $Env:UNITTEST_NUM = "3"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "3"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST4.ps1
+++ b/src/test/blk_non_zero/TEST4.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST4 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST4"
 $Env:UNITTEST_NUM = "4"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "4"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST5.ps1
+++ b/src/test/blk_non_zero/TEST5.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST4 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST5"
 $Env:UNITTEST_NUM = "5"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "5"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST6.ps1
+++ b/src/test/blk_non_zero/TEST6.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST6 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST6"
 $Env:UNITTEST_NUM = "6"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,8 +44,6 @@ $Env:UNITTEST_NUM = "6"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
-
 # standard unit test setup
 . ..\unittest\unittest.ps1
 

--- a/src/test/blk_non_zero/TEST7.ps1
+++ b/src/test/blk_non_zero/TEST7.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST7 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST7"
 $Env:UNITTEST_NUM = "7"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "7"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST8.ps1
+++ b/src/test/blk_non_zero/TEST8.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST8 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST8"
 $Env:UNITTEST_NUM = "8"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "8"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/blk_non_zero/TEST9.ps1
+++ b/src/test/blk_non_zero/TEST9.ps1
@@ -32,6 +32,11 @@
 # src/test/blk_non_zero/TEST9 -- unit test for
 # pmemblk_read/write/set_zero/set_error
 #
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
 $Env:UNITTEST_NAME = "blk_non_zero\TEST9"
 $Env:UNITTEST_NUM = "9"
 # XXX:  bash has a few calls to tools that we don't have on
@@ -39,7 +44,6 @@ $Env:UNITTEST_NUM = "9"
 # on their output
 $Env:PMEM_IS_PMEM = $true
 $Env:NON_PMEM_IS_PMEM = $true
-$DIR = ""
 
 # standard unit test setup
 . ..\unittest\unittest.ps1

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -209,6 +209,14 @@ function create_poolset {
             continue
         }
         sv -Name cmd $args[$i]
+        # need to strip out a drive letter if included because we use :
+        # as a delimeter in the arguement
+        sv -Name driveLetter ""
+        if ($cmd -match "([a-zA-Z]):\\") {
+            sv -Name tmp ($cmd.Split("{:\\}",2,[System.StringSplitOptions]::RemoveEmptyEntries))
+            $cmd = $tmp[0] + ":" + $tmp[1].SubString(2)
+            $driveLetter = $tmp[1].SubString(0,2)
+        }
         sv -Name fparms ($cmd.Split("{:}"))
         sv -Name fsize $fparms[0]
 
@@ -216,6 +224,9 @@ function create_poolset {
         # like linux "fpath=`readlink -mn ${fparms[1]}`" but I've not tested
         # that it works with a symlink or shortcut
         sv -Name fpath $fparms[1]
+        if (-Not $driveLetter -eq "") {
+            $fpath = $driveLetter + $fpath
+        }
         sv -Name cmd $fparms[2]
         sv -Name asize $fparms[3]
         sv -Name mode $fparms[4]
@@ -785,8 +796,8 @@ if (-Not ($TEST_LD_LIBRARY_PATH)) {
 # this test, and if the appropriate fs-type doesn't have a directory
 # defined in testconfig.sh, the test is skipped.
 #
-# This behavior can be overridden by setting DIR.  For example:
-#	DIR=\force\test\dir .\TEST0
+# This behavior can be overridden by passin in DIR with -d.  Example:
+#	.\TEST0 -d \force\test\dir 
 #
 
 sv -Name curtestdir (Get-Item -Path ".\").BaseName


### PR DESCRIPTION
Comment/code was incorrect for windows usage when it comes to
manual override of DIR and create_poolset() needed to be
updated to handle a windows path that included a drive letter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/839)
<!-- Reviewable:end -->
