### PR TITLE
cpp: add include path to C++ documentation

### DIFF
--- a/doc/cppobj.Doxyfile
+++ b/doc/cppobj.Doxyfile
@@ -159,6 +159,15 @@ IMAGE_PATH =
 
 STRIP_FROM_PATH = ../..
 
+# The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
+# path mentioned in the documentation of a class, which tells the reader which
+# header file to include in order to use a class. If left blank only the name
+# of the header file containing the class definition is used. Otherwise one
+# should specify the list of include paths that are normally passed to the
+# compiler using the -I flag.
+
+STRIP_FROM_INC_PATH = ../src/include/
+
 #---------------------------------------------------------------------------
 # Configuration options related to the LATEX output
 #---------------------------------------------------------------------------


### PR DESCRIPTION
The include path now shows `#include <libpmemobj/XXX.hpp>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/929)
<!-- Reviewable:end -->
