### PR TITLE
common: update gitignore in tests

### DIFF
--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -9,3 +9,4 @@ testfile*
 # ignore static binaries generated for testing
 *.static-debug
 *.static-nondebug
+libs.tar


### PR DESCRIPTION
The libs.tar files were visible in untracked files after
37bc8d98218fa68965bdc600b1628aff0f99f7ba.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1010)
<!-- Reviewable:end -->
