### PR TITLE
Obj cpp port

### DIFF
--- a/src/NVML.sln
+++ b/src/NVML.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{853D45D8-980C-4991-B62A-DAC6FD245402}"
 EndProject
@@ -135,6 +135,34 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "win_mmap", "test\win_mmap\w
 	ProjectSection(ProjectDependencies) = postProject
 		{CE3F2DFB-8470-4802-AD37-21CAF6CB2681} = {CE3F2DFB-8470-4802-AD37-21CAF6CB2681}
 	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_cond_var", "test\obj_cpp_cond_var\obj_cpp_cond_var.vcxproj", "{A5794EFF-8232-4E2B-B52C-908823048F54}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_make_persistent", "test\obj_cpp_make_persistent\obj_cpp_make_persistent.vcxproj", "{8F42055F-FFD9-4B10-B266-6DD32923F0AC}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_make_persistent_array", "test\obj_cpp_make_persistent_array\obj_cpp_make_persistent_array.vcxproj", "{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_make_persistent_array_atomic", "test\obj_cpp_make_persistent_array_atomic\obj_cpp_make_persistent_array_atomic.vcxproj", "{0DC1B184-C814-448F-8B5F-CFFA6F05156C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_make_persistent_atomic", "test\obj_cpp_make_persistent_atomic\obj_cpp_make_persistent_atomic.vcxproj", "{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_mutex", "test\obj_cpp_mutex\obj_cpp_mutex.vcxproj", "{1E564DB1-0687-4CC4-BAE5-453F93052FDA}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_p_ext", "test\obj_cpp_p_ext\obj_cpp_p_ext.vcxproj", "{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_pool", "test\obj_cpp_pool\obj_cpp_pool.vcxproj", "{90C5FCF1-8243-4988-A4EA-AA6A88268373}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_pool_primitives", "test\obj_cpp_pool_primitives\obj_cpp_pool_primitives.vcxproj", "{FB6AFFAA-0279-41F7-A698-F81C90BBD987}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_ptr", "test\obj_cpp_ptr\obj_cpp_ptr.vcxproj", "{DFEBEBAA-9624-445C-82A0-93363E22D806}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_ptr_arith", "test\obj_cpp_ptr_arith\obj_cpp_ptr_arith.vcxproj", "{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_shared_mutex", "test\obj_cpp_shared_mutex\obj_cpp_shared_mutex.vcxproj", "{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_timed_mtx", "test\obj_cpp_timed_mtx\obj_cpp_timed_mtx.vcxproj", "{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_cpp_transaction", "test\obj_cpp_transaction\obj_cpp_transaction.vcxproj", "{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -303,6 +331,118 @@ Global
 		{5580D11C-FDA6-4CF2-A0E8-1C2D3FBC11F1}.Static-Debug|x64.Build.0 = Static-Debug|x64
 		{5580D11C-FDA6-4CF2-A0E8-1C2D3FBC11F1}.Static-Release|x64.ActiveCfg = Release|x64
 		{5580D11C-FDA6-4CF2-A0E8-1C2D3FBC11F1}.Static-Release|x64.Build.0 = Release|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Debug|x64.ActiveCfg = Debug|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Debug|x64.Build.0 = Debug|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Release|x64.ActiveCfg = Release|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Release|x64.Build.0 = Release|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Static-Release|x64.ActiveCfg = Release|x64
+		{A5794EFF-8232-4E2B-B52C-908823048F54}.Static-Release|x64.Build.0 = Release|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Debug|x64.ActiveCfg = Debug|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Debug|x64.Build.0 = Debug|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Release|x64.ActiveCfg = Release|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Release|x64.Build.0 = Release|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Static-Release|x64.ActiveCfg = Release|x64
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC}.Static-Release|x64.Build.0 = Release|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Debug|x64.ActiveCfg = Debug|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Debug|x64.Build.0 = Debug|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Release|x64.ActiveCfg = Release|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Release|x64.Build.0 = Release|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Static-Release|x64.ActiveCfg = Release|x64
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}.Static-Release|x64.Build.0 = Release|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Debug|x64.ActiveCfg = Debug|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Debug|x64.Build.0 = Debug|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Release|x64.ActiveCfg = Release|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Release|x64.Build.0 = Release|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Static-Release|x64.ActiveCfg = Release|x64
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C}.Static-Release|x64.Build.0 = Release|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Debug|x64.ActiveCfg = Debug|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Debug|x64.Build.0 = Debug|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Release|x64.ActiveCfg = Release|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Release|x64.Build.0 = Release|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Static-Release|x64.ActiveCfg = Release|x64
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}.Static-Release|x64.Build.0 = Release|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Debug|x64.ActiveCfg = Debug|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Debug|x64.Build.0 = Debug|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Release|x64.ActiveCfg = Release|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Release|x64.Build.0 = Release|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Static-Release|x64.ActiveCfg = Release|x64
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA}.Static-Release|x64.Build.0 = Release|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Debug|x64.ActiveCfg = Debug|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Debug|x64.Build.0 = Debug|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Release|x64.ActiveCfg = Release|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Release|x64.Build.0 = Release|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Static-Release|x64.ActiveCfg = Release|x64
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}.Static-Release|x64.Build.0 = Release|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Debug|x64.ActiveCfg = Debug|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Debug|x64.Build.0 = Debug|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Release|x64.ActiveCfg = Release|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Release|x64.Build.0 = Release|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Static-Release|x64.ActiveCfg = Release|x64
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373}.Static-Release|x64.Build.0 = Release|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Debug|x64.ActiveCfg = Debug|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Debug|x64.Build.0 = Debug|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Release|x64.ActiveCfg = Release|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Release|x64.Build.0 = Release|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Static-Release|x64.ActiveCfg = Release|x64
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987}.Static-Release|x64.Build.0 = Release|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Debug|x64.ActiveCfg = Debug|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Debug|x64.Build.0 = Debug|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Release|x64.ActiveCfg = Release|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Release|x64.Build.0 = Release|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Static-Release|x64.ActiveCfg = Release|x64
+		{DFEBEBAA-9624-445C-82A0-93363E22D806}.Static-Release|x64.Build.0 = Release|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Debug|x64.ActiveCfg = Debug|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Debug|x64.Build.0 = Debug|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Release|x64.ActiveCfg = Release|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Release|x64.Build.0 = Release|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Static-Release|x64.ActiveCfg = Release|x64
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}.Static-Release|x64.Build.0 = Release|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Debug|x64.ActiveCfg = Debug|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Debug|x64.Build.0 = Debug|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Release|x64.ActiveCfg = Release|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Release|x64.Build.0 = Release|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Static-Release|x64.ActiveCfg = Release|x64
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}.Static-Release|x64.Build.0 = Release|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Debug|x64.ActiveCfg = Debug|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Debug|x64.Build.0 = Debug|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Release|x64.ActiveCfg = Release|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Release|x64.Build.0 = Release|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Static-Release|x64.ActiveCfg = Release|x64
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}.Static-Release|x64.Build.0 = Release|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Debug|x64.ActiveCfg = Debug|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Debug|x64.Build.0 = Debug|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Release|x64.ActiveCfg = Release|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Release|x64.Build.0 = Release|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Static-Release|x64.ActiveCfg = Release|x64
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}.Static-Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -330,5 +470,19 @@ Global
 		{1F2E1C51-2B14-4047-BE6D-52E00FC3C780} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 		{C973CD39-D63B-4F5C-BE1D-DED17388B5A4} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 		{5580D11C-FDA6-4CF2-A0E8-1C2D3FBC11F1} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{A5794EFF-8232-4E2B-B52C-908823048F54} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{8F42055F-FFD9-4B10-B266-6DD32923F0AC} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{0DC1B184-C814-448F-8B5F-CFFA6F05156C} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{1E564DB1-0687-4CC4-BAE5-453F93052FDA} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{90C5FCF1-8243-4988-A4EA-AA6A88268373} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{FB6AFFAA-0279-41F7-A698-F81C90BBD987} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{DFEBEBAA-9624-445C-82A0-93363E22D806} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{06FCFDE9-8C88-4B7D-B87A-47953DB203C9} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{8CD79300-941F-4FDD-A371-92BF0EFBA0FC} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{A5DF0746-5496-4C29-9CCD-5FA76604BF8B} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 	EndGlobalSection
 EndGlobal

