### PR TITLE
Fix SIGSEGV when env var is set to PMEMOBJ_LOG_FILE=

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -200,7 +200,7 @@ out_init(const char *log_prefix, const char *log_level_var,
 		}
 	}
 
-	if ((log_file = getenv(log_file_var)) != NULL) {
+	if ((log_file = getenv(log_file_var)) != NULL && strlen(log_file)) {
 		size_t cc = strlen(log_file);
 
 		/* reserve more than enough space for a PID + '\0' */


### PR DESCRIPTION
This commit fix segmentation fault when environment variable is PMEMOBJ_LOG_FILE=

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1004)
<!-- Reviewable:end -->
