### PR TITLE
cpp: clarify make_persistent_atomic

### DIFF
--- a/src/include/libpmemobj/make_persistent_array_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_array_atomic.hpp
@@ -55,7 +55,8 @@ namespace obj
  * Atomically allocate an array of objects.
  *
  * This function can be used to atomically allocate an array of objects.
- * Cannot be used for simple objects.
+ * Cannot be used for simple objects. Do NOT use this inside transactions, as it
+ * might lead to undefined behavior in the presence of transaction aborts.
  *
  * @param[in,out] pool the pool from which the object will be allocated.
  * @param[in,out] ptr the persistent pointer to which the allocation
@@ -85,7 +86,8 @@ make_persistent_atomic(pool_base &pool,
  * Atomically allocate an array of objects.
  *
  * This function can be used to atomically allocate an array of objects.
- * Cannot be used for simple objects.
+ * Cannot be used for simple objects.  Do NOT use this inside transactions, as
+ * it might lead to undefined behavior in the presence of transaction aborts.
  *
  * @param[in,out] pool the pool from which the object will be allocated.
  * @param[in,out] ptr the persistent pointer to which the allocation
@@ -114,7 +116,8 @@ make_persistent_atomic(pool_base &pool,
  * Atomically deallocate an array of objects.
  *
  * There is no way to atomically destroy an object. Any object specific
- * cleanup must be performed elsewhere.
+ * cleanup must be performed elsewhere. Do NOT use this inside transactions, as
+ * it might lead to undefined behavior in the presence of transaction aborts.
  *
  * param[in,out] ptr the persistent_ptr whose pointee is to be
  * deallocated.
@@ -132,7 +135,8 @@ delete_persistent_atomic(typename detail::pp_if_array<T>::type &ptr,
  * Atomically deallocate an array of objects.
  *
  * There is no way to atomically destroy an object. Any object specific
- * cleanup must be performed elsewhere.
+ * cleanup must be performed elsewhere. Do NOT use this inside transactions, as
+ * it might lead to undefined behavior in the presence of transaction aborts.
  *
  * param[in,out] ptr the persistent_ptr whose pointee is to be
  * deallocated.

--- a/src/include/libpmemobj/make_persistent_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_atomic.hpp
@@ -54,7 +54,9 @@ namespace obj
 /**
  * Atomically allocate and construct an object.
  *
- * Constructor parameters are passed through variadic parameters.
+ * Constructor parameters are passed through variadic parameters. Do NOT use
+ * this inside transactions, as it might lead to undefined behavior in the
+ * presence of transaction aborts.
  *
  * @param[in,out] pool the pool from which the object will be allocated.
  * @param[in,out] ptr the persistent pointer to which the allocation
@@ -84,7 +86,8 @@ make_persistent_atomic(pool_base &pool,
  * Atomically deallocate an object.
  *
  * There is no way to atomically destroy an object. Any object specific
- * cleanup must be performed elsewhere.
+ * cleanup must be performed elsewhere.  Do NOT use this inside transactions, as
+ * it might lead to undefined behavior in the presence of transaction aborts.
  *
  * param[in,out] ptr the persistent_ptr whose pointee is to be
  * deallocated.


### PR DESCRIPTION
State clearly, that using the atomic API inside transactions might yield
undefined behavior in the presence of transaction aborts.

Refs pmem/issues#170

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/859)
<!-- Reviewable:end -->