--- a/src/common/pthread_windows.c
+++ b/src/common/pthread_windows.c
@@ -107,7 +107,8 @@ pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
 			return EINVAL;
 	}
 }
-/* number of seconds between 1970-01-01T00:00:00Z and 1601-01-01T00:00:00Z */
+
+/* number of useconds between 1970-01-01T00:00:00Z and 1601-01-01T00:00:00Z */
 #define DELTA_WIN2UNIX (11644473600000000ull)
 #define TIMED_LOCK(action, ts) {\
 	if ((action) == TRUE)\
@@ -301,17 +302,32 @@ pthread_cond_signal(pthread_cond_t *__restrict cond)
 	return 0;
 }
 
+static time_t
+get_rel_wait(const struct timespec *abstime)
+{
+	struct __timeb64 t;
+	_ftime64_s(&t);
+	time_t now_ms = t.time * 1000 + t.millitm;
+	time_t ms = (time_t)(abstime->tv_sec * 1000 +
+		abstime->tv_nsec / 1000000);
+
+	time_t rel_wait = ms - now_ms;
+
+	return rel_wait < 0 ? 0 : rel_wait;
+}
+
 int
 pthread_cond_timedwait(pthread_cond_t *__restrict cond,
 	pthread_mutex_t *__restrict mutex, const struct timespec *abstime)
 {
-	DWORD ms = (DWORD)(abstime->tv_sec * 1000 +
-					abstime->tv_nsec / 1000000);
-
-	/* XXX - return error code based on GetLastError() */
 	BOOL ret;
-	ret = SleepConditionVariableCS(&cond->cond, &mutex->lock, ms);
-	return (ret == FALSE) ? ETIMEDOUT : 0;
+	SetLastError(0);
+	ret = SleepConditionVariableCS(&cond->cond, &mutex->lock,
+			get_rel_wait(abstime));
+	if (ret == FALSE)
+		return (GetLastError() == ERROR_TIMEOUT) ? ETIMEDOUT : EINVAL;
+
+	return 0;
 }
 
 int

--- a/src/include/libpmemobj/detail/conversions.hpp
+++ b/src/include/libpmemobj/detail/conversions.hpp
@@ -55,18 +55,19 @@ namespace detail
  * @return converted timespec structure.
  */
 template <typename Clock, typename Duration = typename Clock::duration>
-struct timespec
+timespec
 timepoint_to_timespec(const std::chrono::time_point<Clock, Duration> &timepoint)
 {
-	struct timespec ts;
+	timespec ts;
 	auto rel_duration = timepoint.time_since_epoch();
 	const auto sec =
 		std::chrono::duration_cast<std::chrono::seconds>(rel_duration);
 
 	ts.tv_sec = sec.count();
-	ts.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(
-			     rel_duration - sec)
-			     .count();
+	ts.tv_nsec = static_cast<long int>(
+		std::chrono::duration_cast<std::chrono::nanoseconds>(
+			rel_duration - sec)
+			.count());
 
 	return ts;
 }

--- a/src/include/libpmemobj/detail/life.hpp
+++ b/src/include/libpmemobj/detail/life.hpp
@@ -87,6 +87,30 @@ struct if_size_array<T[N]> {
 };
 
 /*
+ * Calls object's constructor.
+ */
+template <typename T>
+void
+create(typename if_not_array<T>::type *args)
+{
+	::new (args) T();
+}
+
+/*
+ * Recursively calls array's elements' constructors.
+ */
+template <typename T>
+void
+create(typename if_size_array<T>::type *args)
+{
+	typedef typename detail::pp_array_type<T>::type I;
+	enum { N = pp_array_elems<T>::elems };
+
+	for (std::size_t i = 0; i < N; ++i)
+		create<I>(&(*args)[i]);
+}
+
+/*
  * Calls object's destructor.
  */
 template <typename T>

--- a/src/include/libpmemobj/detail/make_atomic_impl.hpp
+++ b/src/include/libpmemobj/detail/make_atomic_impl.hpp
@@ -41,8 +41,8 @@
 #include <new>
 
 #include "libpmemobj/detail/array_traits.hpp"
-#include "libpmemobj/detail/destroyer.hpp"
 #include "libpmemobj/detail/integer_sequence.hpp"
