### PR TITLE
cpp: check for nullptr deletion in atomic API

### DIFF
--- a/src/include/libpmemobj/make_persistent_array_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_array_atomic.hpp
@@ -127,6 +127,9 @@ void
 delete_persistent_atomic(typename detail::pp_if_array<T>::type &ptr,
 			 std::size_t N)
 {
+	if (ptr == nullptr)
+		return;
+
 	/* we CAN'T call destructor */
 	pmemobj_free(ptr.raw_ptr());
 }
@@ -145,6 +148,9 @@ template <typename T>
 void
 delete_persistent_atomic(typename detail::pp_if_size_array<T>::type &ptr)
 {
+	if (ptr == nullptr)
+		return;
+
 	/* we CAN'T call destructor */
 	pmemobj_free(ptr.raw_ptr());
 }

--- a/src/include/libpmemobj/make_persistent_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_atomic.hpp
@@ -97,6 +97,9 @@ void
 delete_persistent_atomic(
 	typename detail::pp_if_not_array<T>::type &ptr) noexcept
 {
+	if (ptr == nullptr)
+		return;
+
 	/* we CAN'T call the destructor */
 	pmemobj_free(ptr.raw_ptr());
 }

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
@@ -164,6 +164,26 @@ test_constructor_exception(nvobj::pool_base &pop)
 
 	UT_ASSERT(except);
 }
+
+/*
+ * test_delete_null -- (internal) test atomic delete nullptr
+ */
+void
+test_delete_null(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<foo[]> pfoo;
+	nvobj::persistent_ptr<bar[3]> pbar;
+
+	UT_ASSERT(pfoo == nullptr);
+	UT_ASSERT(pbar == nullptr);
+
+	try {
+		nvobj::delete_persistent_atomic<foo[]>(pfoo, 2);
+		nvobj::delete_persistent_atomic<bar[3]>(pbar);
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
 }
 
 int
@@ -188,6 +208,7 @@ main(int argc, char *argv[])
 	test_make_one_d(pop);
 	test_make_two_d(pop);
 	test_constructor_exception(pop);
+	test_delete_null(pop);
 
 	pop.close();
 

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
@@ -125,6 +125,23 @@ test_make_args(nvobj::pool<struct root> &pop)
 
 	nvobj::delete_persistent_atomic<foo>(r->pfoo);
 }
+
+/*
+ * test_delete_null -- (internal) test atomic delete nullptr
+ */
+void
+test_delete_null(nvobj::pool<struct root> &pop)
+{
+	nvobj::persistent_ptr<foo> pfoo;
+
+	UT_ASSERT(pfoo == nullptr);
+
+	try {
+		nvobj::delete_persistent_atomic<foo>(pfoo);
+	} catch (...) {
+		UT_ASSERT(0);
+	}
+}
 }
 
 int
@@ -148,6 +165,7 @@ main(int argc, char *argv[])
 
 	test_make_no_args(pop);
 	test_make_args(pop);
+	test_delete_null(pop);
 
 	pop.close();
 


### PR DESCRIPTION
Properly handle deletion of nullptr in the atomic allocation API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/914)
<!-- Reviewable:end -->
