### PR TITLE
common: fix build scripts

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -75,8 +75,8 @@ function convert_changelog() {
 
 function experimental_install_triggers_overrides() {
 cat << EOF > debian/${OBJ_CPP_NAME}.install
-usr/include/libpmemobj/*.hpp
-usr/include/libpmemobj/detail/*.hpp
+usr/include/libpmemobj++/*.hpp
+usr/include/libpmemobj++/detail/*.hpp
 usr/share/doc/${OBJ_CPP_DOC_DIR}/*
 EOF
 

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -86,8 +86,8 @@ Development files for NVML C++ libpmemobj bindings - EXPERIMENTAL
 %files -n ${OBJ_CPP_NAME}
 %defattr(-,root,root,-)
 %{_libdir}/pkgconfig/libpmemobj++.pc
-%{_includedir}/libpmemobj/*.hpp
-%{_includedir}/libpmemobj/detail/*.hpp
+%{_includedir}/libpmemobj++/*.hpp
+%{_includedir}/libpmemobj++/detail/*.hpp
 %{_docdir}/${OBJ_CPP_NAME}-%{version}/*
 
 EOF

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -72,6 +72,7 @@ sudo docker run --rm --privileged=true --name=$containerName -ti \
 	--env EXTRA_CFLAGS=$EXTRA_CFLAGS \
 	--env REMOTE_TESTS=$REMOTE_TESTS \
 	--env WORKDIR=$WORKDIR \
+	--env EXPERIMENTAL=$EXPERIMENTAL \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-w $SCRIPTSDIR \


### PR DESCRIPTION
Fix docker build script to pass the EXPERIMENTAL env variable.
Fix paths in package build scripts for C++ bindings.

Refs: pmem/issues#213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1027)
<!-- Reviewable:end -->