+#include "libpmemobj/detail/life.hpp"
 
 namespace nvml
 {
@@ -100,7 +100,7 @@ array_constructor(PMEMobjpool *pop, void *ptr, void *arg)
 	T *tptr = static_cast<T *>(ptr);
 	try {
 		for (std::size_t i = 0; i < N; ++i)
-			::new (tptr + i) T();
+			detail::create<T>(tptr + i);
 	} catch (...) {
 		return -1;
 	}

--- a/src/include/libpmemobj/make_persistent_array.hpp
+++ b/src/include/libpmemobj/make_persistent_array.hpp
@@ -44,7 +44,7 @@
 #include "libpmemobj/detail/array_traits.hpp"
 #include "libpmemobj/detail/check_persistent_ptr_array.hpp"
 #include "libpmemobj/detail/common.hpp"
-#include "libpmemobj/detail/destroyer.hpp"
+#include "libpmemobj/detail/life.hpp"
 #include "libpmemobj/detail/pexceptions.hpp"
 
 namespace nvml
@@ -88,7 +88,7 @@ make_persistent(std::size_t N)
 	std::size_t i;
 	try {
 		for (i = 0; i < N; ++i)
-			::new (ptr.get() + i) I();
+			detail::create<I>(ptr.get() + i);
 	} catch (...) {
 		for (std::size_t j = 1; j <= i; ++j)
 			detail::destroy<I>(ptr[i - j]);
@@ -133,7 +133,7 @@ make_persistent()
 	std::size_t i;
 	try {
 		for (i = 0; i < N; ++i)
-			::new (ptr.get() + i) I();
+			detail::create<I>(ptr.get() + i);
 	} catch (...) {
 		for (std::size_t j = 1; j <= i; ++j)
 			detail::destroy<I>(ptr[i - j]);

--- a/src/include/libpmemobj/make_persistent_atomic.hpp
+++ b/src/include/libpmemobj/make_persistent_atomic.hpp
@@ -47,6 +47,8 @@
 #include "libpmemobj/detail/pexceptions.hpp"
 #include "libpmemobj/pool.hpp"
 
+#include <tuple>
+
 namespace nvml
 {
 

--- a/src/include/libpmemobj/persistent_ptr.hpp
+++ b/src/include/libpmemobj/persistent_ptr.hpp
@@ -258,18 +258,6 @@ public:
 		std::swap(this->oid, other.oid);
 	}
 
-	/* Unspecified bool type. */
-	typedef element_type *(
-		persistent_ptr<T>::*unspecified_bool_type)() const;
-
-	/*
-	 * Unspecified bool type conversion operator.
-	 */
-	operator unspecified_bool_type() const noexcept
-	{
-		return OID_IS_NULL(this->oid) ? 0 : &persistent_ptr<T>::get;
-	}
-
 	/*
 	 * Bool conversion operator.
 	 */
@@ -484,6 +472,46 @@ operator!=(const persistent_ptr<T> &lhs, const persistent_ptr<Y> &rhs) noexcept
 }
 
 /**
+ * Equality operator with nullptr.
+ */
+template <typename T>
+inline bool
+operator==(const persistent_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+	return lhs.get() == nullptr;
+}
+
+/**
+ * Equality operator with nullptr.
+ */
+template <typename T>
+inline bool
+operator==(std::nullptr_t, const persistent_ptr<T> &lhs) noexcept
+{
+	return lhs.get() == nullptr;
+}
+
+/**
+ * Inequality operator with nullptr.
+ */
+template <typename T>
+inline bool
+operator!=(const persistent_ptr<T> &lhs, std::nullptr_t) noexcept
+{
+	return lhs.get() != nullptr;
+}
+
+/**
+ * Inequality operator with nullptr.
+ */
+template <typename T>
+inline bool
+operator!=(std::nullptr_t, const persistent_ptr<T> &lhs) noexcept
+{
+	return lhs.get() != nullptr;
+}
+
+/**
  * Less than operator.
  *
  * @return true if the uuid_lo of lhs is less than the uuid_lo of rhs,
@@ -625,7 +653,7 @@ operator>=(std::nullptr_t, const persistent_ptr<T> &rhs) noexcept
  */
 template <typename T>
 inline persistent_ptr<T>
-operator+(const persistent_ptr<T> &lhs, std::size_t s)
+operator+(const persistent_ptr<T> &lhs, std::ptrdiff_t s)
 {
 	PMEMoid noid;
 	noid.pool_uuid_lo = lhs.raw().pool_uuid_lo;
@@ -638,7 +666,7 @@ operator+(const persistent_ptr<T> &lhs, std::size_t s)
  */
 template <typename T>
 inline persistent_ptr<T>
-operator-(const persistent_ptr<T> &lhs, std::size_t s)
+operator-(const persistent_ptr<T> &lhs, std::ptrdiff_t s)
 {
 	PMEMoid noid;
 	noid.pool_uuid_lo = lhs.raw().pool_uuid_lo;

--- a/src/include/libpmemobj/transaction.hpp
+++ b/src/include/libpmemobj/transaction.hpp
@@ -39,6 +39,7 @@
 #define LIBPMEMOBJ_TRANSACTION_HPP
 
 #include <functional>
+#include <string>
 
 #include "libpmemobj.h"
 #include "libpmemobj/detail/pexceptions.hpp"
@@ -156,7 +157,11 @@ public:
 		manual &operator=(manual &&p) = delete;
 	};
 
-#ifdef __cpp_lib_uncaught_exceptions
+/*
+ * XXX The Microsoft compiler does not follow the ISO SD-6: SG10 Feature
+ * Test Recommendations. "|| _MSC_VER >= 1900" is a workaround.
+ */
+#if __cpp_lib_uncaught_exceptions || _MSC_VER >= 1900
 	/**
 	 * C++ automatic scope transaction class.
 	 *

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -48,6 +48,7 @@ EXPORTS
 	pmemobj_mutex_lock
 	pmemobj_mutex_trylock
 	pmemobj_mutex_unlock
+	pmemobj_mutex_timedlock
 	pmemobj_rwlock_zero
 	pmemobj_rwlock_rdlock
 	pmemobj_rwlock_wrlock
@@ -95,6 +96,7 @@ EXPORTS
 	pmemobj_tx_strdup
 	pmemobj_tx_free
 	pmemobj_tx_errno
+	pmemobj_tx_lock
 	pmemobj_memcpy_persist
 	pmemobj_memset_persist
 	pmemobj_persist

--- a/src/test/obj_cpp_cond_var/TEST0.PS1
+++ b/src/test/obj_cpp_cond_var/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_cond_var/TEST0 -- unit test for condition_variable
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_cond_var\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_cond_var$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -51,6 +51,11 @@ namespace nvobj = nvml::obj;
 namespace
 {
 
+/*
+ * Due to premature wakeups with the TIMEDOUT status on the Windows platform,
+ * an "epsilon" tolerance has been introduced where appropriate.
+ */
+
 /* convenience typedef */
 typedef std::function<void(nvobj::persistent_ptr<struct root>)> reader_type;
 
@@ -152,15 +157,21 @@ void
 reader_mutex_until(nvobj::persistent_ptr<struct root> proot)
 {
 	proot->pmutex.lock();
-	auto until = std::chrono::steady_clock::now();
+	auto until = std::chrono::system_clock::now();
 	until += wait_time;
 	auto ret = proot->cond.wait_until(proot->pmutex, until);
 
-	auto now = std::chrono::steady_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	auto now = std::chrono::system_clock::now();
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	proot->pmutex.unlock();
 }
 
@@ -178,10 +189,16 @@ reader_mutex_until_pred(nvobj::persistent_ptr<struct root> proot)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	proot->pmutex.unlock();
 }
 
@@ -197,10 +214,16 @@ reader_lock_until(nvobj::persistent_ptr<struct root> proot)
 	auto ret = proot->cond.wait_until(proot->pmutex, until);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	lock.unlock();
 }
 
@@ -218,10 +241,16 @@ reader_lock_until_pred(nvobj::persistent_ptr<struct root> proot)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	lock.unlock();
 }
 
@@ -237,10 +266,16 @@ reader_mutex_for(nvobj::persistent_ptr<struct root> proot)
 	auto ret = proot->cond.wait_for(proot->pmutex, wait_time);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	proot->pmutex.unlock();
 }
 
@@ -258,10 +293,16 @@ reader_mutex_for_pred(nvobj::persistent_ptr<struct root> proot)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	proot->pmutex.unlock();
 }
 
