### PR TITLE
common: fix setting PKG_CONFIG_PATH on remote node

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -721,7 +721,11 @@ function require_node_pkg() {
 	shift
 
 	local DIR=${NODE_WORKING_DIR[$N]}/$curtestdir
-	local COMMAND="$COMMAND PKG_CONFIG_PATH+=:${NODE_LD_LIBRARY_PATH[$N]}/pkgconfig"
+	local COMMAND=""
+	if [ -n "${NODE_LD_LIBRARY_PATH[$N]}" ]; then
+		COMMAND="PKG_CONFIG_PATH=\$PKG_CONFIG_PATH:${NODE_LD_LIBRARY_PATH[$N]}/pkgconfig"
+	fi
+
 	COMMAND="$COMMAND pkg-config $1"
 
 	set +e


### PR DESCRIPTION
- use PKG_CONFIG_PATH only if LD_LIBRARY_PATH is set
- use '=' instead of '+=' syntax

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1012)
<!-- Reviewable:end -->
