### PR TITLE
obj: increase max buckets by one to fill uint8_t range

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -34,7 +34,7 @@
  * heap.h -- internal definitions for heap
  */
 
-#define MAX_BUCKETS (UINT8_MAX - 1)
+#define MAX_BUCKETS (UINT8_MAX)
 #define RUN_UNIT_MAX 8U
 
 /*


### PR DESCRIPTION
The bucket index is usually represented by 8 byte unsigned variable whereas
the max bucket constant (and by extension the bucket array size) was
UINT8_MAX - 1. This was done to avoid problems with loops that used iters
of uint8_t type. In retrospect that caused more static analysis problems
than it avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/994)
<!-- Reviewable:end -->
