### PR TITLE
obj: check pool consistency in pmemobj_open()

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -916,6 +916,14 @@ pmemobj_open_common(const char *path, const char *layout, int cow, int boot)
 			pop->replica = set->replica[r + 1]->part[0].addr;
 	}
 
+	if (boot) {
+		/* check consistency of 'master' replica */
+		pop = set->replica[0]->part[0].addr;
+		if (pmemobj_check_basic(pop) == 0) {
+			goto err;
+		}
+	}
+
 	/*
 	 * If there is more than one replica, check if all of them are
 	 * consistent (recoverable).


### PR DESCRIPTION
Perform the same consistency check on master replica as in
pmemobj_check().  This way, it should not happen that pmemobj_open()
succeeds, while pmemobj_check() fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/852)
<!-- Reviewable:end -->
