### PR TITLE
docker: add clang-format to docker script

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -43,7 +43,7 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common libunwind8-dev autoconf \
 	devscripts pkg-config ssh git gcc clang debhelper sudo whois \
 	libc6-dbg libncurses5-dev libuv1-dev libfuse-dev libglib2.0-dev \
-	libtool pandoc doxygen graphviz
+	libtool pandoc doxygen graphviz clang-format-3.8
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh


### PR DESCRIPTION
Adding it only to ubuntu, because the fedora used does not have the desired version of clang-format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1058)
<!-- Reviewable:end -->
