### PR TITLE
rpmem: fix use of uninitialized value issue

### DIFF
--- a/src/tools/rpmemd/rpmemd_fip.c
+++ b/src/tools/rpmemd/rpmemd_fip.c
@@ -765,7 +765,7 @@ rpmemd_fip_cq_thread(void *arg)
 	struct fi_cq_err_entry err;
 	const char *str_err;
 	ssize_t sret;
-	int ret;
+	int ret = 0;
 
 	while (!fip->closing) {
 		sret = fi_cq_sread(fip->cq, fip->cq_entries,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/943)
<!-- Reviewable:end -->
