### PR TITLE
rpmem: fix conversion from 'int' to 'uint32_t'

### DIFF
--- a/src/rpmem_common/base64.c
+++ b/src/rpmem_common/base64.c
@@ -157,13 +157,13 @@ base64_decode(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_len)
 
 	size_t j = 0;
 	for (size_t i = 0; i < in_len; ) {
-		uint32_t a = in[i] == BASE64_PAD ? 0 : Base64_dec[in[i]];
+		uint32_t a = in[i] == BASE64_PAD ? 0U : Base64_dec[in[i]];
 		i++;
-		uint32_t b = in[i] == BASE64_PAD ? 0 : Base64_dec[in[i]];
+		uint32_t b = in[i] == BASE64_PAD ? 0U : Base64_dec[in[i]];
 		i++;
-		uint32_t c = in[i] == BASE64_PAD ? 0 : Base64_dec[in[i]];
+		uint32_t c = in[i] == BASE64_PAD ? 0U : Base64_dec[in[i]];
 		i++;
-		uint32_t d = in[i] == BASE64_PAD ? 0 : Base64_dec[in[i]];
+		uint32_t d = in[i] == BASE64_PAD ? 0U : Base64_dec[in[i]];
 		i++;
 
 		uint32_t p = base64_pack6(a, b, c, d);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/971)
<!-- Reviewable:end -->
