### PR TITLE
test: add windows tests for log_pool, add os specific err mapper

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -44,7 +44,8 @@ SOURCE =\
 	set.c\
 	util.c\
 	uuid.c\
-	uuid_linux.c
+	uuid_linux.c\
+	util_linux.c
 
 include ../Makefile.inc
 

--- a/src/common/libpmemcommon.vcxproj
+++ b/src/common/libpmemcommon.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="pthread_windows.c" />
     <ClCompile Include="set.c" />
     <ClCompile Include="util.c" />
+    <ClCompile Include="util_windows.c" />
     <ClCompile Include="uuid.c" />
     <ClCompile Include="uuid_windows.c" />
   </ItemGroup>

--- a/src/common/libpmemcommon.vcxproj.filters
+++ b/src/common/libpmemcommon.vcxproj.filters
@@ -47,6 +47,9 @@
     <ClCompile Include="pthread_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="util_windows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="dlsym.h">

--- a/src/common/out.c
+++ b/src/common/out.c
@@ -47,6 +47,7 @@
 
 #include "out.h"
 #include "valgrind_internal.h"
+#include "util.h"
 
 /* XXX - modify Linux makefiles to generate srcversion.h and remove #ifdef */
 #ifdef _WIN32
@@ -217,9 +218,11 @@ out_init(const char *log_prefix, const char *log_level_var,
 			log_file = log_file_pid;
 		}
 		if ((Out_fp = fopen(log_file, "w")) == NULL) {
+			char buff[UTIL_MAX_ERR_MSG];
+			util_strerror(errno, buff, UTIL_MAX_ERR_MSG);
 			fprintf(stderr, "Error (%s): %s=%s: %s\n",
 					log_prefix, log_file_var,
-					log_file, strerror(errno));
+					log_file, buff);
 			abort();
 		}
 	}
