### PR TITLE
doc: fix default install path in manpages

### DIFF
--- a/doc/libpmem.3
+++ b/doc/libpmem.3
@@ -640,14 +640,14 @@ but it may be modified by subsequent calls to other library functions.
 A second version of
 .BR libpmem ,
 accessed when a program uses the libraries under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable

--- a/doc/libpmemblk.3
+++ b/doc/libpmemblk.3
@@ -577,14 +577,14 @@ but it may be modified by subsequent calls to other library functions.
 A second version of
 .BR libpmemblk ,
 accessed when a program uses the libraries under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable

--- a/doc/libpmemlog.3
+++ b/doc/libpmemlog.3
@@ -571,14 +571,14 @@ but it may be modified by subsequent calls to other library functions.
 A second version of
 .BR libpmemlog ,
 accessed when a program uses the libraries under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable

--- a/doc/libpmemobj.3
+++ b/doc/libpmemobj.3
@@ -3471,14 +3471,14 @@ but it may be modified by subsequent calls to other library functions.
 A second version of
 .BR libpmemobj ,
 accessed when a program uses the libraries under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable

--- a/doc/libvmem.3
+++ b/doc/libvmem.3
@@ -658,14 +658,14 @@ but it may be modified by subsequent calls to other library functions.
 A second version of
 .BR libvmem ,
 accessed when a program uses the libraries under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable

--- a/doc/libvmmalloc.3
+++ b/doc/libvmmalloc.3
@@ -220,14 +220,14 @@ The normal version is optimized for performance.  That version skips checks
 that impact performance and never logs any trace information or performs
 any run-time assertions.  A second version, accessed when using the libraries
 under
-.BR /usr/lib/nvml_debug ,
+.BR /usr/local/lib/nvml_debug ,
 contains run-time assertions and trace points.
 The typical way to access the debug version is to set the environment variable
 .B LD_LIBRARY_PATH
 to
-.B /usr/lib/nvml_debug
+.B /usr/local/lib/nvml_debug
 or
-.B /usr/lib64/nvml_debug
+.B /usr/local/lib64/nvml_debug
 depending on where the debug libraries are installed on the system.
 The trace points in the debug version of the library
 are enabled using the environment variable


### PR DESCRIPTION
Chenge the references to the default install path to /usr/local/*.

Refs pmem/issues#180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/883)
<!-- Reviewable:end -->
