### PR TITLE
obj: simplify & optimize alloc class generation

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -421,9 +421,13 @@ palloc_operation(struct palloc_heap *heap,
 		!MEMORY_BLOCK_IS_EMPTY(new_block)) {
 		size_t old_size = alloc->size;
 		size_t to_cpy = old_size > sizeh ? sizeh : old_size;
+		VALGRIND_ADD_TO_TX(PMALLOC_OFF_TO_PTR(heap, offset_value),
+			to_cpy - ALLOC_OFF);
 		pmemops_memcpy_persist(&heap->p_ops,
 			PMALLOC_OFF_TO_PTR(heap, offset_value),
 			PMALLOC_OFF_TO_PTR(heap, off),
+			to_cpy - ALLOC_OFF);
+		VALGRIND_REMOVE_FROM_TX(PMALLOC_OFF_TO_PTR(heap, offset_value),
 			to_cpy - ALLOC_OFF);
 	}
 

--- a/src/test/obj_out_of_memory/out0.log.match
+++ b/src/test/obj_out_of_memory/out0.log.match
@@ -1,7 +1,7 @@
 obj_out_of_memory/TEST0: START: obj_out_of_memory
  ./obj_out_of_memory$(nW) 1024 $(nW)/testfile1 $(nW)/testfile2 $(nW)/testset1 $(nW)/testset2
-size: 1024 allocs: 2890
-size: 1024 allocs: 8330
-size: 1024 allocs: 2890
-size: 1024 allocs: 8330
+size: 1024 allocs: 3468
+size: 1024 allocs: 9996
+size: 1024 allocs: 3468
+size: 1024 allocs: 9996
 obj_out_of_memory/TEST0: Done

--- a/src/test/obj_out_of_memory/out1.log.match
+++ b/src/test/obj_out_of_memory/out1.log.match
@@ -1,4 +1,4 @@
 obj_out_of_memory/TEST1: START: obj_out_of_memory
  ./obj_out_of_memory$(nW) 1024 $(nW)/testset1
-size: 1024 allocs: 2890
+size: 1024 allocs: 3468
 obj_out_of_memory/TEST1: Done

--- a/src/test/pmemobjcli/out0.log.match
+++ b/src/test/pmemobjcli/out0.log.match
@@ -18,7 +18,7 @@ pmemobj_type_num(r.1): type num = 4
 pmemobj_alloc_usable_size(r.0): size = $(nW)
 pmemobj_alloc_usable_size(r.1): size = $(nW)
 pmemobj_first: off = $(nW) uuid = $(nW)
-pmemobj_next($(nW)): off = 0x382ac0 uuid = $(nW)
+pmemobj_next($(nW)): off = $(nW) uuid = $(nW)
 pmemobj_memset_persist($(nW), 255, 128): ptr = $(nW)
 pmemobj_memset_persist($(nW), 0, 128): ptr = $(nW)
 pmemobj_memcpy_persist($(nW), $(nW), 128): ptr = $(nW)


### PR DESCRIPTION
The current default allocation classes result in duplicate buckets
supporting the same unit size because the bucket map for the class unit
size didn't point to the corresponding bucket. This patch addresses that
issue and also simplifies the related logic in a way that hopefully
makes it easier to reason about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1005)
<!-- Reviewable:end -->
