### PR TITLE
benchmarks: minor updates

### DIFF
--- a/src/benchmarks/perf.cfg
+++ b/src/benchmarks/perf.cfg
@@ -8,7 +8,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 200000
 threads = 1:+1:32
-type-num = per-thread
+type-number = per-thread
 data-size = 256
 
 # pmemobj_tx_alloc(size = 128k, type_num per thread) vs threads
@@ -17,7 +17,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 500
 threads = 1:+1:32
-type-num = per-thread
+type-number = per-thread
 data-size = 131072
 
 # pmemobj_tx_alloc(size = 256, type_num per thread) vs threads
@@ -26,7 +26,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 200000
 threads = 1:+1:32
-type-num = one
+type-number = one
 data-size = 256
 
 # pmemobj_tx_alloc(size = 128k, type_num per thread) vs threads
@@ -35,7 +35,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 500
 threads = 1:+1:32
-type-num = one
+type-number = one
 data-size = 131072
 
 # pmemobj_tx_alloc vs data-size
@@ -44,7 +44,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 50000
 threads = 1
-type-num = one
+type-number = one
 data-size = 32768
 
 # pmalloc (size = 245) vs threads
@@ -69,7 +69,7 @@ bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 50000
 threads = 1
-type-num = one
+type-number = one
 data-size = 1:*2:32768
 
 # btree_map_insert vs threads

--- a/src/benchmarks/perf.cfg
+++ b/src/benchmarks/perf.cfg
@@ -1,6 +1,6 @@
 [global]
 file = testfile
-repeats = 3
+repeats = 5
 
 # pmemobj_tx_alloc(size = 256, type_num per thread) vs threads
 [obj_tx_alloc_small_v_thread_type_num_per_thread]

--- a/src/benchmarks/pmembench_tx.cfg
+++ b/src/benchmarks/pmembench_tx.cfg
@@ -21,7 +21,7 @@ data-size = 512
 bench = obj_tx_alloc
 threads = 1:+1:5
 data-size = 512
-type-num = per-thread
+type-number = per-thread
 
 # obj_tx_alloc benchmark
 # variable allocation size
@@ -32,7 +32,7 @@ bench = obj_tx_alloc
 data-size = 8:*2:16384
 operation = abort-nested
 nestings = 100
-type-num = rand
+type-number = rand
 
 # obj_tx_alloc benchmark
 # variable allocation size
@@ -43,7 +43,7 @@ bench = obj_tx_alloc
 data-size = 8:*2:16384
 nestings = 100
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_alloc benchmark
 # variable allocation size
@@ -54,7 +54,7 @@ bench = obj_tx_alloc
 data-size = 8:*2:16384
 nestings = 100
 lib = pmem
-type-num = rand
+type-number = rand
 
 # obj_tx_alloc benchmark
 # variable number of nested transactions
@@ -66,7 +66,7 @@ data-size = 512
 min-size = 1
 operation = abort-nested
 nestings = 1:*10:10000
-type-num = rand
+type-number = rand
 
 # obj_tx_alloc benchmark
 # variable number of nested transactions
@@ -78,7 +78,7 @@ data-size = 512
 min-size = 1
 nestings = 1:*10:10000
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_alloc benchmark
 # variable number of nested transactions
@@ -90,7 +90,7 @@ data-size = 512
 min-size = 1
 nestings = 1:*10:10000
 lib = pmem
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable allocation size
@@ -101,7 +101,7 @@ bench = obj_tx_free
 data-size = 8:*2:8192
 operation = abort-nested
 nestings = 100
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable allocation size
@@ -112,7 +112,7 @@ bench = obj_tx_free
 data-size = 8:*2:8192
 nestings = 100
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable allocation size
@@ -123,7 +123,7 @@ bench = obj_tx_free
 data-size = 8:*2:8192
 nestings = 100
 lib = pmem
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable number of nested transactions
@@ -135,7 +135,7 @@ data-size = 512
 min-size = 1
 operation = abort-nested
 nestings = 1:*10:10000
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable number of nested transactions
@@ -147,7 +147,7 @@ data-size = 512
 min-size = 1
 nestings = 1:*10:10000
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_free benchmark
 # variable number of nested transactions
@@ -159,7 +159,7 @@ data-size = 512
 min-size = 1
 nestings = 1:*10:10000
 lib = pmem
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable allocation size
@@ -172,7 +172,7 @@ realloc-size = 64
 min-rsize = 1
 operation = abort
 nestings = 100
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable allocation size
@@ -185,7 +185,7 @@ realloc-size = 64
 min-rsize = 1
 nestings = 100
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable allocation size
@@ -198,7 +198,7 @@ realloc-size = 64
 min-rsize = 1
 nestings = 100
 lib = pmem
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable reallocation size
@@ -212,7 +212,7 @@ min-size = 1
 realloc-size = 256:*2:16384
 operation = abort
 changed-type = true
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable reallocation size
@@ -224,7 +224,7 @@ data-size = 4
 min-size = 1
 realloc-size = 256:*2:16384
 lib = dram
-type-num = rand
+type-number = rand
 
 # obj_tx_realloc benchmark
 # variable reallocation size
@@ -238,7 +238,7 @@ min-size = 1
 realloc-size = 256:*2:16384
 lib = pmem
 changed-type = true
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -249,7 +249,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = all-obj
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -261,7 +261,7 @@ bench = obj_tx_add_range
 data-size = 512
 operation = all-obj
 ops-per-thread = 1:*5:625
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -272,7 +272,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = basic
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -284,7 +284,7 @@ bench = obj_tx_add_range
 data-size = 10000
 operation = basic
 ops-per-thread = 1:*5:78125
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -295,7 +295,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = range
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -307,7 +307,7 @@ bench = obj_tx_add_range
 data-size = 10000
 operation = range
 ops-per-thread = 1:*5:625
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -318,7 +318,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = all-obj-nested
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -330,7 +330,7 @@ bench = obj_tx_add_range
 data-size = 10000
 operation = all-obj-nested
 ops-per-thread = 1:*5:625
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -341,7 +341,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = one-obj-nested
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -353,7 +353,7 @@ bench = obj_tx_add_range
 data-size = 10000
 operation = one-obj-nested
 ops-per-thread = 1:*5:625
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable allocation size
@@ -364,7 +364,7 @@ type-num = rand
 bench = obj_tx_add_range
 data-size = 128:*2:16384
 operation = range-nested
-type-num = rand
+type-number = rand
 
 # obj_tx_add_range benchmark
 # variable operations number
@@ -376,4 +376,4 @@ bench = obj_tx_add_range
 data-size = 10000
 operation = range-nested
 ops-per-thread = 1:*5:625
-type-num = rand
+type-number = rand

--- a/src/benchmarks/pmemobj_tx.c
+++ b/src/benchmarks/pmemobj_tx.c
@@ -198,7 +198,7 @@ struct offset
 static struct benchmark_clo obj_tx_clo[] = {
 	{
 		.opt_short	= 'T',
-		.opt_long	= "type-num",
+		.opt_long	= "type-number",
 		.descr		= "Type number - one, rand, per-thread",
 		.def		= "one",
 		.type		= CLO_TYPE_STR,


### PR DESCRIPTION
- use type-number instead of type-num in benchmarks arguments
- increase number of repeats

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/913)
<!-- Reviewable:end -->