@@ -277,10 +318,16 @@ reader_lock_for(nvobj::persistent_ptr<struct root> proot)
 	auto ret = proot->cond.wait_for(proot->pmutex, wait_time);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	lock.unlock();
 }
 
@@ -298,10 +345,16 @@ reader_lock_for_pred(nvobj::persistent_ptr<struct root> proot)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq(proot->counter, limit);
+	}
 	lock.unlock();
 }
 

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.vcxproj
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_cond_var\obj_cpp_cond_var.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A5794EFF-8232-4E2B-B52C-908823048F54}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_cond_var</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.vcxproj.filters
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.vcxproj.filters
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{728e8c61-2ebf-485b-8645-d2160364940b}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_cond_var\obj_cpp_cond_var.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
+++ b/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
@@ -184,10 +184,16 @@ reader_mutex_until(void *arg)
 	auto ret = (*proot)->cond.wait_until((*proot)->pmutex, until);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -209,10 +215,16 @@ reader_mutex_until_pred(void *arg)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -232,10 +244,16 @@ reader_lock_until(void *arg)
 	auto ret = (*proot)->cond.wait_until((*proot)->pmutex, until);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	lock.unlock();
 
 	return nullptr;
@@ -257,10 +275,16 @@ reader_lock_until_pred(void *arg)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	lock.unlock();
 
 	return nullptr;
@@ -280,10 +304,16 @@ reader_mutex_for(void *arg)
 	auto ret = (*proot)->cond.wait_for((*proot)->pmutex, wait_time);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -305,10 +335,16 @@ reader_mutex_for_pred(void *arg)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	(*proot)->pmutex.unlock();
 
 	return nullptr;
@@ -328,10 +364,16 @@ reader_lock_for(void *arg)
 	auto ret = (*proot)->cond.wait_for((*proot)->pmutex, wait_time);
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == std::cv_status::timeout)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == std::cv_status::timeout) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	lock.unlock();
 
 	return nullptr;
@@ -353,10 +395,16 @@ reader_lock_for_pred(void *arg)
 	});
 
 	auto now = std::chrono::system_clock::now();
-	if (ret == false)
-		UT_ASSERT(now >= until);
-	else
+	if (ret == false) {
+		auto epsilon = std::chrono::milliseconds(10);
+		auto diff =
+			std::chrono::duration_cast<std::chrono::milliseconds>(
+				until - now);
+		if (now < until)
+			UT_ASSERT(diff < epsilon);
+	} else {
 		UT_ASSERTeq((*proot)->counter, limit);
+	}
 	lock.unlock();
 
 	return nullptr;

--- a/src/test/obj_cpp_make_persistent/TEST0.PS1
+++ b/src/test/obj_cpp_make_persistent/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_make_persistent/TEST0 -- unit test for make_persistent
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_make_persistent\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_make_persistent$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
@@ -175,7 +175,7 @@ test_additional_delete(nvobj::pool<struct root> &pop)
 
 			nvobj::transaction::abort(EINVAL);
 		});
-	} catch (nvml::manual_tx_abort &ma) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.vcxproj
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent\obj_cpp_make_persistent.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8F42055F-FFD9-4B10-B266-6DD32923F0AC}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_make_persistent</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.vcxproj.filters
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{fbbc73ed-824e-4752-85c3-68c28c46027e}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent\obj_cpp_make_persistent.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_array/TEST0.PS1
+++ b/src/test/obj_cpp_make_persistent_array/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_make_persistent_array/TEST0 -- unit test for make_persistent
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_make_persistent_array\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_make_persistent_array$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
+++ b/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
@@ -117,10 +117,10 @@ test_make_one_d(nvobj::pool_base &pop)
 }
 
 /*
- * test_make_two_d -- (internal) test make_persitent of a 2d array
+ * test_make_N_d -- (internal) test make_persitent of 2d and 3d arrays
  */
 void
-test_make_two_d(nvobj::pool_base &pop)
+test_make_N_d(nvobj::pool_base &pop)
 {
 	try {
 		nvobj::transaction::exec_tx(pop, [&] {
@@ -144,6 +144,22 @@ test_make_two_d(nvobj::pool_base &pop)
 					pfooN[i][j].check_foo();
 
 			nvobj::delete_persistent<foo[5][2]>(pfooN);
+
+			auto pfoo3 = nvobj::make_persistent<foo[][2][3]>(5);
+			for (int i = 0; i < 5; ++i)
+				for (int j = 0; j < 2; j++)
+					for (int k = 0; k < 3; k++)
+						pfoo3[i][j][k].check_foo();
+
+			nvobj::delete_persistent<foo[][2][3]>(pfoo3, 5);
+
+			auto pfoo3N = nvobj::make_persistent<foo[5][2][3]>();
+			for (int i = 0; i < 5; ++i)
+				for (int j = 0; j < 2; j++)
+					for (int k = 0; k < 3; k++)
+						pfoo3N[i][j][k].check_foo();
+
+			nvobj::delete_persistent<foo[5][2][3]>(pfoo3N);
 		});
 	} catch (...) {
 		UT_ASSERT(0);
@@ -179,7 +195,7 @@ test_abort_revert(nvobj::pool_base &pop)
 
 			nvobj::transaction::abort(EINVAL);
 		});
-	} catch (nvml::manual_tx_abort &ma) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -223,7 +239,7 @@ main(int argc, char *argv[])
 	}
 
 	test_make_one_d(pop);
-	test_make_two_d(pop);
+	test_make_N_d(pop);
 	test_abort_revert(pop);
 
 	pop.close();

--- a/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.vcxproj
+++ b/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_array\obj_cpp_make_persistent_array.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{72598DD9-3F44-4E6A-B0B7-C5AE3FF43B1F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_make_persistent_array</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.vcxproj.filters
+++ b/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{b5395226-0fa0-490a-a24b-8c1cf9b76d97}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_array\obj_cpp_make_persistent_array.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_array_atomic/TEST0.PS1
+++ b/src/test/obj_cpp_make_persistent_array_atomic/TEST0.PS1
@@ -1,0 +1,64 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_make_persistent_array_atomic/TEST0 -- unit test for
+#	make_persistent_atomic
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_make_persistent_array_atomic\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_make_persistent_array_atomic$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
@@ -117,10 +117,10 @@ test_make_one_d(nvobj::pool_base &pop)
 }
 
 /*
- * test_make_two_d -- (internal) test make_persitent of a 2d array
+ * test_make_N_d -- (internal) test make_persitent of 2d and 3d arrays
  */
 void
