### PR TITLE
common: pandoc and doxygen packages added to Docker images

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-23
+++ b/utils/docker/images/Dockerfile.fedora-23
@@ -42,7 +42,8 @@ MAINTAINER wojciech.uss@intel.com
 RUN dnf install -y git gcc clang openssh-server autoconf automake make \
 	wget tar lbzip2 passwd sudo pkgconfig procps-ng net-tools jemalloc \
 	findutils man libunwind-devel file rpm-build rpm-build-libs which \
-	fuse fuse-devel ncurses-devel libuv-devel glib2-devel libtool
+	fuse fuse-devel ncurses-devel libuv-devel glib2-devel libtool \
+	pandoc doxygen
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -43,7 +43,7 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common libunwind8-dev autoconf \
 	devscripts pkg-config ssh git gcc clang debhelper vim sudo whois \
 	libc6-dbg libncurses5-dev libuv1-dev libfuse-dev libglib2.0-dev \
-	libtool
+	libtool pandoc doxygen
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh


### PR DESCRIPTION
Pandoc and doxygen packages are required for conversion of markdown into manual pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/973)
<!-- Reviewable:end -->
