### PR TITLE
Use movnt by default

### DIFF
--- a/src/libpmem/cpu.c
+++ b/src/libpmem/cpu.c
@@ -146,18 +146,6 @@ is_cpu_genuine_intel(void)
 }
 
 /*
- * is_cpu_sse2_present -- checks if SSE2 extensions are supported
- */
-int
-is_cpu_sse2_present(void)
-{
-	int ret = is_cpu_feature_present(0x1, EDX_IDX, bit_SSE2);
-	LOG(4, "SSE2 %ssupported", ret == 0 ? "not " : "");
-
-	return ret;
-}
-
-/*
  * is_cpu_clflush_present -- checks if CLFLUSH instruction is supported
  */
 int

--- a/src/libpmem/cpu.h
+++ b/src/libpmem/cpu.h
@@ -38,7 +38,6 @@
  */
 
 int is_cpu_genuine_intel(void);
-int is_cpu_sse2_present(void);
 int is_cpu_clflush_present(void);
 int is_cpu_clflushopt_present(void);
 int is_cpu_clwb_present(void);

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -114,7 +114,9 @@
  *	Checks for overlapped ranges to determine whether to copy from
  *	the beginning of the range or from the end.  If MOVNT instructions
  *	are available, uses the memory copy flow described above, otherwise
- *	calls the libc memmove() followed by pmem_flush().
+ *	calls the libc memmove() followed by pmem_flush(). Since no conditional
+ *	compilation and/or architecture specific CFLAGS are in use at the
+ *	moment, SSE2 ( thus movnt ) is just assumed to be available.
  *
  * pmem_memcpy_nodrain()
  *
@@ -1090,6 +1092,30 @@ pmem_memset_persist(void *pmemdest, int c, size_t len)
 }
 
 /*
+ * pmem_log_cpuinfo -- log the results of cpu dispatching decisions,
+ * and verify them
+ */
+static void
+pmem_log_cpuinfo(void)
+{
+	if (Func_flush == flush_clwb)
+		LOG(3, "using clwb");
+	else if (Func_flush == flush_clflushopt)
+		LOG(3, "using clflushopt");
+	else if (Func_flush == flush_clflush)
+		LOG(3, "using clflush");
+	else
+		FATAL("invalid flush function address");
+
+	if (Func_memmove_nodrain == memmove_nodrain_movnt)
+		LOG(3, "using movnt");
+	else if (Func_memmove_nodrain == memmove_nodrain_normal)
+		LOG(3, "not using movnt");
+	else
+		FATAL("invalid memove_nodrain function address");
+}
+
+/*
  * pmem_get_cpuinfo -- configure libpmem based on CPUID
  */
 static void
@@ -1123,34 +1149,6 @@ pmem_get_cpuinfo(void)
 			Func_predrain_fence = predrain_fence_sfence;
 		}
 	}
-
-	if (Func_flush == flush_clwb)
-		LOG(3, "using clwb");
-	else if (Func_flush == flush_clflushopt)
-		LOG(3, "using clflushopt");
-	else if (Func_flush == flush_clflush)
-		LOG(3, "using clflush");
-	else
-		ASSERT(0);
-
-	if (is_cpu_sse2_present()) {
-		LOG(3, "movnt supported");
-
-		char *e = getenv("PMEM_NO_MOVNT");
-		if (e && strcmp(e, "1") == 0)
-			LOG(3, "PMEM_NO_MOVNT forced no movnt");
-		else {
-			Func_memmove_nodrain = memmove_nodrain_movnt;
-			Func_memset_nodrain = memset_nodrain_movnt;
-		}
-	}
-
-	if (Func_memmove_nodrain == memmove_nodrain_movnt)
-		LOG(3, "using movnt");
-	else if (Func_memmove_nodrain == memmove_nodrain_normal)
-		LOG(3, "not using movnt");
-	else
-		ASSERT(0);
 }
 
 /*
@@ -1180,6 +1178,16 @@ pmem_init(void)
 			Movnt_threshold = (size_t)val;
 		}
 	}
+
+	ptr = getenv("PMEM_NO_MOVNT");
+	if (ptr && strcmp(ptr, "1") == 0)
+		LOG(3, "PMEM_NO_MOVNT forced no movnt");
+	else {
+		Func_memmove_nodrain = memmove_nodrain_movnt;
+		Func_memset_nodrain = memset_nodrain_movnt;
+	}
+
+	pmem_log_cpuinfo();
 }
 
 

--- a/src/test/util_cpuid/util_cpuid.c
+++ b/src/test/util_cpuid/util_cpuid.c
@@ -58,19 +58,6 @@ static char Buf[32];
 static void
 check_cpu_features(void)
 {
-	if (is_cpu_sse2_present()) {
-		UT_OUT("SSE2 supported");
-		char Buf[32];
-		__m128i xmm0 = _mm_set1_epi8(0x55);
-		/* align to 16B boundary */
-		void *dest = (void *)(((uintptr_t)Buf + 16 - 1)
-						& ~((uintptr_t)16 - 1));
-		UT_OUT("%p %p", Buf, dest);
-		_mm_stream_si128(dest, xmm0);
-	} else {
-		UT_OUT("SSE2 not supported");
-	}
-
 	if (is_cpu_clflush_present()) {
 		UT_OUT("CLFLUSH supported");
 		_mm_clflush(Buf);


### PR DESCRIPTION
The CPU dispatching code checking for SSE2 is wrong,
and very misleading.
The code is either compiled using SSE2 instructions - in which
case, such instructions might end up in other places in the binary -
or compiled without such instructions, in which case the
_mm_stream_si128 identifier is not present, thus doesn't compile.
The right way to do such CPU feature based dispatching is to
place appropriate code segments in different translation units,
compiled with appropriate flags e.g. -msse2
and to conditionally call such code from translation units compiled
with some least common denominator platform in mind.

The code not using movnt is left in the code, to available via
an environment variable, as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1061)
<!-- Reviewable:end -->
