### PR TITLE
Speed up tests on Travis by 15%

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -350,11 +350,14 @@ check: test
 	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(TESTS)
 	@echo "No failures."
 
-check-remote: test
+check-remote-quiet: test
 	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(REMOTE_TESTS)
+
+check-remote: check-remote-quiet
 	@echo "No failures."
 
-pcheck: $(TESTS_BUILD)
+# XXX remote tests do not work in parallel mode
+pcheck: pcheck-local-quiet check-remote-quiet
 	@echo "No failures."
 
 pcheck-blk: TARGET = pcheck
@@ -397,8 +400,10 @@ pcheck-vmmalloc: TARGET = pcheck
 pcheck-vmmalloc: $(VMMALLOC_TESTS)
 	@echo "No failures."
 
-pcheck-local: TARGET = pcheck
-pcheck-local: $(LOCAL_TESTS)
+pcheck-local-quiet: TARGET = pcheck
+pcheck-local-quiet: $(LOCAL_TESTS)
+
+pcheck-local: pcheck-local-quiet
 	@echo "No failures."
 
 pcheck-remote: TARGET = pcheck

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -357,55 +357,55 @@ check-remote: test
 pcheck: $(TESTS_BUILD)
 	@echo "No failures."
 
-pcheck_blk: TARGET = pcheck
-pcheck_blk: $(BLK_TESTS)
+pcheck-blk: TARGET = pcheck
+pcheck-blk: $(BLK_TESTS)
 	@echo "No failures."
 
-pcheck_log: TARGET = pcheck
-pcheck_log: $(LOG_TESTS)
+pcheck-log: TARGET = pcheck
+pcheck-log: $(LOG_TESTS)
 	@echo "No failures."
 
-pcheck_obj: TARGET = pcheck
-pcheck_obj: $(OBJ_TESTS)
+pcheck-obj: TARGET = pcheck
+pcheck-obj: $(OBJ_TESTS)
 	@echo "No failures."
 
-pcheck_other: TARGET = pcheck
-pcheck_other: $(OTHER_TESTS)
+pcheck-other: TARGET = pcheck
+pcheck-other: $(OTHER_TESTS)
 	@echo "No failures."
 
-pcheck_pmem: TARGET = pcheck
-pcheck_pmem: $(PMEM_TESTS)
+pcheck-pmem: TARGET = pcheck
+pcheck-pmem: $(PMEM_TESTS)
 	@echo "No failures."
 
-pcheck_rpmem: TARGET = pcheck
-pcheck_rpmem: $(RPMEM_TESTS)
+pcheck-rpmem: TARGET = pcheck
+pcheck-rpmem: $(RPMEM_TESTS)
 	@echo "No failures."
 
-pcheck_pmempool: TARGET = pcheck
-pcheck_pmempool: $(PMEMPOOL_TESTS)
+pcheck-pmempool: TARGET = pcheck
+pcheck-pmempool: $(PMEMPOOL_TESTS)
 	@echo "No failures."
 
-pcheck_libpmempool: TARGET = pcheck
-pcheck_libpmempool: $(LIBPMEMPOOL_TESTS)
+pcheck-libpmempool: TARGET = pcheck
+pcheck-libpmempool: $(LIBPMEMPOOL_TESTS)
 	@echo "No failures."
 
-pcheck_vmem: TARGET = pcheck
-pcheck_vmem: $(VMEM_TESTS)
+pcheck-vmem: TARGET = pcheck
+pcheck-vmem: $(VMEM_TESTS)
 	@echo "No failures."
 
-pcheck_vmmalloc: TARGET = pcheck
-pcheck_vmmalloc: $(VMMALLOC_TESTS)
+pcheck-vmmalloc: TARGET = pcheck
+pcheck-vmmalloc: $(VMMALLOC_TESTS)
 	@echo "No failures."
 
-pcheck_local: TARGET = pcheck
-pcheck_local: $(LOCAL_TESTS)
+pcheck-local: TARGET = pcheck
+pcheck-local: $(LOCAL_TESTS)
 	@echo "No failures."
 
-pcheck_remote: TARGET = pcheck
-pcheck_remote: $(REMOTE_TESTS)
+pcheck-remote: TARGET = pcheck
+pcheck-remote: $(REMOTE_TESTS)
 	@echo "No failures."
 
-.PHONY: all check clean clobber cstyle pcheck pcheck_blk pcheck_log pcheck_obj\
-	 pcheck_other pcheck_pmem pcheck_pmempool pcheck_vmem pcheck_vmmalloc\
-	 test unittest tools check-remote format pcheck_libpmempool\
-	 pcheck_rpmem pcheck_local pcheck_remote $(TESTS_BUILD)
+.PHONY: all check clean clobber cstyle pcheck pcheck-blk pcheck-log pcheck-obj\
+	 pcheck-other pcheck-pmem pcheck-pmempool pcheck-vmem pcheck-vmmalloc\
+	 test unittest tools check-remote format pcheck-libpmempool\
+	 pcheck-rpmem pcheck-local pcheck-remote $(TESTS_BUILD)

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -675,7 +675,7 @@ then
 	experimental_install_triggers_overrides;
 fi
 
-if [ "${BUILD_RPMEM}" = "y" && "${RPMEM_DPKG}" = "y" ]
+if [ "${BUILD_RPMEM}" = "y" -a "${RPMEM_DPKG}" = "y" ]
 then
 	append_rpmem_control;
 	rpmem_install_triggers_overrides;

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -196,7 +196,7 @@ override_dh_auto_test:
 	else\
 	        cp src/test/testconfig.sh.example src/test/testconfig.sh;\
 	fi
-	make check
+	make pcheck $PCHECK_OPTS
 "
 
 if [ "${BUILD_PACKAGE_CHECK}" != "y" ]

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -162,7 +162,7 @@ else
 	cp src/test/testconfig.sh.example src/test/testconfig.sh
 fi
 
-make check
+make pcheck $PCHECK_OPTS
 "
 
 if [ "${BUILD_PACKAGE_CHECK}" != "y" ]

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -37,7 +37,7 @@
 #
 
 # Mount filesystem for tests
-echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=4G
+echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=6G
 
 # Configure tests (e.g. ssh for remote tests)
 ./configure-tests.sh

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -40,5 +40,6 @@
 
 # Build all and run tests
 cd $WORKDIR
+export PCHECK_OPTS=-j2
 make -j2 $PACKAGE_MANAGER
 

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -44,6 +44,6 @@ make check-license \
 	&& make cstyle \
 	&& make -j2 USE_LIBUNWIND=1 \
 	&& make -j2 test USE_LIBUNWIND=1 \
-	&& make check \
+	&& make -j2 pcheck \
 	&& make DESTDIR=/tmp source
 


### PR DESCRIPTION
Times for configurations without Valgrind and remote tests decrease from 18 minutes to 15 minutes (16%).

Times for configurations with Valgrind and remote tests decrease from 40 minutes to 34 minutes (15%).

Total time decreases from 2h56m to 2h29m (15%).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1038)
<!-- Reviewable:end -->
