### PR TITLE
common: do not use -Og for debug build

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -65,12 +65,7 @@ CFLAGS += -Wmissing-variable-declarations
 endif
 
 ifeq ($(DEBUG),1)
-ifeq ($(call check_flag, -Og), y)
-CFLAGS += -Og -fno-omit-frame-pointer
-else
-CFLAGS += -O0
-endif
-CFLAGS += -ggdb -DDEBUG $(EXTRA_CFLAGS_DEBUG)
+CFLAGS += -O0 -ggdb -DDEBUG $(EXTRA_CFLAGS_DEBUG)
 LIB_SUBDIR = /nvml_debug
 OBJDIR = debug
 else


### PR DESCRIPTION
The -Og flag makes it harder to debug the program when performing
instruction steps.

This reverts commit 19a0802f4f929ed8ef014f3f717b7db9b2dffc95.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/921)
<!-- Reviewable:end -->
