### PR TITLE
obj: fix compilation error

### DIFF
--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -394,8 +394,8 @@ get_lane_info_record(PMEMobjpool *pop)
 		}
 		Lane_info_records = info;
 
-		if (unlikely(!cuckoo_insert(
-				Lane_info_ht, pop->uuid_lo, info) == 0)) {
+		if (unlikely(cuckoo_insert(
+				Lane_info_ht, pop->uuid_lo, info) != 0)) {
 			FATAL("cuckoo_insert");
 		}
 	}


### PR DESCRIPTION
Clang-3.8 issues a compilation warning->error on use of '!'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/844)
<!-- Reviewable:end -->
