### PR TITLE
doc: fix pool set creation examples in man pages

### DIFF
--- a/doc/libpmemblk.3
+++ b/doc/libpmemblk.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemblk.3
 .\"
-.TH libpmemblk 3 "pmemblk API version 1.0.1" "NVM Library"
+.TH libpmemblk 3 "pmemblk API version 1.0.2" "NVM Library"
 .SH NAME
 libpmemblk \- persistent memory resident array of blocks
 .SH SYNOPSIS
@@ -336,7 +336,7 @@ PMEMPOOLSET
 The files in the set may be created by running the following command:
 .IP
 .nf
-pmempool create blk <bsize> --from-set=myblkpool.set
+pmempool create blk <bsize> myblkpool.set
 .fi
 .PP
 .BI "void pmemblk_close(PMEMblkpool *" pbp );

--- a/doc/libpmemlog.3
+++ b/doc/libpmemlog.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmemlog.3
 .\"
-.TH libpmemlog 3 "pmemlog API version 1.0.1" "NVM Library"
+.TH libpmemlog 3 "pmemlog API version 1.0.2" "NVM Library"
 .SH NAME
 libpmemlog \- persistent memory resident log file
 .SH SYNOPSIS
@@ -309,7 +309,7 @@ PMEMPOOLSET
 The files in the set may be created by running the following command:
 .IP
 .nf
-pmempool create log --from-set=mylogpool.set
+pmempool create log mylogpool.set
 .fi
 .PP
 .BI "void pmemlog_close(PMEMlogpool *" plp );


### PR DESCRIPTION
Removes not existing 'pmempool' option ('--from-set') from pool set
creation examples.

Ref: pmem/issues#169

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/850)
<!-- Reviewable:end -->