-test_make_two_d(nvobj::pool_base &pop)
+test_make_N_d(nvobj::pool_base &pop)
 {
 	nvobj::persistent_ptr<foo[][2]> pfoo;
 	nvobj::make_persistent_atomic<foo[][2]>(pop, pfoo, 5);
@@ -145,6 +145,24 @@ test_make_two_d(nvobj::pool_base &pop)
 			pfooN[i][j].check_foo();
 
 	nvobj::delete_persistent_atomic<foo[5][2]>(pfooN);
+
+	nvobj::persistent_ptr<foo[][2][3]> pfoo3;
+	nvobj::make_persistent_atomic<foo[][2][3]>(pop, pfoo3, 5);
+	for (int i = 0; i < 5; ++i)
+		for (int j = 0; j < 2; j++)
+			for (int k = 0; k < 3; k++)
+				pfoo3[i][j][k].check_foo();
+
+	nvobj::delete_persistent_atomic<foo[][2][3]>(pfoo3, 5);
+
+	nvobj::persistent_ptr<foo[5][2][3]> pfoo3N;
+	nvobj::make_persistent_atomic<foo[5][2][3]>(pop, pfoo3N);
+	for (int i = 0; i < 5; ++i)
+		for (int j = 0; j < 2; j++)
+			for (int k = 0; k < 3; k++)
+				pfoo3N[i][j][k].check_foo();
+
+	nvobj::delete_persistent_atomic<foo[5][2][3]>(pfoo3N);
 }
 
 /*
@@ -158,7 +176,7 @@ test_constructor_exception(nvobj::pool_base &pop)
 	bool except = false;
 	try {
 		nvobj::make_persistent_atomic<bar[]>(pop, pfoo, 5);
-	} catch (std::bad_alloc &ba) {
+	} catch (std::bad_alloc &) {
 		except = true;
 	}
 
@@ -206,7 +224,7 @@ main(int argc, char *argv[])
 	}
 
 	test_make_one_d(pop);
-	test_make_two_d(pop);
+	test_make_N_d(pop);
 	test_constructor_exception(pop);
 	test_delete_null(pop);
 

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.vcxproj
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_array_atomic\obj_cpp_make_persistent_array_atomic.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0DC1B184-C814-448F-8B5F-CFFA6F05156C}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_make_persistent_array_atomic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.vcxproj.filters
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{6674ee87-4ad5-4bac-9072-44538074d016}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_array_atomic\obj_cpp_make_persistent_array_atomic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_atomic/TEST0.PS1
+++ b/src/test/obj_cpp_make_persistent_atomic/TEST0.PS1
@@ -1,0 +1,64 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_make_persistent_atomic/TEST0 -- unit test for
+#	make_persistent_atomic
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_make_persistent_atomic\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_make_persistent_atomic$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.vcxproj
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_atomic\obj_cpp_make_persistent_atomic.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C96D08A8-AFCD-4C2D-B50F-4582042FCBC1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_make_persistent_atomic</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.vcxproj.filters
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{3d9e9908-77ce-423a-aff1-316fc7b440c8}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_make_persistent_atomic\obj_cpp_make_persistent_atomic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_mutex/TEST0.PS1
+++ b/src/test/obj_cpp_mutex/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_mutex/TEST0 -- unit test for nvml::obj::mutex
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_mutex\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_mutex$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_mutex/obj_cpp_mutex.vcxproj
+++ b/src/test/obj_cpp_mutex/obj_cpp_mutex.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_mutex\obj_cpp_mutex.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1E564DB1-0687-4CC4-BAE5-453F93052FDA}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_mutex</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_mutex/obj_cpp_mutex.vcxproj.filters
+++ b/src/test/obj_cpp_mutex/obj_cpp_mutex.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{9d26fb90-e468-4290-bae8-5ff878f3ea85}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_mutex\obj_cpp_mutex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_p_ext/TEST0.PS1
+++ b/src/test/obj_cpp_p_ext/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_p_ext/TEST0 -- unit test for nvml::obj::mutex
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_p_ext\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_p_ext$Env:EXESUFFIX `
+    $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -149,11 +149,12 @@ arithmetic_test(nvobj::pool_base &pop)
 			r->foo_ptr->pint =
 				r->foo_ptr->pint + r->foo_ptr->puchar;
 			r->foo_ptr->pint = r->foo_ptr->pint + r->foo_ptr->pint;
-			r->foo_ptr->pint = r->foo_ptr->pllong + 8;
+			r->foo_ptr->pint =
+				static_cast<int>(r->foo_ptr->pllong + 8);
 			UT_ASSERTeq(r->foo_ptr->pint, 10);
 
 			/* for float assertions */
-			float epsilon = 0.001;
+			float epsilon = 0.001F;
 
 			/* subtraction */
 			r->bar_ptr->pdouble -= r->foo_ptr->puchar;
@@ -161,8 +162,8 @@ arithmetic_test(nvobj::pool_base &pop)
 			UT_ASSERT(std::fabs(r->bar_ptr->pdouble + 2) < epsilon);
 			UT_ASSERT(std::fabs(r->bar_ptr->pfloat) < epsilon);
 
-			r->bar_ptr->pfloat =
-				r->bar_ptr->pfloat - r->bar_ptr->pdouble;
+			r->bar_ptr->pfloat = static_cast<float>(
+				r->bar_ptr->pfloat - r->bar_ptr->pdouble);
 			r->bar_ptr->pdouble =
 				r->bar_ptr->pdouble - r->bar_ptr->pfloat;
 			UT_ASSERT(std::fabs(r->bar_ptr->pfloat - 2) < epsilon);
@@ -171,14 +172,15 @@ arithmetic_test(nvobj::pool_base &pop)
 			/* multiplication */
 			r->foo_ptr->puchar *= r->foo_ptr->puchar;
 			r->foo_ptr->puchar *= r->foo_ptr->pint;
-			r->foo_ptr->puchar *= r->foo_ptr->pllong;
+			r->foo_ptr->puchar *=
+				static_cast<unsigned char>(r->foo_ptr->pllong);
 			UT_ASSERTeq(r->foo_ptr->puchar, 180);
 
 			r->foo_ptr->pint =
 				r->foo_ptr->pint * r->foo_ptr->puchar;
 			r->foo_ptr->pint = r->foo_ptr->pint * r->foo_ptr->pint;
-			r->foo_ptr->pint =
-				r->foo_ptr->pllong * r->foo_ptr->pint;
+			r->foo_ptr->pint = static_cast<int>(r->foo_ptr->pllong *
+							    r->foo_ptr->pint);
 			/* no assertions needed at this point */
 
 			/* division */
@@ -186,8 +188,8 @@ arithmetic_test(nvobj::pool_base &pop)
 			r->bar_ptr->pfloat /= r->foo_ptr->pllong;
 			/* no assertions needed at this point */
 
-			r->bar_ptr->pfloat =
-				r->bar_ptr->pfloat / r->bar_ptr->pdouble;
+			r->bar_ptr->pfloat = static_cast<float>(
+				r->bar_ptr->pfloat / r->bar_ptr->pdouble);
 			r->bar_ptr->pdouble =
 				r->bar_ptr->pdouble / r->bar_ptr->pfloat;
 			/* no assertions needed at this point */
@@ -238,7 +240,8 @@ bitwise_test(nvobj::pool_base &pop)
 			r->foo_ptr->pint =
 				r->foo_ptr->pint | r->foo_ptr->puchar;
 			r->foo_ptr->pint = r->foo_ptr->pint | r->foo_ptr->pint;
-			r->foo_ptr->pint = r->foo_ptr->pllong | 0xF;
+			r->foo_ptr->pint =
+				static_cast<int>(r->foo_ptr->pllong | 0xF);
 			UT_ASSERTeq(r->foo_ptr->pint, 15);
 
 			/* AND */
