### PR TITLE
ut: workaround race in find

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1584,7 +1584,10 @@ function setup() {
 
 	echo "$UNITTEST_NAME: SETUP ($TEST/$REAL_FS/$BUILD$MCSTR$PROV$PM)"
 
-	find . -maxdepth 1 -name "*[a-zA-Z_]${UNITTEST_NUM}.log" -exec rm -f "{}" \;
+	find . -maxdepth 1\
+		-ignore_readdir_race \
+		-name "*[a-zA-Z_]${UNITTEST_NUM}.log" \
+		-exec rm -f "{}" \;
 
 	if [ "$FS" != "none" ]; then
 		if [ -d "$DIR" ]; then


### PR DESCRIPTION
It manifested during "make pcheck -jN" as eg:
find: './out2.log': No such file or directory
find: './err2.log': No such file or directory
find: './trace2.log': No such file or directory
RUNTESTS: stopping: util_map_proc/TEST3 failed, TEST=check FS=none BUILD=nondebug

(Note how TEST3 fails with errors which mention logs for TEST2)

http://git.savannah.gnu.org/cgit/findutils.git/commit/?h=rel-4-2-fixes&id=bfa4fbe01262070f1274c60110e44e2020108d75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1042)
<!-- Reviewable:end -->
