### PR TITLE
test: fix 'make pcheck'

### DIFF
--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -190,7 +190,7 @@ clobber: clean
 	$(RM) -r .deps
 
 TST=$(shell basename `pwd`)
-TSTCHECKS=$(shell ls -1 TEST* | grep -v "\.ps1" | sort -V)
+TSTCHECKS=$(shell ls -1 TEST* | grep -v -i -e "\.ps1" | sort -V)
 
 $(TSTCHECKS): all
 	@cd .. && ./RUNTESTS ${TST} -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) -p $(PMEMCHECK) -e $(HELGRIND) -d $(DRD) -s $@

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -104,7 +104,7 @@ runtest() {
 	builds=$buildtype
 	[ "$builds" = all ] && builds="debug nondebug static-debug static-nondebug"
 	runscripts=$testfile
-	[ "$runscripts" = all ] && runscripts=`ls -1 TEST* | grep -v "\.PS1" | sort -V`
+	[ "$runscripts" = all ] && runscripts=`ls -1 TEST* | grep -v -i -e "\.ps1" | sort -V`
 
 	# for each fs-type being tested...
 	for fs in $fss


### PR DESCRIPTION
Fix parallel unit tests ('make pcheck') broken by commit 971d91.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/905)
<!-- Reviewable:end -->
