### PR TITLE
win: disable abort msgbox on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,6 @@ test_script:
         echo "`$NON_PMEM_FS_DIR = '\temp'" > testconfig.ps1
         echo "`$PMEM_FS_DIR = '\temp'" >> testconfig.ps1
         echo "`$PMEM_FS_DIR_FORCE_PMEM = 1" >> testconfig.ps1
+        $Env:UNITTEST_NO_ABORT_MSG = 1
         ./RUNTESTS.ps1 -b debug -o 3m
     }

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -352,6 +352,15 @@ ut_start(const char *file, int line, const char *func,
 
 	va_start(ap, fmt);
 
+#ifdef _WIN32
+	if (getenv("UNITTEST_NO_ABORT_MSG") != NULL) {
+		/* disable windows error message boxes */
+		DWORD dwMode = GetErrorMode();
+		SetErrorMode(dwMode | SEM_NOGPFAULTERRORBOX |
+			SEM_FAILCRITICALERRORS);
+		_set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+	}
+#endif
 	if (getenv("UNITTEST_NO_SIGHANDLERS") == NULL)
 		ut_register_sighandlers();
 


### PR DESCRIPTION
Calling abort in our unit tests was causing appveyour build to hang -
build was waiting for pressing a button on abort message box...

This commit disables that message box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1037)
<!-- Reviewable:end -->
