### PR TITLE
win: Add file to pmempool project

### DIFF
--- a/src/tools/pmempool/pmempool.vcxproj
+++ b/src/tools/pmempool/pmempool.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="..\..\libpmemobj\memblock.c" />
     <ClCompile Include="..\..\libpmemobj\memops.c" />
     <ClCompile Include="..\..\libpmemobj\obj.c" />
+    <ClCompile Include="..\..\libpmemobj\palloc.c" />
     <ClCompile Include="..\..\libpmemobj\pmalloc.c" />
     <ClCompile Include="..\..\libpmemobj\pvector.c" />
     <ClCompile Include="..\..\libpmemobj\redo.c" />

--- a/src/tools/pmempool/pmempool.vcxproj.filters
+++ b/src/tools/pmempool/pmempool.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="..\..\libpmemobj\sync.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmemobj\palloc.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="rm.h">


### PR DESCRIPTION
Missing palloc.c in pmempoll project was causing fail of windows build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1026)
<!-- Reviewable:end -->
