### PR TITLE
win: move memory mapping routines to libpmem

### DIFF
--- a/src/common/liblinux.vcxproj
+++ b/src/common/liblinux.vcxproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="file_windows.c" />
-    <ClCompile Include="mmap_windows.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B3FF772D-F2FF-4E6E-ABD8-763407BB6A5C}</ProjectGuid>

--- a/src/common/liblinux.vcxproj.filters
+++ b/src/common/liblinux.vcxproj.filters
@@ -14,8 +14,5 @@
     <ClCompile Include="file_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="mmap_windows.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/libpmem/libpmem.def
+++ b/src/libpmem/libpmem.def
@@ -32,6 +32,30 @@
 ;
 ;;;;  End Copyright Notice
 
+/*
+ * XXX - libpmem exports mmap/munmap/msync/mprotect functions
+ *
+ * This is a _temporary_ solution to make those function available for all
+ * the other NVM libraries and to have only one instance of a file mapping
+ * list (owned by libpmem).  Otherwise, each library would have its own
+ * instance of the file mapping list, resulting in libpmem being not able
+ * to find a file handle associated with the mapping address passed to
+ * pmem_msync(), pmem_memcpy(), etc. causing those functions to fail.
+ *
+ * The proposed target solution would include:
+ * - implementation of pmem_mmap, pmem_unmap, pmem_msync and
+ *   pmem_mprotect functions in libpmem (pmem_unmap and pmem_msync are
+ *   already there);
+ * - making sure that all the NVM libraries never call mmap, munmap,
+ *   msync and mprotect directly, but only through their libpmem
+ *   counterparts;
+ * - new pmem_mmap() function must provide similar functionality to
+ *   mmap(), i.e. it must take 'offset' argument, but should not take
+ *   file descriptor argument.  Perhaps it could be an opaque handle
+ *   to the file, that is internally casted to a file descriptor
+ *   or a HANDLE, depending on the OS.
+ */
+
 LIBRARY libpmem
 
 VERSION 1.0
@@ -53,4 +77,10 @@ EXPORTS
 	pmem_memset_nodrain
 	pmem_check_version
 	pmem_errormsg
+
+	mmap
+	munmap
+	msync
+	mprotect
+
 	DllMain

--- a/src/libpmemblk/libpmemblk.vcxproj
+++ b/src/libpmemblk/libpmemblk.vcxproj
@@ -24,7 +24,6 @@
     <ClCompile Include="..\..\src\libpmemblk\btt.c" />
     <ClCompile Include="..\..\src\libpmemblk\libpmemblk.c" />
     <ClCompile Include="..\common\file_windows.c" />
-    <ClCompile Include="..\common\mmap_windows.c" />
     <ClCompile Include="..\common\pthread_windows.c" />
     <ClCompile Include="libpmemblk_main.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">true</ExcludedFromBuild>

--- a/src/libpmemblk/libpmemblk.vcxproj.filters
+++ b/src/libpmemblk/libpmemblk.vcxproj.filters
@@ -39,9 +39,6 @@
     <ClCompile Include="..\common\file_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\mmap_windows.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\pthread_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/libpmemlog/libpmemlog.vcxproj
+++ b/src/libpmemlog/libpmemlog.vcxproj
@@ -23,7 +23,6 @@
     <ClCompile Include="..\..\src\libpmemlog\log.c" />
     <ClCompile Include="..\..\src\libpmemlog\libpmemlog.c" />
     <ClCompile Include="..\common\file_windows.c" />
-    <ClCompile Include="..\common\mmap_windows.c" />
     <ClCompile Include="..\common\pthread_windows.c" />
     <ClCompile Include="libpmemlog_main.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">true</ExcludedFromBuild>

--- a/src/libpmemlog/libpmemlog.vcxproj.filters
+++ b/src/libpmemlog/libpmemlog.vcxproj.filters
@@ -28,9 +28,6 @@
     <ClCompile Include="..\common\file_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\mmap_windows.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\pthread_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/libpmemobj/libpmemobj.vcxproj
+++ b/src/libpmemobj/libpmemobj.vcxproj
@@ -34,7 +34,6 @@
     <ClCompile Include="..\..\src\libpmemobj\sync.c" />
     <ClCompile Include="..\..\src\libpmemobj\tx.c" />
     <ClCompile Include="..\common\file_windows.c" />
-    <ClCompile Include="..\common\mmap_windows.c" />
     <ClCompile Include="..\common\pthread_windows.c" />
     <ClCompile Include="libpmemobj_main.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">true</ExcludedFromBuild>

--- a/src/libpmemobj/libpmemobj.vcxproj.filters
+++ b/src/libpmemobj/libpmemobj.vcxproj.filters
@@ -61,9 +61,6 @@
     <ClCompile Include="..\common\file_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\common\mmap_windows.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\pthread_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Windows implementation of mmap(), munmap(), msync() and mprotect() has
been moved to libpmem.
On Windows, those functions are exported by libpmem, making them available
for all the other NVM libraries. So, there is no need to link mmap_windows
unit to each NVM library or test program.
libpmem now holds the only instance of file mapping list, so it is able
to find the file handle associated with the address passed to
pmem_msync() and flush the data to persistence, regardless of which
library created the file mapping.

Note: This is a temporary solution - a subject for change in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/904)
<!-- Reviewable:end -->
