### PR TITLE
pmem: deprecate PCOMMIT

### DIFF
--- a/doc/libpmem.3
+++ b/doc/libpmem.3
@@ -37,7 +37,7 @@
 .\" or
 .\"	groff -man -Tascii libpmem.3
 .\"
-.TH libpmem 3 "pmem API version 1.0.0" "NVM Library"
+.TH libpmem 3 "pmem API version 1.0.1" "NVM Library"
 .SH NAME
 libpmem \- persistent memory support library
 .SH SYNOPSIS
@@ -418,42 +418,26 @@ for each range and then follow up by
 calling
 .BR pmem_drain ()
 once.
-.IP
-NOTE: Some software is designed for custom platforms that obviate the
-need for using PCOMMIT (perhaps the platform issues PCOMMIT on shutdown
-or something similar).  Even in such cases, it is recommended that
-applications using
-.B libpmem
-do not skip the step of calling
-.BR pmem_drain (),
-either directly or by using
-.BR pmem_persist ().
-The recommended way to inhibit use of the PCOMMIT instruction is
-by setting the
-.B PMEM_NO_PCOMMIT
-environment variable as described in the
-.B ENVIRONMENT VARIABLES
-section.
 .PP
 .BI "int pmem_has_hw_drain(void);"
 .IP
 The
 .BR pmem_has_hw_drain ()
-function returns true if the machine supports the
+function returns true if the machine supports an explicit
 .I hardware drain
-function for persistent memory, such as that provided by the
-.B PCOMMIT
-instruction on Intel processors.  If support for hardware drain
-is not found, or cannot be detected by the library,
-.BR pmem_has_hw_drain ()
-will return false.  Although it is typically an administrative task
-to provide the correct platform configuration for persistent memory,
-this function is provided for the less common cases where an application
-needs to ensure this feature is available.  Note that the lack of this
-feature means that calling
+instruction for persistent memory.  On Intel processors with
+persistent memory, stores to persistent memory are considered
+persistent once they are flushed from the CPU caches, so this
+function always returns false.  Despite that, programs using
+.BR pmem_flush ()
+to flush ranges of memory should still follow up by calling
+.BR pmem_drain ()
+once to ensure the flushes are complete.  As mentioned above,
 .BR pmem_persist ()
-may not fully ensure stores are durable, without additional platform
-features such as Asynchronous DRAM Refresh (ADR) or something similar.
+handles calling both
+.BR pmem_flush ()
+and
+.BR pmem_drain ().
 .SH COPYING TO PERSISTENT MEMORY
 .PP
 The functions in this section provide optimized copying to
@@ -704,17 +688,6 @@ to 1 causes
 to always return true.  This variable is mostly used for testing
 but can be used to force pmem behavior on a system where a range
 of pmem is not detectable as pmem for some reason.
-.PP
-.B PMEM_NO_PCOMMIT=1
-.IP
-Setting this environment variable to 1 forces
-.B libpmem
-to never issue the Intel PCOMMIT instruction.  This can be used on
-platforms where the hardware drain function
-is performed some other way, like automatic flushing during a power failure.
-.IP
-WARNING: Using this environment variable incorrectly
-may impact program correctness.
 .PP
 .B PMEM_NO_CLWB=1
 .IP

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -94,10 +94,6 @@ cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 #define bit_CLFLUSH	(1 << 23)
 #endif
 
-#ifndef bit_PCOMMIT
-#define bit_PCOMMIT	(1 << 22)
-#endif
-
 #ifndef bit_CLFLUSHOPT
 #define bit_CLFLUSHOPT	(1 << 23)
 #endif
@@ -189,7 +185,7 @@ is_cpu_clflushopt_present(void)
 }
 
 /*
- * is_cpu_pcommit_present -- checks if CLWB instruction is supported
+ * is_cpu_clwb_present -- checks if CLWB instruction is supported
  */
 int
 is_cpu_clwb_present(void)
@@ -199,21 +195,6 @@ is_cpu_clwb_present(void)
 
 	int ret = is_cpu_feature_present(0x7, EBX_IDX, bit_CLWB);
 	LOG(4, "CLWB %ssupported", ret == 0 ? "not " : "");
-
-	return ret;
-}
-
-/*
- * is_cpu_pcommit_present -- checks if PCOMMIT instruction is supported
- */
-int
-is_cpu_pcommit_present(void)
-{
-	if (!is_cpu_genuine_intel())
-		return 0;
-
-	int ret = is_cpu_feature_present(0x7, EBX_IDX, bit_PCOMMIT);
-	LOG(4, "PCOMMIT %ssupported", ret == 0 ? "not " : "");
 
 	return ret;
 }

--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -39,4 +39,3 @@ int is_cpu_sse2_present(void);
 int is_cpu_clflush_present(void);
 int is_cpu_clflushopt_present(void);
 int is_cpu_clwb_present(void);
-int is_cpu_pcommit_present(void);

--- a/src/test/util_cpuid/util_cpuid.c
+++ b/src/test/util_cpuid/util_cpuid.c
@@ -49,8 +49,6 @@
 	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *)addr));
 #define _mm_clwb(addr)\
 	asm volatile(".byte 0x66; xsaveopt %0" : "+m" (*(volatile char *)addr));
-#define _mm_pcommit()\
-	asm volatile(".byte 0x66, 0x0f, 0xae, 0xf8");
 
 static char Buf[32];
 
@@ -92,13 +90,6 @@ check_cpu_features(void)
 		_mm_clwb(Buf);
 	} else {
 		UT_OUT("CLWB not supported");
-	}
-
-	if (is_cpu_pcommit_present()) {
-		UT_OUT("PCOMMIT supported");
-		_mm_pcommit();
-	} else {
-		UT_OUT("PCOMMIT not supported");
 	}
 }
 


### PR DESCRIPTION
Since PCOMMIT is deprecated before ever being implemented in a CPU, the CPUID check will always return false and the code protected by that check will never be enabled.  There's no API change and this pull request simply removes dead code.

The only visible change to a programmer is the libpmem.3 man page, which no longer mentions PCOMMIT and no longer describes the debug environment variable PMEM_NO_PCOMMIT which forced the library to act as if PCOMMIT doesn't exist.  It will never exist now so that debug variable is no longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/889)
<!-- Reviewable:end -->
