### PR TITLE
obj: remove one redundant flush from atomic allocs API

### DIFF
--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -86,7 +86,6 @@ alloc_write_header(PMEMobjpool *pop, struct allocation_header *alloc,
 	alloc->size = size;
 	alloc->zone_id = m.zone_id;
 	VALGRIND_REMOVE_FROM_TX(alloc, sizeof(*alloc));
-	pop->persist(pop, alloc, sizeof(*alloc));
 }
 
 /*
@@ -195,8 +194,7 @@ alloc_prep_block(PMEMobjpool *pop, struct memory_block m,
 	pmalloc_constr constructor, void *arg, uint64_t *offset_value)
 {
 	void *block_data = heap_get_block_data(pop, m);
-	void *datap = (char *)block_data + sizeof(struct allocation_header);
-	void *userdatap = (char *)datap + DATA_OFF;
+	void *userdatap = (char *)block_data + ALLOC_OFF;
 
 	uint64_t unit_size = MEMBLOCK_OPS(AUTO, &m)->block_size(&m,
 		pop->hlayout);
@@ -226,8 +224,33 @@ alloc_prep_block(PMEMobjpool *pop, struct memory_block m,
 		VALGRIND_DO_MEMPOOL_FREE(pop, userdatap);
 		VALGRIND_DO_MAKE_MEM_NOACCESS(pop, block_data, ALLOC_OFF);
 
+		/*
+		 * During this method there are several stores to pmem that are
+		 * not immediately flushed and in case of a cancelation those
+		 * stores are no longer relevant anyway.
+		 */
+		VALGRIND_SET_CLEAN(block_data, ALLOC_OFF);
+
 		return ret;
 	}
+
+	/* flushes both the alloc and oob headers */
+	pop->persist(pop, block_data, ALLOC_OFF);
+
+#ifdef USE_VG_MEMCHECK
+	if (On_valgrind) {
+		struct oob_header *pobj = (struct oob_header *)
+			((char *)block_data + sizeof(struct allocation_header));
+
+		/*
+		 * The first few bytes of the oobh are unused and double as
+		 * an object guard which will cause valgrind to issue an error
+		 * whenever the unused memory is accessed.
+		 */
+		VALGRIND_DO_MAKE_MEM_NOACCESS(pop, pobj->unused,
+			sizeof(pobj->unused));
+	}
+#endif
 
 	/*
 	 * To avoid determining the user data pointer twice this method is also
@@ -236,7 +259,6 @@ alloc_prep_block(PMEMobjpool *pop, struct memory_block m,
 	 * caller.
 	 */
 	*offset_value = OBJ_PTR_TO_OFF(pop, userdatap);
-
 
 	return ret;
 }

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -279,7 +279,6 @@ constructor_tx_add_range(PMEMobjpool *pop, void *ptr,
 				+ OBJ_OOB_SIZE);
 
 	oobh->size = OBJ_INTERNAL_OBJECT_MASK;
-	pop->flush(pop, &oobh->size, sizeof(oobh->size));
 
 	range->offset = args->offset;
 	range->size = args->size;
@@ -631,16 +630,14 @@ tx_pre_commit_alloc(PMEMobjpool *pop, struct tx_undo_runtime *tx_rt)
 		struct oob_header *oobh = OOB_HEADER_FROM_OFF(pop, offset);
 		SET_TX_VAR(pop, oobh->undo_entry_offset, 0);
 
-		size_t size = pmalloc_usable_size(pop, offset);
-		pop->flush(pop, oobh, size);
-
 		/*
-		 * The first few bytes of the oobh are unused and double as
-		 * an object guard which will cause valgrind to issue an error
-		 * whenever the unused memory is accessed.
+		 * Flush the entire object with the exception of the unused part
+		 * of the OOB header. This code is very reliant on the object
+		 * header layout so be careful when modifying.
 		 */
-		VALGRIND_DO_MAKE_MEM_NOACCESS(pop, oobh->unused,
-			sizeof(oobh->unused));
+		size_t size = pmalloc_usable_size(pop, offset) -
+			sizeof(oobh->unused);
+		pop->flush(pop, &oobh->undo_entry_offset, size);
 	}
 }
 

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -3,7 +3,7 @@ obj_persist_count/TEST0: START: obj_persist_count
 persist	;msync	;flush	;drain	;task
 0	;11	;0	;0	;pool_create
 0	;8	;0	;0	;root_alloc
-0	;3	;0	;0	;atomic_alloc
+0	;2	;0	;0	;atomic_alloc
 0	;1	;0	;0	;atomic_free
 0	;11	;0	;0	;tx_alloc
 0	;10	;0	;0	;tx_alloc_next

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -3,7 +3,7 @@ obj_persist_count/TEST1: START: obj_persist_count
 persist	;msync	;flush	;drain	;task
 3	;8	;0	;0	;pool_create
 6	;0	;1	;0	;root_alloc
-2	;0	;1	;1	;atomic_alloc
+2	;0	;0	;0	;atomic_alloc
 1	;0	;0	;0	;atomic_free
 9	;0	;2	;1	;tx_alloc
 8	;0	;2	;1	;tx_alloc_next


### PR DESCRIPTION
The allocation and OOB headers are currently created and persisted
separately even though they reside on the same 64 byte cacheline. This
patch removes the requirement of flushing OOB header data from the internal
constructors and combines the flushes into one call after both of the
object headers have been written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1007)
<!-- Reviewable:end -->
