### PR TITLE
obj: restore part of pmemcheck vs multi-threaded app fix

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -665,7 +665,8 @@ tx_post_commit_alloc(PMEMobjpool *pop, struct tx_undo_runtime *tx_rt)
 {
 	LOG(3, NULL);
 
-	tx_clear_undo_log(pop, tx_rt->ctx[UNDO_ALLOC], 0);
+	tx_clear_undo_log(pop, tx_rt->ctx[UNDO_ALLOC],
+			TX_CLR_FLAG_VG_TX_REMOVE);
 }
 
 /*

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -110,6 +110,7 @@ OBJ_TESTS = \
 	obj_tx_invalid\
 	obj_tx_locks\
 	obj_tx_locks_abort\
+	obj_tx_mt\
 	obj_tx_realloc\
 	obj_tx_strdup\
 	obj_constructor

--- a/src/test/obj_tx_mt/.gitignore
+++ b/src/test/obj_tx_mt/.gitignore
@@ -1,0 +1,1 @@
+obj_tx_mt

--- a/src/test/obj_tx_mt/Makefile
+++ b/src/test/obj_tx_mt/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_mt/Makefile -- build obj_tx_mt unit test
+#
+TARGET = obj_tx_mt
+OBJS = obj_tx_mt.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_tx_mt/TEST0
+++ b/src/test/obj_tx_mt/TEST0
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_mt/TEST0 -- multi-threaded test for pmemobj_tx*
+#
+export UNITTEST_NAME=obj_tx_mt/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type any
+
+setup
+
+expect_normal_exit ./obj_tx_mt$EXESUFFIX $DIR/testfile1
+
+pass

--- a/src/test/obj_tx_mt/TEST1
+++ b/src/test/obj_tx_mt/TEST1
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_tx_mt/TEST1 -- multi-threaded test for pmemobj_tx*
+#
+export UNITTEST_NAME=obj_tx_mt/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type any
+configure_valgrind pmemcheck force-enable
+
+setup
+
+expect_normal_exit ./obj_tx_mt$EXESUFFIX $DIR/testfile1
+
+pass

--- a/src/test/obj_tx_mt/obj_tx_mt.c
+++ b/src/test/obj_tx_mt/obj_tx_mt.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_tx_mt.c -- multi-threaded test for pmemobj_tx_*
+ *
+ * It checks that objects are removed from transactions before on abort/commit
+ * phase.
+ */
+#include <pthread.h>
+#include "unittest.h"
+
+#define LOOPS 100
+
+static PMEMobjpool *pop;
+static PMEMoid tab;
+static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+
+static void *
+tx_alloc_free(void *arg)
+{
+	volatile int locked;
+	for (int i = 0; i < LOOPS; ++i) {
+		locked = 0;
+		TX_BEGIN(pop) {
+			pthread_mutex_lock(&mtx);
+			locked = 1;
+			tab = pmemobj_tx_alloc(128, 1);
+		} TX_ONCOMMIT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_ONABORT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_END
+
+		locked = 0;
+		TX_BEGIN(pop) {
+			pthread_mutex_lock(&mtx);
+			locked = 1;
+			pmemobj_tx_free(tab);
+			tab = OID_NULL;
+		} TX_ONCOMMIT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_ONABORT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_END
+	}
+	return NULL;
+}
+
+static void *
+tx_snap(void *arg)
+{
+	volatile int locked;
+	for (int i = 0; i < LOOPS; ++i) {
+		locked = 0;
+		TX_BEGIN(pop) {
+			pthread_mutex_lock(&mtx);
+			locked = 1;
+			if (!OID_IS_NULL(tab))
+				pmemobj_tx_add_range(tab, 0, 8);
+		} TX_ONCOMMIT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_ONABORT {
+			if (locked)
+				pthread_mutex_unlock(&mtx);
+		} TX_END
+		locked = 0;
+	}
+
+	return NULL;
+}
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_tx_mt");
+
+	if (argc != 2)
+		UT_FATAL("usage: %s [file]", argv[0]);
+
+	if ((pop = pmemobj_create(argv[1], "mt", PMEMOBJ_MIN_POOL,
+			S_IWUSR | S_IRUSR)) == NULL)
+		UT_FATAL("!pmemobj_create");
+
+	int i = 0;
+	long ncpus = sysconf(_SC_NPROCESSORS_ONLN);
+	pthread_t *threads = MALLOC(2 * ncpus * sizeof(threads[0]));
+
+	for (int j = 0; j < ncpus; ++j) {
+		PTHREAD_CREATE(&threads[i++], NULL, tx_alloc_free, NULL);
+		PTHREAD_CREATE(&threads[i++], NULL, tx_snap, NULL);
+	}
+
+	while (i > 0)
+		PTHREAD_JOIN(threads[--i], NULL);
+
+	pmemobj_close(pop);
+
+	FREE(threads);
+
+	DONE(NULL);
+}


### PR DESCRIPTION
Originally fixed by 862263318de2c3d6befbb18e602f511c9b30d9ae (merged Feb 2016). 
Broken since ced2ce3cb2187143dc95a50930701d2f06b4ee52 (merged March 2016).

Now with tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1045)
<!-- Reviewable:end -->
