### PR TITLE
win: fix flock() implementation

### DIFF
--- a/src/test/blk_pool_lock/blk_pool_lock.c
+++ b/src/test/blk_pool_lock/blk_pool_lock.c
@@ -95,12 +95,7 @@ test_reopen(const char *path)
 	if (blk2)
 		UT_FATAL("pmemblk_open should not succeed");
 
-#ifndef _WIN32
-	int expected_err = EWOULDBLOCK;
-#else
-	int expected_err = EACCES;
-#endif
-	if (errno != expected_err)
+	if (errno != EWOULDBLOCK)
 		UT_FATAL("!pmemblk_open failed but for unexpected reason");
 
 	pmemblk_close(blk1);
@@ -200,7 +195,7 @@ main(int argc, char *argv[])
 			UT_FATAL("pmemblk_open after CreateProcess should "
 				"not succeed");
 
-		if (errno != EACCES)
+		if (errno != EWOULDBLOCK)
 			UT_FATAL("!pmemblk_open after CreateProcess failed "
 				"but for unexpected reason");
 	}

--- a/src/test/log_pool_lock/log_pool_lock.c
+++ b/src/test/log_pool_lock/log_pool_lock.c
@@ -95,12 +95,7 @@ test_reopen(const char *path)
 	if (log2)
 		UT_FATAL("pmemlog_open should not succeed");
 
-#ifndef _WIN32
-	int expected_err = EWOULDBLOCK;
-#else
-	int expected_err = EACCES;
-#endif
-	if (errno != expected_err)
+	if (errno != EWOULDBLOCK)
 		UT_FATAL("!pmemlog_open failed but for unexpected reason");
 
 	pmemlog_close(log1);
@@ -201,7 +196,7 @@ main(int argc, char *argv[])
 			UT_FATAL("pmemlog_open after CreateProcess should "
 				"not succeed");
 
-		if (errno != EACCES)
+		if (errno != EWOULDBLOCK)
 			UT_FATAL("!pmemlog_open after CreateProcess failed "
 				"but for unexpected reason");
 	}

--- a/src/windows/win_file.c
+++ b/src/windows/win_file.c
@@ -124,5 +124,10 @@ flock(int fd, int operation)
 	/* for our purpose it's enough to lock the first page of the file */
 	long len = (filelen > systemInfo.dwPageSize) ?
 				systemInfo.dwPageSize : (long)filelen;
-	return _locking(fd, flags, len);
+
+	int res = _locking(fd, flags, len);
+	if (res != 0 && errno == EACCES)
+		errno = EWOULDBLOCK; /* for consistency with flock() */
+
+	return res;
 }


### PR DESCRIPTION
Let it set the same error code (errno) as on Linux.
If the file is already locked, errno should be set to EWOULDBLOCK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1056)
<!-- Reviewable:end -->