@@ -365,7 +368,7 @@ out_common(const char *file, int line, const char *func, int level,
 	unsigned cc = 0;
 	int ret;
 	const char *sep = "";
-	const char *errstr = "";
+	char errstr[UTIL_MAX_ERR_MSG] = "";
 
 	if (file) {
 		char *f = strrchr(file, DIR_SEPARATOR);
@@ -389,7 +392,7 @@ out_common(const char *file, int line, const char *func, int level,
 		if (*fmt == '!') {
 			fmt++;
 			sep = ": ";
-			errstr = strerror(errno);
+			util_strerror(errno, errstr, UTIL_MAX_ERR_MSG);
 		}
 		ret = Vsnprintf(&buf[cc], MAXPRINT - cc, fmt, ap);
 		if (ret < 0) {
@@ -418,7 +421,7 @@ out_error(const char *file, int line, const char *func,
 	unsigned cc = 0;
 	int ret;
 	const char *sep = "";
-	const char *errstr = "";
+	char errstr[UTIL_MAX_ERR_MSG] = "";
 
 	char *errormsg = (char *)out_get_errormsg();
 
@@ -426,7 +429,7 @@ out_error(const char *file, int line, const char *func,
 		if (*fmt == '!') {
 			fmt++;
 			sep = ": ";
-			errstr = strerror(errno);
+			util_strerror(errno, errstr, UTIL_MAX_ERR_MSG);
 		}
 		ret = Vsnprintf(&errormsg[cc], MAXPRINT, fmt, ap);
 		if (ret < 0) {

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -64,6 +64,8 @@ int util_is_zeroed(const void *addr, size_t len);
 int util_checksum(void *addr, size_t len, uint64_t *csump, int insert);
 int util_parse_size(const char *str, size_t *sizep);
 char *util_fgets(char *buffer, int max, FILE *stream);
+#define UTIL_MAX_ERR_MSG 128
+void util_strerror(int errnum, char *buff, size_t bufflen);
 
 void util_set_alloc_funcs(
 		void *(*malloc_func)(size_t size),

--- a/src/common/util_linux.c
+++ b/src/common/util_linux.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * util_linux.c -- misc utilities with OS-specific implementation
+ */
+
+#include <string.h>
+#include <util.h>
+
+/* pass through for Linux */
+void
+util_strerror(int errnum, char *buff, size_t bufflen)
+{
+	strerror_r(errnum, buff, bufflen);
+}

--- a/src/common/util_windows.c
+++ b/src/common/util_windows.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * util_windows.c -- misc utilities with OS-specific implementation
+ */
+
+#include <string.h>
+#include "util.h"
+
+/* Windows CRT doesn't support all errors, add unmapped here */
+#define ENOTSUP_STR "Operation not supported"
+#define UNMAPPED_STR "Unmapped error"
+void
+util_strerror(int errnum, char *buff, size_t bufflen)
+{
+	switch (errnum) {
+	case ENOTSUP:
+		strcpy_s(buff, bufflen, ENOTSUP_STR);
+		break;
+	default:
+		if (strerror_s(buff, bufflen, errnum))
+			strcpy_s(buff, bufflen, UNMAPPED_STR);
+	}
+}

--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -39,6 +39,7 @@ SOURCE =\
 	$(COMMON)/file_linux.c\
 	$(COMMON)/out.c\
 	$(COMMON)/util.c\
+	$(COMMON)/util_linux.c\
 	$(COMMON)/mmap.c\
 	$(COMMON)/mmap_linux.c\
 	libpmem.c\

--- a/src/libpmemblk/Makefile
+++ b/src/libpmemblk/Makefile
@@ -47,6 +47,7 @@ SOURCE =\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
 	$(COMMON)/uuid_linux.c\
+	$(COMMON)/util_linux.c\
 	blk.c\
 	btt.c\
 	libpmemblk.c

--- a/src/libpmemblk/libpmemblk.vcxproj
+++ b/src/libpmemblk/libpmemblk.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/libpmemblk/libpmemblk.vcxproj.filters
+++ b/src/libpmemblk/libpmemblk.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Header Files">

--- a/src/libpmemlog/Makefile
+++ b/src/libpmemlog/Makefile
@@ -47,6 +47,7 @@ SOURCE =\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
 	$(COMMON)/uuid_linux.c\
+	$(COMMON)/util_linux.c\
 	libpmemlog.c\
 	log.c
 

--- a/src/libpmemlog/libpmemlog.vcxproj
+++ b/src/libpmemlog/libpmemlog.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/libpmemlog/libpmemlog.vcxproj.filters
+++ b/src/libpmemlog/libpmemlog.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\..\src\libpmemlog\libpmemlog.c">

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -47,6 +47,7 @@ SOURCE =\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
 	$(COMMON)/uuid_linux.c\
+	$(COMMON)/util_linux.c\
 	bucket.c\
 	ctree.c\
 	cuckoo.c\

--- a/src/libpmemobj/libpmemobj.vcxproj
+++ b/src/libpmemobj/libpmemobj.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="..\common\pool_hdr.c" />
     <ClCompile Include="..\common\pool_hdr_windows.c" />
     <ClCompile Include="..\common\pthread_windows.c" />
+    <ClCompile Include="..\common\util_windows.c" />
     <ClCompile Include="..\common\uuid.c" />
     <ClCompile Include="..\common\uuid_windows.c" />
     <ClCompile Include="libpmemobj_main.c">

--- a/src/libpmemobj/libpmemobj.vcxproj.filters
+++ b/src/libpmemobj/libpmemobj.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="..\..\src\libpmemobj\bucket.c">
@@ -86,6 +86,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\libpmemobj\palloc.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\common\util_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -52,6 +52,7 @@ SOURCE =\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
 	$(COMMON)/uuid_linux.c\
+	$(COMMON)/util_linux.c\
 	libpmempool.c\
 	check.c\
 	check_backup.c\

--- a/src/libpmempool/check_util.c
+++ b/src/libpmempool/check_util.c
@@ -356,8 +356,10 @@ check_status_create(PMEMpoolcheck *ppc, enum pmempool_check_msg_type type,
 		/* append possible strerror at the end of the message */
 		if (type != PMEMPOOL_CHECK_MSG_TYPE_QUESTION && errno &&
 				p > 0) {
+			char buff[UTIL_MAX_ERR_MSG];
+			util_strerror(errno, buff, UTIL_MAX_ERR_MSG);
 			snprintf(st->msg + p, MAX_MSG_STR_SIZE - (size_t)p,
-				": %s", strerror(errno));
+				": %s", buff);
 		}
 
 		st->status.type = type;

--- a/src/libpmempool/libpmempool.vcxproj
+++ b/src/libpmempool/libpmempool.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/libpmempool/libpmempool.vcxproj.filters
+++ b/src/libpmempool/libpmempool.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -40,6 +40,7 @@ LIBRARY_NAME = rpmem
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
 SOURCE = $(COMMON)/util.c\
+	$(COMMON)/util_linux.c\
 	$(COMMON)/out.c\
 	librpmem.c\
 	rpmem.c\

--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -316,8 +316,10 @@ rpmem_ssh_strerror(struct rpmem_ssh *rps)
 
 	if (ret == 0) {
 		if (errno) {
+			char buff[UTIL_MAX_ERR_MSG];
+			util_strerror(errno, buff, UTIL_MAX_ERR_MSG);
 			snprintf(error_str, ERR_BUFF_SIZE,
-				"%s: %s", rps->node, strerror(errno));
+				"%s: %s", rps->node, buff);
 		} else {
 			snprintf(error_str, ERR_BUFF_SIZE,
 				"%s: unknown error", rps->node);

--- a/src/libvmem/Makefile
+++ b/src/libvmem/Makefile
@@ -40,6 +40,7 @@ SOURCE = libvmem.c vmem.c\
 	$(COMMON)/mmap.c\
 	$(COMMON)/mmap_linux.c\
 	$(COMMON)/out.c\
+	$(COMMON)/util_linux.c\
 	$(COMMON)/util.c
 
 default: all

--- a/src/libvmmalloc/Makefile
+++ b/src/libvmmalloc/Makefile
@@ -40,7 +40,8 @@ SOURCE = libvmmalloc.c\
 	$(COMMON)/mmap.c\
 	$(COMMON)/mmap_linux.c\
 	$(COMMON)/out.c\
-	$(COMMON)/util.c
+	$(COMMON)/util.c\
+	$(COMMON)/util_linux.c
 
 default: all
 

--- a/src/test/checksum/checksum.vcxproj
+++ b/src/test/checksum/checksum.vcxproj
@@ -166,6 +166,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\common\util.c" />
+    <ClCompile Include="..\..\common\util_windows.c" />
     <ClCompile Include="checksum.c" />
   </ItemGroup>
   <ItemGroup>

--- a/src/test/checksum/checksum.vcxproj.filters
+++ b/src/test/checksum/checksum.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="..\..\common\util.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\common\util_windows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1">

--- a/src/test/libpmempool_api/libpmempool_test.c
+++ b/src/test/libpmempool_api/libpmempool_test.c
@@ -69,7 +69,9 @@ check_pool(struct pmempool_check_args *args, size_t args_size)
 
 	PMEMpoolcheck *ppc = pmempool_check_init(args, args_size);
 	if (!ppc) {
-		UT_OUT("Error: %s", strerror(errno));
+		char buff[UT_MAX_ERR_MSG];
+		ut_strerror(errno, buff, UT_MAX_ERR_MSG);
+		UT_OUT("Error: %s", buff);
 		return;
 	}
 

--- a/src/test/log_pool/TEST0
+++ b/src/test/log_pool/TEST0
@@ -46,7 +46,7 @@ umask 0
 #
 # TEST0 non-existing file, poolsize > 0
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 20 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 20 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST0.PS1
+++ b/src/test/log_pool/TEST0.PS1
@@ -1,0 +1,65 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST0 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST0 non-existing file, poolsize > 0
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 20 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST1
+++ b/src/test/log_pool/TEST1
@@ -45,12 +45,12 @@ setup
 umask 0
 
 create_holey_file 40M $DIR/testfile
-chmod 0640 $DIR/testfile
+chmod 0600 $DIR/testfile
 
 #
 # TEST1 existing file, file length >= min required size, poolsize == 0
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST1.PS1
+++ b/src/test/log_pool/TEST1.PS1
@@ -1,0 +1,67 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST1 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST1"
+$Env:UNITTEST_NUM = "1"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 40M $DIR\testfile
+
+#
+# TEST1 existing file, file length >= min required size, poolsize == 0
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST10
+++ b/src/test/log_pool/TEST10
@@ -53,7 +53,7 @@ chmod 0440 $DIR/testfile
 # TEST11 existing file, file length >= min required size, poolsize == 0,
 #        (no write permissions)
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST10.PS1
+++ b/src/test/log_pool/TEST10.PS1
@@ -1,0 +1,74 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST10 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST10"
+$Env:UNITTEST_NUM = "10"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 20 $DIR\testfile
+
+# deny write (make read only)
+& icacls $DIR\testfile /deny ${Env:USERNAME}:W >$null
+
+#
+# TEST11 existing file, file length >= min required size, poolsize == 0,
+#        (no write permissions)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+# restore full permissions
+& icacls $DIR\testfile /grant ${Env:USERNAME}:F >$null
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST11
+++ b/src/test/log_pool/TEST11
@@ -49,7 +49,7 @@ umask 0
 #
 create_poolset $DIR/testset 20M:$DIR/testfile1:x 20M:$DIR/testfile2:x
 
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testset 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testset 0 0600
 
 check_files $DIR/testset $DIR/testfile1 $DIR/testfile2
 

--- a/src/test/log_pool/TEST11w.PS1
+++ b/src/test/log_pool/TEST11w.PS1
@@ -1,0 +1,68 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST11 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST11w"
+$Env:UNITTEST_NUM = "11w"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST11 non-existing file, poolsize > 0
+#        (pool set)
+#
+create_poolset $DIR\testset 20M:$DIR\testfile1:x 20M:$DIR\testfile2:x
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testset 0 0600
+
+check_files $DIR\testset $DIR\testfile1 $DIR\testfile2
+
+check
+
+pass

--- a/src/test/log_pool/TEST12
+++ b/src/test/log_pool/TEST12
@@ -49,7 +49,7 @@ umask 0
 #
 create_poolset $DIR/testset 20M:$DIR/testfile1:x R 20M:$DIR/testfile2:x
 
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testset 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testset 0 0600
 
 check_files $DIR/testset
 check_no_files $DIR/testfile1 $DIR/testfile2

--- a/src/test/log_pool/TEST12.PS1
+++ b/src/test/log_pool/TEST12.PS1
@@ -1,0 +1,69 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST12 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST12"
+$Env:UNITTEST_NUM = "12"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST12 non-existing file, poolsize > 0
+#        (pool set with replica section)
+#
+create_poolset $DIR\testset 20M:$DIR\testfile1:x R 20M:$DIR\testfile2:x
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testset 0 0600
+
+check_files $DIR\testset
+check_no_files $DIR\testfile1 $DIR\testfile2
+
+check
+
+pass

--- a/src/test/log_pool/TEST2
+++ b/src/test/log_pool/TEST2
@@ -46,7 +46,7 @@ umask 0
 #
 # TEST2 non-existing file, poolsize == 0
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_no_files $DIR/testfile
 

--- a/src/test/log_pool/TEST2.PS1
+++ b/src/test/log_pool/TEST2.PS1
@@ -1,0 +1,65 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST2 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST2"
+$Env:UNITTEST_NUM = "2"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST2 non-existing file, poolsize == 0
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+check_no_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST20.PS1
+++ b/src/test/log_pool/TEST20.PS1
@@ -1,0 +1,63 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST20 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST20"
+$Env:UNITTEST_NUM = "20"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST20 non-existing file
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST21.PS1
+++ b/src/test/log_pool/TEST21.PS1
@@ -1,0 +1,67 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST21 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST21"
+$Env:UNITTEST_NUM = "21"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 1 $DIR\testfile
+
+#
+# TEST21 existing file, file size < min required size
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+rm $DIR/testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST22.PS1
+++ b/src/test/log_pool/TEST22.PS1
@@ -1,0 +1,83 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST22 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST22"
+$Env:UNITTEST_NUM = "22"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST22 existing file, file size < min required size
+#        (valid pool header)
+#
+
+# XXX This isn't quite equivalent to the linux test, need
+# to implement linux truncate in our sparsefile tool...
+
+# write valid signature to testfile "PMEMPOOLSET"
+$sig = New-Object Byte[] 11
+$sig[0] = 80 # 0x50 P
+$sig[1] = 77 # 0x4d M
+$sig[2] = 69 # 0x45 E
+$sig[3] = 77 # 0x4d M
+$sig[4] = 80 # 0x50 P
+$sig[5] = 79 # 0x4f O
+$sig[6] = 79 # 0x4f O
+$sig[7] = 76 # 0x4c L
+$sig[8] = 83 # 0x53 S
+$sig[9] = 69 # 0x45 E
+$sig[10] = 84 # 0x54 T
+Set-Content -Path $DIR\testfile -Value $sig -Encoding Byte
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST23.PS1
+++ b/src/test/log_pool/TEST23.PS1
@@ -1,0 +1,66 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST23 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST23"
+$Env:UNITTEST_NUM = "23"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 20 $DIR\testfile
+
+#
+# TEST23 existing file, file size >= min required size
+#        (empty pool header)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST24.PS1
+++ b/src/test/log_pool/TEST24.PS1
@@ -1,0 +1,70 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST24 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST24"
+$Env:UNITTEST_NUM = "24"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST24 existing file, file size >= min required size
+#        (no read permissions)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 20 0600
+# deny read
+& icacls $DIR\testfile /deny ${Env:USERNAME}:R >$null
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+# restore full permissions
+& icacls $DIR\testfile /grant ${Env:USERNAME}:F >$null
+check
+
+pass

--- a/src/test/log_pool/TEST25.PS1
+++ b/src/test/log_pool/TEST25.PS1
@@ -1,0 +1,70 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST25 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST25"
+$Env:UNITTEST_NUM = "25"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST25 existing file, file size >= min required size
+#        (no write permissions)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 20 0600
+# deny write
+& icacls $DIR\testfile /deny ${Env:USERNAME}:W >$null
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+# restore full permissions
+& icacls $DIR\testfile /grant ${Env:USERNAME}:F >$null
+check
+
+pass

--- a/src/test/log_pool/TEST26.PS1
+++ b/src/test/log_pool/TEST26.PS1
@@ -1,0 +1,65 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST26 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST26"
+$Env:UNITTEST_NUM = "26"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST26 existing file, file size >= min required size
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 20 0600
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST27.PS1
+++ b/src/test/log_pool/TEST27.PS1
@@ -1,0 +1,66 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST27 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST27"
+$Env:UNITTEST_NUM = "27"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST27 existing file, file size >= min required size
+#
+create_poolset $DIR\testset 20M:$DIR\testfile1:x 20M:$DIR\testfile2:x
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testset 0 0600
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testset
+
+check
+
+pass

--- a/src/test/log_pool/TEST28.PS1
+++ b/src/test/log_pool/TEST28.PS1
@@ -1,0 +1,83 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST28 -- unit test for pmemlog_open
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST28"
+$Env:UNITTEST_NUM = "28"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST28 existing file, file size >= min required size
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile1 20 0600
+
+cp $DIR\testfile1 $DIR\testfile2
+
+&$PMEMSPOIL $DIR/testfile1 pool_hdr.uuid=1111111111111111 `
+        pool_hdr.next_part_uuid=1111111111111111 `
+        pool_hdr.prev_part_uuid=1111111111111111 `
+        pool_hdr.next_repl_uuid=2222222222222222 `
+        pool_hdr.prev_repl_uuid=2222222222222222 `
+        "pool_hdr.checksum_gen()"
+
+&$PMEMSPOIL $DIR/testfile2 pool_hdr.uuid=2222222222222222 `
+        pool_hdr.next_part_uuid=2222222222222222 `
+        pool_hdr.prev_part_uuid=2222222222222222 `
+        pool_hdr.next_repl_uuid=1111111111111111 `
+        pool_hdr.prev_repl_uuid=1111111111111111 `
+        "pool_hdr.checksum_gen()"
+
+create_poolset $DIR\testset 20M:$DIR\testfile1 R 20M:$DIR\testfile2
+
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX o $DIR\testset
+
+check
+
+pass

--- a/src/test/log_pool/TEST3
+++ b/src/test/log_pool/TEST3
@@ -45,12 +45,12 @@ setup
 umask 0
 
 create_holey_file 20M $DIR/testfile
-chmod 0640 $DIR/testfile
+chmod 0600 $DIR/testfile
 
 #
 # TEST3 existing file, file length >= min required size, poolsize > 0
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 20 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 20 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST3.PS1
+++ b/src/test/log_pool/TEST3.PS1
@@ -1,0 +1,67 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST3 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST3"
+$Env:UNITTEST_NUM = "3"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 20 $DIR\testfile
+
+#
+# TEST3 existing file, file length >= min required size, poolsize > 0
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 20 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST4
+++ b/src/test/log_pool/TEST4
@@ -44,12 +44,12 @@ setup
 umask 0
 
 touch $DIR/testfile
-chmod 0640 $DIR/testfile
+chmod 0600 $DIR/testfile
 
 #
 # TEST4 existing file, file length < min required size, poolsize == 0
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST4.PS1
+++ b/src/test/log_pool/TEST4.PS1
@@ -1,0 +1,67 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST4 -- unit test for pmemlog_createte
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST4"
+$Env:UNITTEST_NUM = "4"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+touch $DIR\testfile
+
+#
+# TEST4 existing file, file length < min required size, poolsize == 0
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST5
+++ b/src/test/log_pool/TEST5
@@ -47,7 +47,7 @@ umask 0
 # TEST5 non-existing file, poolsize > 0
 #       (path is invalid, directory does not exist)
 #
-expect_normal_exit ./log_pool$EXESUFFIX c /NULL/testfile 20 0640
+expect_normal_exit ./log_pool$EXESUFFIX c /NULL/testfile 20 0600
 
 check_no_files $DIR/testfile
 

--- a/src/test/log_pool/TEST5.PS1
+++ b/src/test/log_pool/TEST5.PS1
@@ -1,0 +1,66 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST5 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST5"
+$Env:UNITTEST_NUM = "5"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST5 non-existing file, poolsize > 0
+#       (path is invalid, directory does not exist)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c /NULL/testfile 20 0600
+
+check_no_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST6
+++ b/src/test/log_pool/TEST6
@@ -51,7 +51,7 @@ chmod 0640 $DIR/testfile
 # TEST6 existing file, file length >= min required size, poolsize == 0
 #       (file contains garbage)
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST6.PS1
+++ b/src/test/log_pool/TEST6.PS1
@@ -1,0 +1,68 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST6 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST6"
+$Env:UNITTEST_NUM = "6"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_nonzeroed_file 2M 0K $DIR\testfile
+
+#
+# TEST6 existing file, file length >= min required size, poolsize == 0
+#       (file contains garbage)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST7
+++ b/src/test/log_pool/TEST7
@@ -45,13 +45,13 @@ setup
 umask 0
 
 create_nonzeroed_file 2M 8K $DIR/testfile
-chmod 0640 $DIR/testfile
+chmod 0600 $DIR/testfile
 
 #
 # TEST7 existing file, file length >= min required size, poolsize == 0
 #       (file contains garbage, except for header)
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST7.PS1
+++ b/src/test/log_pool/TEST7.PS1
@@ -1,0 +1,68 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST7 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST7"
+$Env:UNITTEST_NUM = "7"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_nonzeroed_file 2 8 $DIR\testfile
+
+#
+# TEST7 existing file, file length >= min required size, poolsize == 0
+#       (file contains garbage, except for header)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST8
+++ b/src/test/log_pool/TEST8
@@ -46,7 +46,7 @@ umask 0
 #
 # TEST8 non-existing file, poolsize < min required size
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 1 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 1 0600
 
 check_no_files $DIR/testfile
 

--- a/src/test/log_pool/TEST8.PS1
+++ b/src/test/log_pool/TEST8.PS1
@@ -1,0 +1,65 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST8 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST8"
+$Env:UNITTEST_NUM = "8"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+#
+# TEST8 non-existing file, poolsize < min required size
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 1 0600
+
+check_no_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/TEST9
+++ b/src/test/log_pool/TEST9
@@ -53,7 +53,7 @@ chmod 0240 $DIR/testfile
 # TEST9 existing file, file length >= min required size, poolsize == 0,
 #       (no read permissions)
 #
-expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0640
+expect_normal_exit ./log_pool$EXESUFFIX c $DIR/testfile 0 0600
 
 check_files $DIR/testfile
 

--- a/src/test/log_pool/TEST9.PS1
+++ b/src/test/log_pool/TEST9.PS1
@@ -1,0 +1,74 @@
+﻿#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/log_pool/TEST9 -- unit test for pmemlog_create
+#
+# parameter handling
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "log_pool\TEST9"
+$Env:UNITTEST_NUM = "9"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type "any"
+
+setup
+
+create_holey_file 20 $DIR\testfile
+
+# deny write (make write only)
+& icacls $DIR\testfile /deny ${Env:USERNAME}:R >$null
+
+#
+# TEST9 existing file, file length >= min required size, poolsize == 0,
+#       (no read permissions)
+#
+expect_normal_exit $Env:EXE_DIR\log_pool$EXESUFFIX c $DIR\testfile 0 0600
+
+# restore full permissions
+& icacls $DIR\testfile /grant ${Env:USERNAME}:F >$null
+
+check_files $DIR\testfile
+
+check
+
+pass

--- a/src/test/log_pool/out0.log.match
+++ b/src/test/log_pool/out0.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST0: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 20 0640
-$(nW)/testfile: file size 20971520 usable space 20963328 mode 0640
-log_pool/TEST0: Done
+log_pool$(nW)TEST0: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 20 0600
+$(nW)testfile: file size 20971520 usable space 20963328 mode 0600
+log_pool$(nW)TEST0: Done

--- a/src/test/log_pool/out1.log.match
+++ b/src/test/log_pool/out1.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST1: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: file size 41943040 usable space 41934848 mode 0640
-log_pool/TEST1: Done
+log_pool$(nW)TEST1: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: file size 41943040 usable space 41934848 mode 0600
+log_pool$(nW)TEST1: Done

--- a/src/test/log_pool/out10.log.match
+++ b/src/test/log_pool/out10.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST10: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: pmemlog_create: Permission denied
-log_pool/TEST10: Done
+log_pool$(nW)TEST10: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: pmemlog_create: Permission denied
+log_pool$(nW)TEST10: Done

--- a/src/test/log_pool/out11.log.match
+++ b/src/test/log_pool/out11.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST11: START: log_pool
- ./log_pool$(nW) c $(nW)/testset 0 0640
-$(nW)/testset: file size $(N) usable space 41930752 mode 0666
-log_pool/TEST11: Done
+log_pool$(nW)TEST11: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testset 0 0600
+$(nW)testset: file size $(N) usable space 41930752 mode 0666
+log_pool$(nW)TEST11: Done

--- a/src/test/log_pool/out11w.log.match
+++ b/src/test/log_pool/out11w.log.match
@@ -1,0 +1,4 @@
+log_pool$(nW)TEST11w: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testset 0 0600
+$(nW)testset: file size $(N) usable space 41869312 mode 0600
+log_pool$(nW)TEST11w: Done

--- a/src/test/log_pool/out12.log.match
+++ b/src/test/log_pool/out12.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST12: START: log_pool
- ./log_pool$(nW) c $(nW)/testset 0 0640
-$(nW)/testset: pmemlog_create: Operation not supported
-log_pool/TEST12: Done
+log_pool$(nW)TEST12: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testset 0 0600
+$(nW)testset: pmemlog_create: Operation not supported
+log_pool$(nW)TEST12: Done

--- a/src/test/log_pool/out2.log.match
+++ b/src/test/log_pool/out2.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST2: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: pmemlog_create: No such file or directory
-log_pool/TEST2: Done
+log_pool$(nW)TEST2: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: pmemlog_create: No such file or directory
+log_pool$(nW)TEST2: Done

--- a/src/test/log_pool/out20.log.match
+++ b/src/test/log_pool/out20.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST20: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: No such file or directory
-log_pool/TEST20: Done
+log_pool$(nW)TEST20: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: No such file or directory
+log_pool$(nW)TEST20: Done

--- a/src/test/log_pool/out21.log.match
+++ b/src/test/log_pool/out21.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST21: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Invalid argument
-log_pool/TEST21: Done
+log_pool$(nW)TEST21: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Invalid argument
+log_pool$(nW)TEST21: Done

--- a/src/test/log_pool/out22.log.match
+++ b/src/test/log_pool/out22.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST22: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Invalid argument
-log_pool/TEST22: Done
+log_pool$(nW)TEST22: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Invalid argument
+log_pool$(nW)TEST22: Done

--- a/src/test/log_pool/out23.log.match
+++ b/src/test/log_pool/out23.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST23: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Invalid argument
-log_pool/TEST23: Done
+log_pool$(nW)TEST23: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Invalid argument
+log_pool$(nW)TEST23: Done

--- a/src/test/log_pool/out24.log.match
+++ b/src/test/log_pool/out24.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST24: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Permission denied
-log_pool/TEST24: Done
+log_pool$(nW)TEST24: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Permission denied
+log_pool$(nW)TEST24: Done

--- a/src/test/log_pool/out25.log.match
+++ b/src/test/log_pool/out25.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST25: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Permission denied
-log_pool/TEST25: Done
+log_pool$(nW)TEST25: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Permission denied
+log_pool$(nW)TEST25: Done

--- a/src/test/log_pool/out26.log.match
+++ b/src/test/log_pool/out26.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST26: START: log_pool
- ./log_pool$(nW) o $(nW)/testfile
-$(nW)/testfile: pmemlog_open: Success
-log_pool/TEST26: Done
+log_pool$(nW)TEST26: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testfile
+$(nW)testfile: pmemlog_open: Success
+log_pool$(nW)TEST26: Done

--- a/src/test/log_pool/out27.log.match
+++ b/src/test/log_pool/out27.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST27: START: log_pool
- ./log_pool$(nW) o $(nW)/testset
-$(nW)/testset: pmemlog_open: Success
-log_pool/TEST27: Done
+log_pool$(nW)TEST27: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testset
+$(nW)testset: pmemlog_open: Success
+log_pool$(nW)TEST27: Done

--- a/src/test/log_pool/out28.log.match
+++ b/src/test/log_pool/out28.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST28: START: log_pool
- ./log_pool$(nW) o $(nW)/testset
-$(nW)/testset: pmemlog_open: Operation not supported
-log_pool/TEST28: Done
+log_pool$(nW)TEST28: START: log_pool
+ $(nW)log_pool$(nW) o $(nW)testset
+$(nW)testset: pmemlog_open: Operation not supported
+log_pool$(nW)TEST28: Done

--- a/src/test/log_pool/out3.log.match
+++ b/src/test/log_pool/out3.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST3: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 20 0640
-$(nW)/testfile: pmemlog_create: File exists
-log_pool/TEST3: Done
+log_pool$(nW)TEST3: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 20 0600
+$(nW)testfile: pmemlog_create: File exists
+log_pool$(nW)TEST3: Done

--- a/src/test/log_pool/out4.log.match
+++ b/src/test/log_pool/out4.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST4: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: pmemlog_create: Invalid argument
-log_pool/TEST4: Done
+log_pool$(nW)TEST4: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: pmemlog_create: Invalid argument
+log_pool$(nW)TEST4: Done

--- a/src/test/log_pool/out5.log.match
+++ b/src/test/log_pool/out5.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST5: START: log_pool
- ./log_pool$(nW) c /NULL/testfile 20 0640
-/NULL/testfile: pmemlog_create: No such file or directory
-log_pool/TEST5: Done
+log_pool$(nW)TEST5: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)NULL$(nW)testfile 20 0600
+$(nW)NULL$(nW)testfile: pmemlog_create: No such file or directory
+log_pool$(nW)TEST5: Done

--- a/src/test/log_pool/out6.log.match
+++ b/src/test/log_pool/out6.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST6: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: pmemlog_create: File exists
-log_pool/TEST6: Done
+log_pool$(nW)TEST6: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: pmemlog_create: File exists
+log_pool$(nW)TEST6: Done

--- a/src/test/log_pool/out7.log.match
+++ b/src/test/log_pool/out7.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST7: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: file size 2097152 usable space 2088960 mode 0640
-log_pool/TEST7: Done
+log_pool$(nW)TEST7: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: file size 2097152 usable space 2088960 mode 0600
+log_pool$(nW)TEST7: Done

--- a/src/test/log_pool/out8.log.match
+++ b/src/test/log_pool/out8.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST8: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 1 0640
-$(nW)/testfile: pmemlog_create: Invalid argument
-log_pool/TEST8: Done
+log_pool$(nW)TEST8: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 1 0600
+$(nW)testfile: pmemlog_create: Invalid argument
+log_pool$(nW)TEST8: Done

--- a/src/test/log_pool/out9.log.match
+++ b/src/test/log_pool/out9.log.match
@@ -1,4 +1,4 @@
-log_pool/TEST9: START: log_pool
- ./log_pool$(nW) c $(nW)/testfile 0 0640
-$(nW)/testfile: pmemlog_create: Permission denied
-log_pool/TEST9: Done
+log_pool$(nW)TEST9: START: log_pool
+ $(nW)log_pool$(nW) c $(nW)testfile 0 0600
+$(nW)testfile: pmemlog_create: Permission denied
+log_pool$(nW)TEST9: Done

--- a/src/test/obj_locks/obj_locks.vcxproj.filters
+++ b/src/test/obj_locks/obj_locks.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/test/out_err/out_err.c
+++ b/src/test/out_err/out_err.c
@@ -48,6 +48,8 @@
 int
 main(int argc, char *argv[])
 {
+	char buff[UT_MAX_ERR_MSG];
+
 	START(argc, argv, "out_err");
 
 	/* Execute test */
@@ -67,13 +69,15 @@ main(int argc, char *argv[])
 	UT_OUT("%s", out_get_errormsg());
 
 	errno = EBADF;
+	ut_strerror(errno, buff, UT_MAX_ERR_MSG);
 	out_err(__FILE__, 100, __func__,
-		"ERR1: %s:%d", strerror(errno), 1234);
+		"ERR1: %s:%d", buff, 1234);
 	UT_OUT("%s", out_get_errormsg());
 
 	errno = EBADF;
+	ut_strerror(errno, buff, UT_MAX_ERR_MSG);
 	out_err(NULL, 0, NULL,
-		"ERR2: %s:%d", strerror(errno), 1234);
+		"ERR2: %s:%d", buff, 1234);
 	UT_OUT("%s", out_get_errormsg());
 
 	/* Cleanup */

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -116,15 +116,18 @@ extern "C" {
 #include <libpmempool.h>
 #include <libvmem.h>
 
+#define UT_MAX_ERR_MSG 128
+/* XXX - fix this temp hack dup'ing util_strerror when we get mock for win */
+void ut_strerror(int errnum, char *buff, size_t bufflen);
 /* XXX - eliminate duplicated definitions in unittest.h and util.h */
 #ifndef _WIN32
 typedef struct stat ut_util_stat_t;
-#define ut_util_fstat	fstat
-#define ut_util_stat	stat
-#define ut_util_lseek	lseek
+#define ut_util_fstat fstat
+#define ut_util_stat stat
+#define ut_util_lseek lseek
 #else
 typedef struct _stat64 ut_util_stat_t;
-#define ut_util_fstat	_fstat64
+#define ut_util_fstat _fstat64
 static inline int ut_util_stat(const char *path,
 	ut_util_stat_t *st_bufp) {
 	int retVal = _stat64(path, st_bufp);
@@ -132,7 +135,7 @@ static inline int ut_util_stat(const char *path,
 	st_bufp->st_mode &= 0600;
 	return retVal;
 }
-#define ut_util_lseek	_lseeki64
+#define ut_util_lseek _lseeki64
 #endif
 
 /*

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -32,6 +32,10 @@
 
 . "..\testconfig.ps1"
 
+function touch {
+    Out-File -InputObject $null -Encoding ascii -FilePath $args[0]
+}
+
 function epoch {
     return [int64](([datetime]::UtcNow)-(get-date "1/1/1970")).TotalMilliseconds
 }

--- a/src/test/util_is_absolute/util_is_absolute.vcxproj
+++ b/src/test/util_is_absolute/util_is_absolute.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">

--- a/src/test/util_is_absolute/util_is_absolute.vcxproj.filters
+++ b/src/test/util_is_absolute/util_is_absolute.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/src/test/vmmalloc_memalign/vmmalloc_memalign.c
+++ b/src/test/vmmalloc_memalign/vmmalloc_memalign.c
@@ -62,9 +62,11 @@ posix_memalign_wrap(size_t alignment, size_t size)
 	int err = posix_memalign(&ptr, alignment, size);
 	/* ignore OOM */
 	if (err) {
+		char buff[UT_MAX_ERR_MSG];
 		ptr = NULL;
+		ut_strerror(err, buff, UT_MAX_ERR_MSG);
 		if (err != ENOMEM)
-			UT_OUT("posix_memalign: %s", strerror(err));
+			UT_OUT("posix_memalign: %s", buff);
 	}
 	return ptr;
 }

--- a/src/windows/liblinux/liblinux.vcxproj
+++ b/src/windows/liblinux/liblinux.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\common\util_windows.c" />
     <ClCompile Include="..\win_file.c" />
     <ClCompile Include="..\win_signal.c" />
   </ItemGroup>

--- a/src/windows/liblinux/liblinux.vcxproj.filters
+++ b/src/windows/liblinux/liblinux.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
Add windows tests for log_pool and because windows doesn't support
all C errors, added a new abstraction util_strerror() that is a pass
through on Linux but on windows will map error strings unknown to
Windows based on the incoming code. The unit test equivalent is
called ut_strerror() and implemented so that the UT framework need
not rely on libutil.

This includes new util_linux.c and util_windows.c files to hold
utility like OS abstractions. The util_strerror() function is dup'd
in the unit test code until we implement mock functions for win.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1043)
<!-- Reviewable:end -->
