### PR TITLE
pmemblk: cast translation entry to uint64_t when calculating data offset

### DIFF
--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -1583,7 +1583,7 @@ btt_read(struct btt *bttp, unsigned lane, uint64_t lba, void *buf)
 	 * block from getting re-allocated to something else by a write.
 	 */
 	uint64_t data_block_off =
-		arenap->dataoff + (entry & BTT_MAP_ENTRY_LBA_MASK) *
+		arenap->dataoff + (uint64_t)(entry & BTT_MAP_ENTRY_LBA_MASK) *
 		arenap->internal_lbasize;
 	int readret = (*bttp->ns_cbp->nsread)(bttp->ns, lane, buf,
 					bttp->lbasize, data_block_off);
@@ -1748,7 +1748,7 @@ btt_write(struct btt *bttp, unsigned lane, uint64_t lba, const void *buf)
 
 	/* it is now safe to perform write to the free block */
 	uint64_t data_block_off = arenap->dataoff +
-		(free_entry & BTT_MAP_ENTRY_LBA_MASK) *
+		(uint64_t)(free_entry & BTT_MAP_ENTRY_LBA_MASK) *
 		arenap->internal_lbasize;
 	if ((*bttp->ns_cbp->nswrite)(bttp->ns, lane, buf,
 				bttp->lbasize, data_block_off) < 0)


### PR DESCRIPTION
In btt_read() and btt_write(), when calculating the final data offset, the translation entry value and arena internal_lbasize are 32-bit, resulting in truncation when the offset is large followed by a read/write of the wrong offset.  Cast the entry value to uint64_t to avoid the truncation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/920)
<!-- Reviewable:end -->
