### PR TITLE
test: use Valgrind workaround for all tests

### DIFF
--- a/src/test/obj_memcheck/TEST0
+++ b/src/test/obj_memcheck/TEST0
@@ -57,8 +57,6 @@ fi
 
 expect_normal_exit ./obj_memcheck$EXESUFFIX t $DIR/testfile
 
-ignore_debug_info_errors ${VALGRIND_LOG_FILE}
-
 check
 
 pass

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -530,8 +530,11 @@ function expect_normal_exit() {
 	fi
 	if [ "$CHECK_TYPE" != "none" ]; then
 		TRACE="$OLDTRACE"
-		if [ -f $VALGRIND_LOG_FILE -a "${VALIDATE_VALGRIND_LOG}" = "1" ]; then
+		if [ -f $VALGRIND_LOG_FILE ]; then
 			ignore_debug_info_errors ${VALGRIND_LOG_FILE}
+		fi
+
+		if [ -f $VALGRIND_LOG_FILE -a "${VALIDATE_VALGRIND_LOG}" = "1" ]; then
 			if [ ! -e $CHECK_TYPE$UNITTEST_NUM.log.match ] && grep "ERROR SUMMARY: [^0]" $VALGRIND_LOG_FILE >/dev/null; then
 				msg="failed"
 				[ -t 2 ] && command -v tput >/dev/null && msg="$(tput setaf 1)$msg$(tput sgr0)"


### PR DESCRIPTION
Now obj_constructor test requires it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/948)
<!-- Reviewable:end -->