@@ -262,25 +265,28 @@ bitwise_test(nvobj::pool_base &pop)
 			r->foo_ptr->pint =
 				r->foo_ptr->pint ^ r->foo_ptr->puchar;
 			r->foo_ptr->pint = r->foo_ptr->pint ^ r->foo_ptr->pint;
-			r->foo_ptr->pint = r->foo_ptr->pllong ^ 8;
+			r->foo_ptr->pint =
+				static_cast<int>(r->foo_ptr->pllong ^ 8);
 			UT_ASSERTeq(r->foo_ptr->pint, 10);
 
 			/* RSHIFT */
 			r->foo_ptr->puchar = 255;
 			r->foo_ptr->puchar >>= 1;
 			r->foo_ptr->puchar >>= r->foo_ptr->pllong;
-			r->foo_ptr->puchar = r->foo_ptr->pllong >> 2;
-			r->foo_ptr->puchar =
-				r->foo_ptr->pllong >> r->foo_ptr->pllong;
+			r->foo_ptr->puchar = static_cast<unsigned char>(
+				r->foo_ptr->pllong >> 2);
+			r->foo_ptr->puchar = static_cast<unsigned char>(
+				r->foo_ptr->pllong >> r->foo_ptr->pllong);
 			UT_ASSERTeq(r->foo_ptr->puchar, 0);
 
 			/* LSHIFT */
 			r->foo_ptr->puchar = 1;
 			r->foo_ptr->puchar <<= 1;
 			r->foo_ptr->puchar <<= r->foo_ptr->pllong;
-			r->foo_ptr->puchar = r->foo_ptr->pllong << 2;
-			r->foo_ptr->puchar = r->foo_ptr->pllong
-				<< r->foo_ptr->pllong;
+			r->foo_ptr->puchar = static_cast<unsigned char>(
+				r->foo_ptr->pllong << 2);
+			r->foo_ptr->puchar = static_cast<unsigned char>(
+				r->foo_ptr->pllong << r->foo_ptr->pllong);
 			UT_ASSERTeq(r->foo_ptr->puchar, 8);
 
 			/* COMPLEMENT */

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.vcxproj
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_p_ext\obj_cpp_p_ext.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FD86DEA2-449E-44CD-A014-BFC30ED3FDF2}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_p_ext</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.vcxproj.filters
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{ef271958-5eef-46b1-90cd-3539f46970ca}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_p_ext\obj_cpp_p_ext.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_pool/TEST0
+++ b/src/test/obj_cpp_pool/TEST0
@@ -48,7 +48,7 @@ umask 0
 #
 # TEST0 non-existing file, poolsize > 0
 #
