### PR TITLE
common: add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Jan M Michalski <jan.m.michalski@intel.com>
+Krzysztof Czuryło <krzysztof.czurylo@intel.com>
+Łukasz Plewa <lukasz.plewa@intel.com>
+Paul Luse <paul.e.luse@intel.com>
+Piotr Balcer <piotr.balcer@intel.com>
+Sławomir Pawłowski <slawomir.pawlowski@intel.com>
+Tomasz Kapela <tomasz.kapela@intel.com>


### PR DESCRIPTION
From "git shortlog" man page:
"The .mailmap feature is used to coalesce together commits by
the same person in the shortlog, where their name and/or email
address was spelled differently."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/984)
<!-- Reviewable:end -->
