### PR TITLE
blk: match BTT Flog initialization to Linux NVDIMM BTT Flog initialization

### DIFF
--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -999,7 +999,7 @@ write_layout(struct btt *bttp, unsigned lane, int write)
 		uint32_t next_free_lba = external_nlba;
 		for (uint32_t i = 0; i < bttp->nfree; i++) {
 			struct btt_flog flog;
-			flog.lba = 0;
+			flog.lba = htole32(i);
 			flog.old_map = flog.new_map =
 				htole32(next_free_lba | BTT_MAP_ENTRY_ZERO);
 			flog.seq = htole32(1);


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/master/drivers/nvdimm/btt.c#L427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/856)
<!-- Reviewable:end -->
