### PR TITLE
ut: automatically detect libunwind

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -52,12 +52,14 @@ EX_LIBPMEMOBJ=$(EXAMPLES_DIR)/libpmemobj
 UT = ../unittest/libut.a
 LIBS += $(UT)
 
-ifneq ($(USE_LIBUNWIND),)
-LIBS += -ldl
-ifeq ($(call check_package, libunwind), y)
-LIBS += $(shell $(PKG_CONFIG) --libs libunwind)
+ifeq ($(USE_LIBUNWIND),1)
+LIBS += -ldl -lunwind
 else
-LIBS += -lunwind
+ifneq ($(USE_LIBUNWIND),0)
+UNWIND := $(call check_package, libunwind)
+ifeq ($(UNWIND),y)
+LIBS += -ldl $(shell $(PKG_CONFIG) --libs libunwind)
+endif
 endif
 endif
 

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -62,13 +62,15 @@ ifeq ($(call check_flag, -Wmissing-variable-declarations), y)
 CFLAGS += -Wmissing-variable-declarations
 endif
 
-ifneq ($(USE_LIBUNWIND),)
-
-ifeq ($(call check_package, libunwind), y)
-CFLAGS += $(shell $(PKG_CONFIG) --cflags libunwind)
-endif
-
+ifeq ($(USE_LIBUNWIND),1)
 CFLAGS += -DUSE_LIBUNWIND
+else
+ifneq ($(USE_LIBUNWIND),0)
+UNWIND := $(call check_package, libunwind)
+ifeq ($(UNWIND),y)
+CFLAGS += $(shell $(PKG_CONFIG) --cflags libunwind) -DUSE_LIBUNWIND
+endif
+endif
 endif
 
 CFLAGS += $(EXTRA_CFLAGS)


### PR DESCRIPTION
USE_LIBUNWIND=0 disables detection
USE_LIBUNWIND=1 force enables libunwind (still needed by travis)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/877)
<!-- Reviewable:end -->
