### PR TITLE
ut: remove all log files in setup()

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1584,7 +1584,7 @@ function setup() {
 
 	echo "$UNITTEST_NAME: SETUP ($TEST/$REAL_FS/$BUILD$MCSTR$PROV$PM)"
 
-	rm -f check_pool_${BUILD}_${UNITTEST_NUM}.log
+	find . -maxdepth 1 -name "*[a-zA-Z_]${UNITTEST_NUM}.log" -exec rm -f "{}" \;
 
 	if [ "$FS" != "none" ]; then
 		if [ -d "$DIR" ]; then


### PR DESCRIPTION
Release libraries ignore *_LOG_FILE variables, so when test passes
in debug mode, but fails in release mode, it's easy to get confused
by looking at log file from previous run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1034)
<!-- Reviewable:end -->
