### PR TITLE
obj: allow for memblocks /w size index equal to 64

### DIFF
--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -227,8 +227,14 @@ run_prep_operation_hdr(struct memory_block *m, struct palloc_heap *heap,
 	 * the block offset are tied 1:1 to the bitmap this operation is
 	 * relatively simple.
 	 */
-	uint64_t bmask = ((1ULL << m->size_idx) - 1ULL) <<
-			(m->block_off % BITS_PER_VALUE);
+	uint64_t bmask;
+	if (m->size_idx == BITS_PER_VALUE) {
+		ASSERTeq(m->block_off % BITS_PER_VALUE, 0);
+		bmask = UINT64_MAX;
+	} else {
+		bmask = ((1ULL << m->size_idx) - 1ULL) <<
+				(m->block_off % BITS_PER_VALUE);
+	}
 
 	/*
 	 * The run bitmap is composed of several 8 byte values, so a proper


### PR DESCRIPTION
The size index of a run memory allocation is currently capped by
RUN_UNIT_MAX compile-time constant, which happens to be 8. This caused
a potential issue to creep into the algorithm. The issue could trigger
undefined behavior to present itself when the above mentioned constant
is changed to its edge value of 64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1062)
<!-- Reviewable:end -->
