### PR TITLE
rpmem: fix building packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@
 # You can override the prefix within DESTDIR using prefix variable
 # e.g.: "make install prefix=/usr"
 
+include src/common.inc
+
 export SRCVERSION = $(shell git describe 2>/dev/null ||\
 			cat .version 2>/dev/null ||\
 			git log -1 --format=%h 2>/dev/null)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -49,8 +49,10 @@ MANPAGES_1 = pmempool.1 pmempool-info.1 pmempool-create.1 \
 	pmempool-check.1 pmempool-dump.1 pmempool-rm.1 pmempool-convert.1 \
 	$(MANPAGES_1_GROFF)
 
+ifeq ($(BUILD_RPMEM),y)
 MANPAGES_3_MD_EXP = librpmem.3.md
 MANPAGES_1_MD_EXP = rpmemd.1.md
+endif
 
 MANPAGES_3_GROFF_EXP = $(MANPAGES_3_MD_EXP:.3.md=.3)
 MANPAGES_1_GROFF_EXP = $(MANPAGES_1_MD_EXP:.1.md=.1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,11 +65,11 @@ PKG_CONFIG_FILES = libpmem.pc libvmem.pc libvmmalloc.pc libpmemobj.pc\
 
 ifeq ($(EXPERIMENTAL),y)
 	PKG_CONFIG_FILES += libpmemobj++.pc
+ifeq ($(BUILD_RPMEM),y)
 	PKG_CONFIG_FILES += librpmem.pc
-
 	HEADERS_INSTALL += include/librpmem.h
-
 	INSTALL_TARGETS += librpmem
+endif
 endif
 
 SCOPE_SRC_DIRS = $(TARGETS) include jemalloc/src

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -186,21 +186,29 @@ $(PMEMBLK_PRIV_OBJ):
 	$(MAKE) -C $(LIBSDIR) libpmemblk
 
 install: all
+ifneq ($(LIBRARY_NAME),)
 	$(INSTALL) -d $(LIBS_DESTDIR)
 	$(INSTALL) -p -m 0755 $(TARGET_LIBS) $(LIBS_DESTDIR)
 	$(CP) -d $(TARGET_LINKS) $(LIBS_DESTDIR)
+endif
 
 uninstall:
+ifneq ($(LIBRARY_NAME),)
 	$(foreach f, $(TARGET_LIBS), $(RM) $(LIBS_DESTDIR)/$(notdir $(f)))
 	$(foreach f, $(TARGET_LINKS), $(RM) $(LIBS_DESTDIR)/$(notdir $(f)))
+endif
 
 clean: $(EXTRA_TARGETS_CLEAN)
+ifneq ($(LIBRARY_NAME),)
 	$(RM) $(OBJS)
 	$(RM) $(LIB_AR_ALL) $(LIB_AR_UNSCOPED)
+endif
 
 clobber: clean $(EXTRA_TARGETS_CLOBBER)
+ifneq ($(LIBRARY_NAME),)
 	$(RM) $(LIB_AR) $(LIB_SO_SONAME) $(LIB_SO_REAL) $(LIB_SO)
 	$(RM) -r $(objdir)/.deps
+endif
 
 $(eval $(cstyle-rule))
 

--- a/src/common.inc
+++ b/src/common.inc
@@ -145,3 +145,5 @@ export includedir := $(prefix)/$(INC_PREFIX)
 export pkgconfigdir := $(libdir)/pkgconfig
 export bindir := $(exec_prefix)/bin
 export bashcompdir := $(sysconfdir)/bash_completion.d
+
+export BUILD_RPMEM := $(call check_package, libfabric)

--- a/src/examples/librpmem/Makefile
+++ b/src/examples/librpmem/Makefile
@@ -36,9 +36,7 @@
 TOP := ../../..
 include $(TOP)/src/common.inc
 
-HAS_LIBRABRIC=$(call check_package, libfabric)
-
-ifeq ($(HAS_LIBRABRIC), y)
+ifeq ($(BUILD_RPMEM), y)
 PROGS = basic manpage
 
 LIBS = -lrpmem -pthread $(shell $(PKG_CONFIG) --libs libfabric)

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -35,7 +35,7 @@ include ../common.inc
 
 vpath %.c ../rpmem_common
 
-ifeq ($(call check_package, libfabric),y)
+ifeq ($(BUILD_RPMEM),y)
 LIBRARY_NAME = rpmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
@@ -59,7 +59,7 @@ endif
 
 include ../Makefile.inc
 
-ifeq ($(call check_package, libfabric),y)
+ifeq ($(BUILD_RPMEM),y)
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 CFLAGS += -I. -I../rpmem_common

--- a/src/test/rpmem_basic/Makefile
+++ b/src/test/rpmem_basic/Makefile
@@ -38,9 +38,7 @@ include ../../common.inc
 vpath %.c ../../common
 vpath %.c ../../rpmem_common
 
-HAS_LIBFABRIC=$(call check_package, libfabric)
-
-ifeq ($(HAS_LIBFABRIC), y)
+ifeq ($(BUILD_RPMEM), y)
 TARGET = rpmem_basic
 OBJS = rpmem_basic.o\
        rpmem_fip_common.o\
@@ -56,8 +54,8 @@ endif
 
 include ../Makefile.inc
 
+ifeq ($(BUILD_RPMEM), y)
 out.o: CFLAGS += -DDEBUG -DSRCVERSION=\"utversion\"
-ifeq ($(HAS_LIBFABRIC), y)
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 INCS += -I../../common

--- a/src/test/rpmem_fip/Makefile
+++ b/src/test/rpmem_fip/Makefile
@@ -40,9 +40,7 @@ vpath %.c ../../rpmem_common/
 vpath %.c ../../tools/rpmemd
 vpath %.c ../../common/
 
-HAS_LIBFABRIC=$(call check_package, libfabric)
-
-ifeq ($(HAS_LIBFABRIC), y)
+ifeq ($(BUILD_RPMEM), y)
 TARGET = rpmem_fip
 OBJS = rpmem_fip_test.o\
        rpmem_fip_sock.o\
@@ -63,7 +61,7 @@ LIBPMEM=y
 
 include ../Makefile.inc
 
-ifeq ($(HAS_LIBFABRIC), y)
+ifeq ($(BUILD_RPMEM), y)
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 CFLAGS += -DDEBUG

--- a/src/test/tools/fip/Makefile
+++ b/src/test/tools/fip/Makefile
@@ -37,8 +37,7 @@ include $(TOP)/src/common.inc
 
 vpath %.c $(TOP)/src/rpmem_common/
 
-HAS_LIBFABRIC=$(call check_package, libfabric)
-ifeq ($(HAS_LIBFABRIC),y)
+ifeq ($(BUILD_RPMEM),y)
 TARGET = fip
 
 OBJS = fip.o rpmem_fip_common.o rpmem_common.o base64.o
@@ -50,7 +49,7 @@ endif
 
 include $(TOP)/src/tools/Makefile.inc
 
-ifeq ($(HAS_LIBFABRIC),y)
+ifeq ($(BUILD_RPMEM),y)
 CFLAGS += -I$(TOP)/src/rpmem_common
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -36,7 +36,7 @@ vpath %.c ../../rpmem_common/
 TOP = ../../..
 include $(TOP)/src/common.inc
 
-ifeq ($(call check_package, libfabric),y)
+ifeq ($(BUILD_RPMEM),y)
 TARGET = rpmemd
 OBJS = rpmemd.o\
        rpmemd_log.o\

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -674,7 +674,7 @@ then
 	experimental_install_triggers_overrides;
 fi
 
-if [ "${RPMEM_DPKG}" = "y" ]
+if [ "${BUILD_RPMEM}" = "y" && "${RPMEM_DPKG}" = "y" ]
 then
 	append_rpmem_control;
 	rpmem_install_triggers_overrides;

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -90,6 +90,11 @@ Development files for NVML C++ libpmemobj bindings - EXPERIMENTAL
 %{_includedir}/libpmemobj/detail/*.hpp
 %{_docdir}/${OBJ_CPP_NAME}-%{version}/*
 
+EOF
+}
+
+function add_rpmem_packages() {
+cat << EOF >> $RPM_SPEC_FILE
 %package -n librpmem
 Summary: librpmem library
 Group: %{package_group}/Libraries
@@ -468,6 +473,10 @@ EOF
 if [ "${EXPERIMENTAL}" = "y" ]
 then
 	add_experimental_packages;
+	if [ "${BUILD_RPMEM}" = "y" ]
+	then
+		add_rpmem_packages;
+	fi
 fi
 
 [ -f $CHANGELOG_FILE ] && create_changelog $CHANGELOG_FILE >> $RPM_SPEC_FILE


### PR DESCRIPTION
Build librpmem and rpmemd packages only if libfabric is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/986)
<!-- Reviewable:end -->
