### PR TITLE
Win: fix missing messages on Appveyor 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,5 +22,5 @@ test_script:
         echo "`$NON_PMEM_FS_DIR = '\temp'" > testconfig.ps1
         echo "`$PMEM_FS_DIR = '\temp'" >> testconfig.ps1
         echo "`$PMEM_FS_DIR_FORCE_PMEM = 1" >> testconfig.ps1
-        ./RUNTESTS.ps1 -b debug -o 60s -v
+        ./RUNTESTS.ps1 -b debug -o 60s
     }

--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -251,7 +251,7 @@ function runtest {
                 } Else {
                     $p.WaitForExit()
                 }
-                
+
                 if($p.StandardOutput.EndOfStream -eq $false) {
                     $output = $p.StandardOutput.ReadToEnd();
                     Write-Host -NoNewline $output

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -442,10 +442,21 @@ function check {
     #	../match $(find . -regex "[^0-9]*${UNITTEST_NUM}\.log\.match" | xargs)
     [string]$listing = Get-ChildItem -File | Where-Object  {$_.Name -match "[^0-9]${Env:UNITTEST_NUM}.log.match"}
     if ($listing) {
-        $p = start-process -PassThru -Wait -NoNewWindow -FilePath perl -ArgumentList '..\..\..\src\test\match', $listing
+        $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+        $pinfo.FileName = "perl"
+        $pinfo.RedirectStandardError = $true
+        $pinfo.RedirectStandardOutput = $true
+        $pinfo.UseShellExecute = $false
+        $pinfo.Arguments = "..\..\..\src\test\match $listing"
+        $p = New-Object System.Diagnostics.Process
+        $p.StartInfo = $pinfo
+        $p.Start() | Out-Null
+        $p.WaitForExit()
+
         if ($p.ExitCode -eq 0) {
             pass
         } else {
+            $p.StandardError.ReadToEnd()
             fail $p.ExitCode
         }
     } else {


### PR DESCRIPTION
This PR fixes 2 problems:
- Appveyor was not showing FAIL/PASS messages
- Windows tests was not showing match error messages

The drawback of this change is that RUNTEST.PS1 script will not show FAIL/PASS messages in red/green color

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/990)
<!-- Reviewable:end -->
