### PR TITLE
rpmem: fix casting type in parse_cl_args()

### DIFF
--- a/src/tools/rpmemd/rpmemd_config.c
+++ b/src/tools/rpmemd/rpmemd_config.c
@@ -456,7 +456,7 @@ parse_cl_args(int argc, char *argv[], struct rpmemd_config *config,
 		default:
 			if (set_option((enum rpmemd_option)opt, optarg, config)
 					== 0) {
-				*cl_options |= (uint32_t)(1 << opt);
+				*cl_options |= (uint64_t)(1 << opt);
 			} else {
 				print_usage(argv[0]);
 				exit(-1);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1011)
<!-- Reviewable:end -->
