### PR TITLE
cpp: add p<> to ctree example

### DIFF
--- a/src/examples/libpmemobj/cpp_map/ctree_map_persistent.hpp
+++ b/src/examples/libpmemobj/cpp_map/ctree_map_persistent.hpp
@@ -333,7 +333,7 @@ private:
 			entries[1] = nullptr;
 		}
 
-		int diff; /* most significant differing bit */
+		nvobj::p<int> diff; /* most significant differing bit */
 		nvobj::persistent_ptr<entry> entries[2];
 
 		void


### PR DESCRIPTION
This is not needed for correctness, because the field is only modified in the transaction the enclosing object was created in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/882)
<!-- Reviewable:end -->