-expect_normal_exit ./obj_cpp_pool$EXESUFFIX c $DIR/testfile "test" 20 0640
+expect_normal_exit ./obj_cpp_pool$EXESUFFIX c $DIR/testfile "test" 20 0600
 
 [ -f $DIR/testfile ] || {
     echo "error: $DIR/testfile doesn't exist"

--- a/src/test/obj_cpp_pool/TEST0.PS1
+++ b/src/test/obj_cpp_pool/TEST0.PS1
@@ -1,0 +1,65 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_pool/TEST0 -- unit test for nvml::obj::pool
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_pool\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool$Env:EXESUFFIX `
+    c $DIR/testfile "test" 20 0600
+
+check_files $DIR\testfile
+
+# check will print the appropriate pass/fail message
+check

--- a/src/test/obj_cpp_pool/TEST1
+++ b/src/test/obj_cpp_pool/TEST1
@@ -49,7 +49,7 @@ umask 0
 # TEST1 existing file, file size >= min required size
 #        layout matches the value from pool header
 #
-expect_normal_exit ./obj_cpp_pool$EXESUFFIX c $DIR/testfile "test" 20 0640
+expect_normal_exit ./obj_cpp_pool$EXESUFFIX c $DIR/testfile "test" 20 0600
 
 expect_normal_exit ./obj_cpp_pool$EXESUFFIX o $DIR/testfile "test"
 

--- a/src/test/obj_cpp_pool/TEST1.PS1
+++ b/src/test/obj_cpp_pool/TEST1.PS1
@@ -1,0 +1,66 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_pool/TEST1 -- unit test for nvml::obj::pool
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_pool\TEST1"
+$Env:UNITTEST_NUM = "1"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST1
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool$Env:EXESUFFIX `
+    c $DIR/testfile "test" 20 0600
+
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool$Env:EXESUFFIX `
+    o $DIR/testfile "test"
+
+# check will print the appropriate pass/fail message
+check

--- a/src/test/obj_cpp_pool/TEST2
+++ b/src/test/obj_cpp_pool/TEST2
@@ -48,7 +48,7 @@ umask 0
 #
 # TEST2 non-existing file, poolsize > 0
 #
-expect_normal_exit ./obj_cpp_pool$EXESUFFIX d $DIR/testfile "test" 20 0640
+expect_normal_exit ./obj_cpp_pool$EXESUFFIX d $DIR/testfile "test" 20 0600
 
 [ -f $DIR/testfile ] || {
     echo "error: $DIR/testfile doesn't exist"

--- a/src/test/obj_cpp_pool/TEST2.PS1
+++ b/src/test/obj_cpp_pool/TEST2.PS1
@@ -1,0 +1,65 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_pool/TEST2 -- unit test for nvml::obj::pool
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_pool\TEST2"
+$Env:UNITTEST_NUM = "2"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST2
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool$Env:EXESUFFIX `
+    d $DIR/testfile "test" 20 0600
+
+check_files $DIR\testfile
+
+# check will print the appropriate pass/fail message
+check

--- a/src/test/obj_cpp_pool/TEST3
+++ b/src/test/obj_cpp_pool/TEST3
@@ -45,7 +45,7 @@ require_cxx11
 setup
 umask 0
 
-expect_normal_exit ./obj_cpp_pool$EXESUFFIX i $DIR/testfile "test" 20 0640
+expect_normal_exit ./obj_cpp_pool$EXESUFFIX i $DIR/testfile "test" 20 0600
 
 check
 

--- a/src/test/obj_cpp_pool/TEST3.PS1
+++ b/src/test/obj_cpp_pool/TEST3.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_pool/TEST3 -- unit test for nvml::obj::pool
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_pool\TEST3"
+$Env:UNITTEST_NUM = "3"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST3
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool$Env:EXESUFFIX `
+    i $DIR/testfile "test" 20 0600
+
+# check will print the appropriate pass/fail message
+check

--- a/src/test/obj_cpp_pool/obj_cpp_pool.cpp
+++ b/src/test/obj_cpp_pool/obj_cpp_pool.cpp
@@ -68,7 +68,7 @@ pool_create(const char *path, const char *layout, size_t poolsize,
 		return;
 	}
 
-	struct stat stbuf;
+	ut_util_stat_t stbuf;
 	STAT(path, &stbuf);
 
 	UT_OUT("%s: file size %zu mode 0%o", path, stbuf.st_size,

--- a/src/test/obj_cpp_pool/obj_cpp_pool.vcxproj
+++ b/src/test/obj_cpp_pool/obj_cpp_pool.vcxproj
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_pool\obj_cpp_pool.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="out0.log.match" />
+    <None Include="out1.log.match" />
+    <None Include="out2.log.match" />
+    <None Include="out3.log.match" />
+    <None Include="TEST0.PS1" />
+    <None Include="TEST1.PS1" />
+    <None Include="TEST2.PS1" />
+    <None Include="TEST3.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{90C5FCF1-8243-4988-A4EA-AA6A88268373}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_pool</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_pool/obj_cpp_pool.vcxproj.filters
+++ b/src/test/obj_cpp_pool/obj_cpp_pool.vcxproj.filters
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{9058564b-41e9-4021-bee4-c045aff7fae5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Match Files">
+      <UniqueIdentifier>{32ba9e6c-033c-4b69-a40a-a93a55e1d999}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_pool\obj_cpp_pool.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST1.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST2.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST3.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="out0.log.match">
+      <Filter>Match Files</Filter>
+    </None>
+    <None Include="out1.log.match">
+      <Filter>Match Files</Filter>
+    </None>
+    <None Include="out2.log.match">
+      <Filter>Match Files</Filter>
+    </None>
+    <None Include="out3.log.match">
+      <Filter>Match Files</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_pool/out0.log.match
+++ b/src/test/obj_cpp_pool/out0.log.match
@@ -1,4 +1,4 @@
-obj_cpp_pool/TEST0: START: obj_cpp_pool
- ./obj_cpp_pool$(nW) c $(nW)/testfile test 20 0640
-$(nW)/testfile: file size 20971520 mode 0640
-obj_cpp_pool/TEST0: Done
+obj_cpp_pool$(nW)TEST0: START: obj_cpp_pool
+ $(nW)obj_cpp_pool$(nW) c $(nW)testfile test 20 0600
+$(nW)testfile: file size 20971520 mode 0600
+obj_cpp_pool$(nW)TEST0: Done

--- a/src/test/obj_cpp_pool/out1.log.match
+++ b/src/test/obj_cpp_pool/out1.log.match
@@ -1,4 +1,4 @@
-obj_cpp_pool/TEST1: START: obj_cpp_pool
- ./obj_cpp_pool$(nW) o $(nW)/testfile test
-$(nW)/testfile: pool::open: Success
-obj_cpp_pool/TEST1: Done
+obj_cpp_pool$(nW)TEST1: START: obj_cpp_pool
+ $(nW)obj_cpp_pool$(nW) o $(nW)testfile test
+$(nW)testfile: pool::open: Success
+obj_cpp_pool$(nW)TEST1: Done

--- a/src/test/obj_cpp_pool/out2.log.match
+++ b/src/test/obj_cpp_pool/out2.log.match
@@ -1,6 +1,6 @@
-obj_cpp_pool/TEST2: START: obj_cpp_pool
- ./obj_cpp_pool$(nW) d $(nW)/testfile test 20 0640
-$(nW)/testfile: pool::create: Success
-$(nW)/testfile: pool.close: Success
-$(nW)/testfile: pool.close: Pool already closed
-obj_cpp_pool/TEST2: Done
+obj_cpp_pool$(nW)TEST2: START: obj_cpp_pool
+ $(nW)obj_cpp_pool$(nW) d $(nW)testfile test 20 0600
+$(nW)testfile: pool::create: Success
+$(nW)testfile: pool.close: Success
+$(nW)testfile: pool.close: Pool already closed
+obj_cpp_pool$(nW)TEST2: Done

--- a/src/test/obj_cpp_pool/out3.log.match
+++ b/src/test/obj_cpp_pool/out3.log.match
@@ -1,4 +1,4 @@
-obj_cpp_pool/TEST3: START: obj_cpp_pool
- ./obj_cpp_pool$(nW) i $(nW)/testfile test 20 0640
+obj_cpp_pool$(nW)TEST3: START: obj_cpp_pool
+ $(nW)obj_cpp_pool$(nW) i $(nW)testfile test 20 0600
 pool.get_root: Invalid pool handle
-obj_cpp_pool/TEST3: Done
+obj_cpp_pool$(nW)TEST3: Done

--- a/src/test/obj_cpp_pool_primitives/TEST0.PS1
+++ b/src/test/obj_cpp_pool_primitives/TEST0.PS1
@@ -1,0 +1,65 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_pool_primitives/TEST0 -- unit test for nvml::obj::pool
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_pool_primitives\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_pool_primitives$Env:EXESUFFIX `
+    $DIR/testfile
+
+check_file $DIR/testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.vcxproj
+++ b/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_pool_primitives\obj_cpp_pool_primitives.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FB6AFFAA-0279-41F7-A698-F81C90BBD987}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_pool_primitives</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.vcxproj.filters
+++ b/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{363b2ade-2fe3-43d8-996e-9ed9b61bdc60}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_pool_primitives\obj_cpp_pool_primitives.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_ptr/TEST0.PS1
+++ b/src/test/obj_cpp_ptr/TEST0.PS1
@@ -1,0 +1,65 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_ptr/TEST0 -- unit test for persistent_ptr
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_ptr\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_ptr$Env:EXESUFFIX `
+    $DIR\testfile
+
+check_files $DIR\testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -198,7 +198,7 @@ test_ptr_transactional(nvobj::pool<root> &pop)
 			pfoo->bar = 0;
 			nvobj::transaction::abort(-1);
 		});
-	} catch (nvml::manual_tx_abort &ma) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -261,7 +261,7 @@ test_ptr_array(nvobj::pool<root> &pop)
 
 			nvobj::transaction::abort(-1);
 		});
-	} catch (nvml::manual_tx_abort &ma) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -277,7 +277,7 @@ test_ptr_array(nvobj::pool<root> &pop)
 
 			nvobj::transaction::abort(-1);
 		});
-	} catch (nvml::manual_tx_abort &ma) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.vcxproj
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_ptr\obj_cpp_ptr.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DFEBEBAA-9624-445C-82A0-93363E22D806}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_ptr</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.vcxproj.filters
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{4e4de84d-63e3-45cc-a1f3-fdf5af2b07c3}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_ptr\obj_cpp_ptr.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_ptr_arith/TEST0.PS1
+++ b/src/test/obj_cpp_ptr_arith/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_ptr_arith/TEST0 -- unit test for nvml::obj::persistent_ptr
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_ptr_arith\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_ptr_arith$Env:EXESUFFIX `
+    $DIR/testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.vcxproj
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_ptr_arith\obj_cpp_ptr_arith.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{06FCFDE9-8C88-4B7D-B87A-47953DB203C9}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_ptr_arith</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.vcxproj.filters
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{6d37b40d-35c6-4331-804a-a1ada34b9d30}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_ptr_arith\obj_cpp_ptr_arith.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_shared_mutex/TEST0.PS1
+++ b/src/test/obj_cpp_shared_mutex/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_shared_mutex/TEST0 -- unit test for shared_mutex
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_shared_mutex\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_shared_mutex$Env:EXESUFFIX `
+    $DIR/testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.vcxproj
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_shared_mutex\obj_cpp_shared_mutex.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8CD79300-941F-4FDD-A371-92BF0EFBA0FC}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_shared_mutex</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.vcxproj.filters
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{d93c2f0a-b2b1-45db-89e8-31b87f49fb2a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_shared_mutex\obj_cpp_shared_mutex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_timed_mtx/TEST0.PS1
+++ b/src/test/obj_cpp_timed_mtx/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_timed_mtx/TEST0 -- unit test for timed_mutex
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_timed_mtx\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_timed_mtx$Env:EXESUFFIX `
+    $DIR/testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.vcxproj
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_timed_mtx\obj_cpp_timed_mtx.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A2DEA0DC-04F3-4384-BCC2-F7EE2CFD6EE7}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_timed_mtx</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.vcxproj.filters
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{a2938aab-19b9-48ae-9121-12e4bce70fda}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_timed_mtx\obj_cpp_timed_mtx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_cpp_transaction/TEST0.PS1
+++ b/src/test/obj_cpp_transaction/TEST0.PS1
@@ -1,0 +1,63 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_cpp_transaction/TEST0 -- unit test for nvml::obj::persistent_ptr
+#
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+
+$Env:UNITTEST_NAME = "obj_cpp_transaction\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+setup
+
+#
+# TEST0
+#
+expect_normal_exit ..\..\x64\debug\obj_cpp_transaction$Env:EXESUFFIX `
+    $DIR/testfile
+
+# pass will print the appropriate pass/fail message
+pass

--- a/src/test/obj_cpp_transaction/obj_cpp_transaction.cpp
+++ b/src/test/obj_cpp_transaction/obj_cpp_transaction.cpp
@@ -48,6 +48,11 @@ namespace
 int counter = 0;
 }
 
+/*
+* XXX The Microsoft compiler does not follow the ISO SD-6: SG10 Feature
+* Test Recommendations. "_MSC_VER" is a workaround.
+*/
+#if _MSC_VER < 1900
 #ifndef __cpp_lib_uncaught_exceptions
 #define __cpp_lib_uncaught_exceptions 201411
 namespace std
@@ -61,6 +66,7 @@ uncaught_exceptions() noexcept
 
 } /* namespace std */
 #endif /* __cpp_lib_uncaught_exceptions */
+#endif /* _MSC_VER */
 
 #include "libpmemobj/transaction.hpp"
 
@@ -218,7 +224,7 @@ test_tx_throw_no_abort(nvobj::pool<root> &pop)
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			throw std::runtime_error("error");
 		});
-	} catch (std::runtime_error &re) {
+	} catch (std::runtime_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -236,7 +242,7 @@ test_tx_throw_no_abort(nvobj::pool<root> &pop)
 				throw std::runtime_error("error");
 			});
 		});
-	} catch (std::runtime_error &re) {
+	} catch (std::runtime_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -290,7 +296,7 @@ test_tx_no_throw_abort(nvobj::pool<root> &pop)
 			rootp->pfoo = nvobj::make_persistent<foo>();
 			nvobj::transaction::abort(-1);
 		});
-	} catch (nvml::manual_tx_abort &ta) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -307,7 +313,7 @@ test_tx_no_throw_abort(nvobj::pool<root> &pop)
 			nvobj::transaction::exec_tx(
 				pop, [&]() { nvobj::transaction::abort(-1); });
 		});
-	} catch (nvml::manual_tx_abort &ta) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -331,7 +337,7 @@ test_tx_no_throw_abort(nvobj::pool<root> &pop)
 				UT_ASSERT(0);
 			}
 		});
-	} catch (nvml::transaction_error &ta) {
+	} catch (nvml::transaction_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -436,7 +442,7 @@ test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 		rootp->pfoo = nvobj::make_persistent<foo>();
 		counter = 1;
 		throw std::runtime_error("error");
-	} catch (std::runtime_error &re) {
+	} catch (std::runtime_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -457,7 +463,7 @@ test_tx_throw_no_abort_scope(nvobj::pool<root> &pop)
 			counter = 1;
 			throw std::runtime_error("error");
 		}
-	} catch (std::runtime_error &re) {
+	} catch (std::runtime_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -515,7 +521,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 		rootp->pfoo = nvobj::make_persistent<foo>();
 		counter = 1;
 		nvobj::transaction::abort(ECANCELED);
-	} catch (nvml::manual_tx_abort &ta) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -536,7 +542,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 			counter = 1;
 			nvobj::transaction::abort(EINVAL);
 		}
-	} catch (nvml::manual_tx_abort &ta) {
+	} catch (nvml::manual_tx_abort &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);
@@ -561,7 +567,7 @@ test_tx_no_throw_abort_scope(nvobj::pool<root> &pop)
 		} catch (...) {
 			UT_ASSERT(0);
 		}
-	} catch (nvml::transaction_error &ta) {
+	} catch (nvml::transaction_error &) {
 		exception_thrown = true;
 	} catch (...) {
 		UT_ASSERT(0);

--- a/src/test/obj_cpp_transaction/obj_cpp_transaction.vcxproj
+++ b/src/test/obj_cpp_transaction/obj_cpp_transaction.vcxproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_transaction\obj_cpp_transaction.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A5DF0746-5496-4C29-9CCD-5FA76604BF8B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_cpp_transaction</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Debug</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\unittest;$(ProjectDir)\..\..\windows\include;$(ProjectDir)\..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);$(OutDir)/../Static-Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libut.lib;libpmem.lib;libpmemobj.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_cpp_transaction/obj_cpp_transaction.vcxproj.filters
+++ b/src/test/obj_cpp_transaction/obj_cpp_transaction.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{e47bc62c-f75d-466f-8715-ced19986a41a}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\test\obj_cpp_transaction\obj_cpp_transaction.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -215,7 +215,7 @@ void ut_err(const char *file, int line, const char *func,
 #else /* _MSC_VER */
 #define UT_COMPILE_ERROR_ON(cond) C_ASSERT(!(cond))
 /* XXX - can't be done with C_ASSERT() unless we have __builtin_constant_p() */
-#define UT_ASSERT_COMPILE_ERROR_ON(cond)
+#define UT_ASSERT_COMPILE_ERROR_ON(cond) (void)(cond)
 #endif /* _MSC_VER */
 
 /* assert a condition is true */

--- a/src/windows/include/pthread.h
+++ b/src/windows/include/pthread.h
@@ -60,7 +60,7 @@
 
 /* XXX - dummy */
 typedef int pthread_t;
-typedef pthread_attr_t;
+typedef int pthread_attr_t;
 typedef long pthread_once_t;
 typedef DWORD pthread_key_t;
 


### PR DESCRIPTION
This is an initial implementation of the C++ bindings for Windows. Most of the unit tests are ported, with the exception of \*_posix tests. They were implemented to be able to properly test the implementation using Valgrind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/977)
<!-- Reviewable:end -->
