### PR TITLE
test: fix the input size hack in create_holey_file

### DIFF
--- a/src/test/blk_nblock/TEST0w.PS1
+++ b/src/test/blk_nblock/TEST0w.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -69,13 +70,13 @@ setup
 # sparse Windows still won't let you overcommit
 #
 
-create_holey_file 2 $DIR\testfile1
-create_holey_file 2048 $DIR\testfile2.512
-create_holey_file 2048 $DIR\testfile2.520
-create_holey_file 2048 $DIR\testfile2.528
-create_holey_file 2048 $DIR\testfile2.4096
-create_holey_file 2048 $DIR\testfile2.4160
-create_holey_file 2048 $DIR\testfile2.4224
+create_holey_file 2M $DIR\testfile1
+create_holey_file 2048M $DIR\testfile2.512
+create_holey_file 2048M $DIR\testfile2.520
+create_holey_file 2048M $DIR\testfile2.528
+create_holey_file 2048M $DIR\testfile2.4096
+create_holey_file 2048M $DIR\testfile2.4160
+create_holey_file 2048M $DIR\testfile2.4224
 
 #
 # Larger file coverage is provided on the linux side
@@ -84,7 +85,7 @@ create_holey_file 2048 $DIR\testfile2.4224
 #
 
 # MINIMUM POOL SIZE = 16MB + 64KB
-$MIN_POOL_SIZE = "16+64"
+$MIN_POOL_SIZE = ((16*1024*1024 + 64*1024).ToString() + "b")
 create_holey_file $MIN_POOL_SIZE $DIR\testfile7.512
 create_holey_file $MIN_POOL_SIZE $DIR\testfile7.520
 create_holey_file $MIN_POOL_SIZE $DIR\testfile7.528

--- a/src/test/blk_nblock/TEST1.PS1
+++ b/src/test/blk_nblock/TEST1.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,25 +63,25 @@ setup
 # These are holey files, so they actually don't take up
 # any significant space.
 #
-create_holey_file 1024 $DIR\testfile1.2096896
-create_holey_file 1024 $DIR\testfile1.2096897
-create_holey_file 2048 $DIR\testfile2.0
-create_holey_file 2048 $DIR\testfile2.1
-create_holey_file 2048 $DIR\testfile2.17
-create_holey_file 2048 $DIR\testfile2.511
-create_holey_file 2048 $DIR\testfile2.1048576
-create_holey_file 2048 $DIR\testfile2.2097152
-create_holey_file 2048 $DIR\testfile2.4194304
-create_holey_file 2048 $DIR\testfile2.8388608
-create_holey_file 2048 $DIR\testfile2.16777216
-create_holey_file 2048 $DIR\testfile2.33554432
-create_holey_file 2048 $DIR\testfile2.67108864
-create_holey_file 2048 $DIR\testfile2.134217728
-create_holey_file 2048 $DIR\testfile2.268435456
-create_holey_file 2048 $DIR\testfile2.536870912
-create_holey_file 2048 $DIR\testfile2.1073741824
-create_holey_file 2048 $DIR\testfile2.2147483648
-create_holey_file 2048 $DIR\testfile2.-1
+create_holey_file 1024M $DIR\testfile1.2096896
+create_holey_file 1024M $DIR\testfile1.2096897
+create_holey_file 2048M $DIR\testfile2.0
+create_holey_file 2048M $DIR\testfile2.1
+create_holey_file 2048M $DIR\testfile2.17
+create_holey_file 2048M $DIR\testfile2.511
+create_holey_file 2048M $DIR\testfile2.1048576
+create_holey_file 2048M $DIR\testfile2.2097152
+create_holey_file 2048M $DIR\testfile2.4194304
+create_holey_file 2048M $DIR\testfile2.8388608
+create_holey_file 2048M $DIR\testfile2.16777216
+create_holey_file 2048M $DIR\testfile2.33554432
+create_holey_file 2048M $DIR\testfile2.67108864
+create_holey_file 2048M $DIR\testfile2.134217728
+create_holey_file 2048M $DIR\testfile2.268435456
+create_holey_file 2048M $DIR\testfile2.536870912
+create_holey_file 2048M $DIR\testfile2.1073741824
+create_holey_file 2048M $DIR\testfile2.2147483648
+create_holey_file 2048M $DIR\testfile2.-1
 
 expect_normal_exit $Env:EXE_DIR\blk_nblock$Env:EXESUFFIX `
     2096896:$DIR\testfile1.2096896 `

--- a/src/test/blk_non_zero/TEST0
+++ b/src/test/blk_non_zero/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +48,7 @@ require_fs_type pmem non-pmem
 setup
 
 # single arena and minimum pmemblk pool file case
-create_nonzeroed_file 17 8 $DIR/testfile1
+create_nonzeroed_file 17M 8K $DIR/testfile1
 
 #
 # All reads to an unwritten block pool should return zeros.

--- a/src/test/blk_non_zero/TEST0.PS1
+++ b/src/test/blk_non_zero/TEST0.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,7 +55,7 @@ require_fs_type non-pmem pmem
 setup
 
 # single arena and minimum pmemblk pool file case
-create_nonzeroed_file 17 8 $DIR\testfile1
+create_nonzeroed_file 17M 8K $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 $DIR\testfile1 c 0 `
 r:0 r:1 r:34217 r:34218 z:0 z:1 r:0 e:3 r:4

--- a/src/test/blk_non_zero/TEST1
+++ b/src/test/blk_non_zero/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ require_test_type long
 setup
 
 # single arena write case
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR/testfile1
+create_nonzeroed_file 1G 824K $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2

--- a/src/test/blk_non_zero/TEST1.PS1
+++ b/src/test/blk_non_zero/TEST1.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ require_test_type long
 setup
 
 # single arena write case
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR\testfile1
+create_nonzeroed_file 1G 824M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 $DIR\testfile1 c 0 `
 w:0 r:1 r:0 w:1 r:0 r:1 r:2

--- a/src/test/blk_non_zero/TEST2
+++ b/src/test/blk_non_zero/TEST2
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ require_test_type long
 setup
 
 # write re-use test case
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR/testfile1
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0

--- a/src/test/blk_non_zero/TEST2.PS1
+++ b/src/test/blk_non_zero/TEST2.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ require_test_type long
 setup
 
 # write re-use test case
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR\testfile1
+create_nonzeroed_file 1G 824M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 $DIR\testfile1 c 0 `
 w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0

--- a/src/test/blk_non_zero/TEST3
+++ b/src/test/blk_non_zero/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR/testfile1
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 	w:100 w:200 w:300 w:400\

--- a/src/test/blk_non_zero/TEST3.PS1
+++ b/src/test/blk_non_zero/TEST3.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR\testfile1
+create_nonzeroed_file 1G 824M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 $DIR\testfile1 c 0 `
 w:100 w:200 w:300 w:400 `

--- a/src/test/blk_non_zero/TEST4
+++ b/src/test/blk_non_zero/TEST4
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 1024 $((824*1024)) $DIR/testfile1
+create_nonzeroed_file 1G 824M $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		e:1 r:1\

--- a/src/test/blk_non_zero/TEST4.PS1
+++ b/src/test/blk_non_zero/TEST4.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 1024 $((824 * 1024)) $DIR\testfile1
+create_nonzeroed_file 1G 824M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 $DIR\testfile1 c 0 `
 e:1 r:1 `

--- a/src/test/blk_non_zero/TEST5.PS1
+++ b/src/test/blk_non_zero/TEST5.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,7 +55,7 @@ require_fs_type pmem non-pmem
 setup
 
 # single arena and minimum pmemblk pool file case
-$MIN_POOL_SIZE = $((16*1024*1024 + 64*1024))
+$MIN_POOL_SIZE = ((16*1024*1024 + 64*1024).ToString() + "b")
 
 #
 # All reads to an unwritten block pool should return zeros.

--- a/src/test/blk_non_zero/TEST9
+++ b/src/test/blk_non_zero/TEST9
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +49,7 @@ configure_valgrind pmemcheck force-enable
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 128 8 $DIR/testfile1
+create_nonzeroed_file 128M 8K $DIR/testfile1
 
 expect_normal_exit ./blk_non_zero$EXESUFFIX 512 $DIR/testfile1 c 0\
 		e:1 r:1\

--- a/src/test/blk_non_zero/TEST9.PS1
+++ b/src/test/blk_non_zero/TEST9.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_nonzeroed_file 128 8 $DIR\testfile1
+create_nonzeroed_file 128M 8K $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_non_zero$EXESUFFIX 512 `
 $DIR\testfile1 c 0 e:1 r:1 e:2 w:2 r:2 z:3 e:3 r:3 e:4 z:4 r:4 `

--- a/src/test/blk_non_zero/out5.log.match
+++ b/src/test/blk_non_zero/out5.log.match
@@ -1,5 +1,5 @@
 blk_non_zero$(nW)TEST5: START: blk_non_zero
- $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N) r:0 r:1 r:32312 r:32313 z:0 z:1 r:0
+ $(nW)blk_non_zero$(nW) 512 $(nW)testfile1 c $(N)$(S) r:0 r:1 r:32312 r:32313 z:0 z:1 r:0
 512 block size 512 usable blocks 32313
 is zeroed:	1
 read      lba 0: {0}

--- a/src/test/blk_pool/TEST1
+++ b/src/test/blk_pool/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=1
 setup
 umask 0
 
-create_holey_file 40 $DIR/testfile
+create_holey_file 40M $DIR/testfile
 chmod 0600 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST1.PS1
+++ b/src/test/blk_pool/TEST1.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 40 $DIR\testfile
+create_holey_file 40M $DIR\testfile
 
 #
 # TEST1 existing file, file length >= min required size, poolsize == 0

--- a/src/test/blk_pool/TEST10
+++ b/src/test/blk_pool/TEST10
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0240 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST10.PS1
+++ b/src/test/blk_pool/TEST10.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 20 $DIR\testfile
+create_holey_file 20M $DIR\testfile
 # XXX Doesn't change outcome whether we make it WO or not,
 # same goes for linux test
 & icacls $DIR\testfile /grant ${Env:USERNAME}:W >$null

--- a/src/test/blk_pool/TEST11
+++ b/src/test/blk_pool/TEST11
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0440 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST11.PS1
+++ b/src/test/blk_pool/TEST11.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 20 $DIR\testfile
+create_holey_file 20M $DIR\testfile
 # XXX Doesn't change outcome whether we make it RO or not,
 # same goes for linux test
 & icacls $DIR\testfile /grant ${Env:USERNAME}:R >$null

--- a/src/test/blk_pool/TEST21
+++ b/src/test/blk_pool/TEST21
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=21
 setup
 umask 0
 
-create_holey_file 1 $DIR/testfile
+create_holey_file 1M $DIR/testfile
 
 #
 # TEST21 existing file, file size < min required size, bsize == 0

--- a/src/test/blk_pool/TEST21.PS1
+++ b/src/test/blk_pool/TEST21.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 1 $DIR\testfile
+create_holey_file 1M $DIR\testfile
 
 #
 # TEST21 existing file, file size < min required size, bsize == 0

--- a/src/test/blk_pool/TEST22.PS1
+++ b/src/test/blk_pool/TEST22.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,7 +62,7 @@ expect_normal_exit $Env:EXE_DIR\blk_pool$Env:EXESUFFIX `
     c $DIR/testfile 512 20 0640
 
 rm $DIR\testfile
-create_holey_file 1 $DIR\testfile
+create_holey_file 1M $DIR\testfile
 
 expect_normal_exit $Env:EXE_DIR\blk_pool$Env:EXESUFFIX `
     o $DIR/testfile 0

--- a/src/test/blk_pool/TEST23
+++ b/src/test/blk_pool/TEST23
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=23
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 
 #
 # TEST23 existing file, file size >= min required size, bsize == 0

--- a/src/test/blk_pool/TEST23.PS1
+++ b/src/test/blk_pool/TEST23.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 20 $DIR\testfile
+create_holey_file 20M $DIR\testfile
 
 #
 # TEST23 existing file, file size >= min required size, bsize == 0

--- a/src/test/blk_pool/TEST3
+++ b/src/test/blk_pool/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=3
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST3.PS1
+++ b/src/test/blk_pool/TEST3.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_holey_file 20 $DIR\testfile
+create_holey_file 20M $DIR\testfile
 
 #
 # TEST3 existing file, file length >= min required size, poolsize > 0

--- a/src/test/blk_pool/TEST7
+++ b/src/test/blk_pool/TEST7
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-create_nonzeroed_file 17 0 $DIR/testfile
+create_nonzeroed_file 17M 0K $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST7.PS1
+++ b/src/test/blk_pool/TEST7.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_nonzeroed_file 17 0 $DIR\testfile
+create_nonzeroed_file 17M 0K $DIR\testfile
 
 #
 # TEST7 existing file, file length >= min required size, poolsize == 0

--- a/src/test/blk_pool/TEST8
+++ b/src/test/blk_pool/TEST8
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=8
 setup
 umask 0
 
-create_nonzeroed_file 17 8 $DIR/testfile
+create_nonzeroed_file 17M 8K $DIR/testfile
 chmod 0600 $DIR/testfile
 
 #

--- a/src/test/blk_pool/TEST8.PS1
+++ b/src/test/blk_pool/TEST8.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ $Env:NON_PMEM_IS_PMEM = $true
 
 setup
 
-create_nonzeroed_file 17 8 $DIR\testfile
+create_nonzeroed_file 17M 8K $DIR\testfile
 
 #
 # TEST8 existing file, file length >= min required size, poolsize == 0

--- a/src/test/blk_rw/TEST0.PS1
+++ b/src/test/blk_rw/TEST0.PS1
@@ -57,7 +57,7 @@ setup
 
 # single arena and minimum pmemblk pool file case
 # MIN_POOL_SIZE = 16MB + 64KB
-$MIN_POOL_SIZE="16+64"
+$MIN_POOL_SIZE = ((16*1024*1024 + 64*1024).ToString() + "b")
 create_holey_file $MIN_POOL_SIZE $DIR\testfile1
 #
 # All reads to an unwritten block pool should return zeros.

--- a/src/test/blk_rw/TEST1.PS1
+++ b/src/test/blk_rw/TEST1.PS1
@@ -61,7 +61,7 @@ require_unlimited_vm
 setup
 
 # multi-arena case
-create_holey_file (1026*1024) $DIR\testfile1
+create_holey_file 1026G $DIR\testfile1
 #
 # All reads to an unwritten block pool should return zeros.
 # Block 2134997326 is out of range and should return EINVAL.

--- a/src/test/blk_rw/TEST2.PS1
+++ b/src/test/blk_rw/TEST2.PS1
@@ -62,7 +62,7 @@ require_unlimited_vm
 setup
 
 # multi-arena case
-create_holey_file (1026*1024) $DIR\testfile1
+create_holey_file 1026G $DIR\testfile1
 #
 # All reads to an unwritten block pool should return zeros.
 # Block 268696551 is out of range and should return EINVAL.

--- a/src/test/blk_rw/TEST3.PS1
+++ b/src/test/blk_rw/TEST3.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 setup
 
 # single arena write case
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 c `
 	w:0 r:1 r:0 w:1 r:0 r:1 r:2
 

--- a/src/test/blk_rw/TEST4.PS1
+++ b/src/test/blk_rw/TEST4.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 setup
 
 # write re-use test case
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 c `
 	w:0 w:1 w:2 w:3 w:4 r:4 r:3 r:2 r:1 r:0
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 o `

--- a/src/test/blk_rw/TEST5.PS1
+++ b/src/test/blk_rw/TEST5.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 setup
 
 # mix writes with set_zero and set_error and check results
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 c `
 	w:100 w:200 w:300 w:400 `
 	r:100 r:200 r:300 r:400 `

--- a/src/test/blk_rw/TEST6.PS1
+++ b/src/test/blk_rw/TEST6.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 setup
 
 # mix writes with set_zero and set_error and check results
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 c `
 		e:1 r:1 `
 		e:2 w:2 r:2 `

--- a/src/test/blk_rw/TEST7.PS1
+++ b/src/test/blk_rw/TEST7.PS1
@@ -61,7 +61,7 @@ require_test_type long
 setup
 
 # mix writes with set_zero and set_error and check results
-create_holey_file 128 $DIR\testfile1
+create_holey_file 128M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\blk_rw$EXESUFFIX 512 $DIR\testfile1 c `
 		e:1 r:1 `

--- a/src/test/blk_rw_mt/TEST0.PS1
+++ b/src/test/blk_rw_mt/TEST0.PS1
@@ -53,7 +53,7 @@ require_fs_type pmem non-pmem
 
 setup
 
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 # 5 threads, each doing 80 random I/Os
 expect_normal_exit $Env:EXE_DIR\blk_rw_mt$EXESUFFIX 4096 $DIR\testfile1 123 5 80
 

--- a/src/test/blk_rw_mt/TEST1.PS1
+++ b/src/test/blk_rw_mt/TEST1.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 
 setup
 
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 # 100 threads, each doing 100 random I/Os
 expect_normal_exit $Env:EXE_DIR\blk_rw_mt$EXESUFFIX 4096 $DIR\testfile1 456 100 100
 

--- a/src/test/blk_rw_mt/TEST2.PS1
+++ b/src/test/blk_rw_mt/TEST2.PS1
@@ -56,7 +56,7 @@ require_fs_type pmem non-pmem
 
 setup
 
-create_holey_file 1024 $DIR\testfile1
+create_holey_file 1G $DIR\testfile1
 # 300 threads, each doing 100000 random I/Os
 expect_normal_exit $Env:EXE_DIR\blk_rw_mt$EXESUFFIX 4096 $DIR/testfile1 789 300 100000
 

--- a/src/test/ex_libpmem/TEST0
+++ b/src/test/ex_libpmem/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ setup
 
 EX_PATH=../../examples/libpmem
 
-create_nonzeroed_file 2 0 $DIR/testfile1
+create_nonzeroed_file 2M 0K $DIR/testfile1
 
 expect_normal_exit $EX_PATH/simple_copy $DIR/testfile1 $DIR/testfile2 \
 	> out$UNITTEST_NUM.log 2>&1

--- a/src/test/ex_libpmem/TEST1
+++ b/src/test/ex_libpmem/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ setup
 
 EX_PATH=../../examples/libpmem
 
-create_nonzeroed_file 2 0 $DIR/testfile1
+create_nonzeroed_file 2M 0K $DIR/testfile1
 
 expect_normal_exit $EX_PATH/full_copy $DIR/testfile1 $DIR/testfile2 \
 	> out$UNITTEST_NUM.log 2>&1

--- a/src/test/ex_libpmemblk/TEST0
+++ b/src/test/ex_libpmemblk/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ setup
 
 EX_PATH=../../examples/libpmemblk/assetdb
 
-create_holey_file 32 $DIR/testfile1
+create_holey_file 32M $DIR/testfile1
 
 expect_normal_exit $EX_PATH/asset_load $DIR/testfile1 ./asset_list.txt > out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/asset_list $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1

--- a/src/test/ex_libpmemlog/TEST0
+++ b/src/test/ex_libpmemlog/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ setup
 
 EX_PATH=../../examples/libpmemlog/logfile
 
-create_holey_file 32 $DIR/testfile1
+create_holey_file 32M $DIR/testfile1
 
 expect_normal_exit $EX_PATH/addlog $DIR/testfile1 "Hello World! foo bar" > out$UNITTEST_NUM.log 2>&1
 expect_normal_exit $EX_PATH/printlog $DIR/testfile1 >> out$UNITTEST_NUM.log 2>&1

--- a/src/test/log_basic/TEST0
+++ b/src/test/log_basic/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +51,7 @@ export UNITTEST_NUM=0
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 n t w r
 

--- a/src/test/log_basic/TEST0.PS1
+++ b/src/test/log_basic/TEST0.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,7 +63,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 2 $DIR\testfile1
+create_holey_file 2M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\log_basic$EXESUFFIX $DIR\testfile1 n t w r
 

--- a/src/test/log_basic/TEST1
+++ b/src/test/log_basic/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,7 +53,7 @@ export UNITTEST_NUM=1
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 a n t w r t w
 

--- a/src/test/log_basic/TEST1.PS1
+++ b/src/test/log_basic/TEST1.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -64,7 +65,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 2 $DIR\testfile1
+create_holey_file 2M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\log_basic$EXESUFFIX $DIR\testfile1 a n t w r t w
 

--- a/src/test/log_basic/TEST2
+++ b/src/test/log_basic/TEST2
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,7 +53,7 @@ export UNITTEST_NUM=2
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 v n t w r t w
 

--- a/src/test/log_basic/TEST2.PS1
+++ b/src/test/log_basic/TEST2.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -64,7 +65,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 2 $DIR\testfile1
+create_holey_file 2M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\log_basic$EXESUFFIX $DIR\testfile1 v n t w r t w
 

--- a/src/test/log_basic/TEST3
+++ b/src/test/log_basic/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,7 +54,7 @@ export UNITTEST_NUM=3
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1 a n t w r t w v n t w r t w
 

--- a/src/test/log_basic/TEST3.PS1
+++ b/src/test/log_basic/TEST3.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +66,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 2 $DIR\testfile1
+create_holey_file 2M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\log_basic$EXESUFFIX $DIR\testfile1 `
 a n t w r t w v n t w r t w

--- a/src/test/log_basic/TEST4
+++ b/src/test/log_basic/TEST4
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +56,7 @@ export UNITTEST_NUM=4
 configure_valgrind pmemcheck force-enable
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 
 expect_normal_exit ./log_basic$EXESUFFIX $DIR/testfile1\
 	 a n t w r t w v n t w r t w

--- a/src/test/log_basic/TEST4.PS1
+++ b/src/test/log_basic/TEST4.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +66,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 2 $DIR\testfile1
+create_holey_file 2M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\log_basic$EXESUFFIX $DIR\testfile1 `
 a n t w r t w v n t w r t w

--- a/src/test/log_pool/TEST1
+++ b/src/test/log_pool/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=1
 setup
 umask 0
 
-create_holey_file 40 $DIR/testfile
+create_holey_file 40M $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST10
+++ b/src/test/log_pool/TEST10
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0440 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST21
+++ b/src/test/log_pool/TEST21
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=21
 setup
 umask 0
 
-create_holey_file 1 $DIR/testfile
+create_holey_file 1M $DIR/testfile
 
 #
 # TEST21 existing file, file size < min required size

--- a/src/test/log_pool/TEST23
+++ b/src/test/log_pool/TEST23
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=23
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 
 #
 # TEST23 existing file, file size >= min required size

--- a/src/test/log_pool/TEST3
+++ b/src/test/log_pool/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=3
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST6
+++ b/src/test/log_pool/TEST6
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=6
 setup
 umask 0
 
-create_nonzeroed_file 2 0 $DIR/testfile
+create_nonzeroed_file 2M 0K $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST7
+++ b/src/test/log_pool/TEST7
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-create_nonzeroed_file 2 8 $DIR/testfile
+create_nonzeroed_file 2M 8K $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/log_pool/TEST9
+++ b/src/test/log_pool/TEST9
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0240 $DIR/testfile
 
 #

--- a/src/test/obj_basic_integration/TEST0
+++ b/src/test/obj_basic_integration/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +43,7 @@ configure_valgrind memcheck force-disable
 
 setup
 
-create_holey_file 8 $DIR/testfile1
+create_holey_file 8M $DIR/testfile1
 
 expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_basic_integration/TEST1
+++ b/src/test/obj_basic_integration/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,7 +41,7 @@ export UNITTEST_NUM=1
 configure_valgrind pmemcheck force-enable
 setup
 
-create_holey_file 8 $DIR/testfile1
+create_holey_file 8M $DIR/testfile1
 
 expect_normal_exit\
 	./obj_basic_integration$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_basic_integration/TEST5
+++ b/src/test/obj_basic_integration/TEST5
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +43,7 @@ export PMEMOBJ_VG_CHECK_UNDEF=1
 
 setup
 
-create_holey_file 8 $DIR/testfile1
+create_holey_file 8M $DIR/testfile1
 
 expect_normal_exit\
     ./obj_basic_integration$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_constructor/TEST0
+++ b/src/test/obj_constructor/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ configure_valgrind memcheck force-disable
 
 setup
 
-create_holey_file 8 $DIR/testfile1
+create_holey_file 8M $DIR/testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 export PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_constructor/TEST0.PS1
+++ b/src/test/obj_constructor/TEST0.PS1
@@ -1,5 +1,6 @@
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,7 +55,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 8 $DIR\testfile1
+create_holey_file 8M $DIR\testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 $Env:PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_constructor/TEST1
+++ b/src/test/obj_constructor/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +48,7 @@ require_build_type debug
 
 setup
 
-create_holey_file 8 $DIR/testfile1
+create_holey_file 8M $DIR/testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 export PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_heap_interrupt/TEST0
+++ b/src/test/obj_heap_interrupt/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_heap_interrupt$EXESUFFIX $DIR/testfile c 0
 expect_normal_exit ./obj_heap_interrupt$EXESUFFIX $DIR/testfile o 0

--- a/src/test/obj_heap_state/TEST0
+++ b/src/test/obj_heap_state/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,7 +42,7 @@ setup
 
 export PMEM_IS_PMEM_FORCE=1
 
-create_holey_file 16 $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
 	./obj_heap_state$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_many_size_allocs/TEST0
+++ b/src/test/obj_many_size_allocs/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ setup
 
 export PMEM_IS_PMEM_FORCE=1
 
-create_holey_file 16 $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
 	./obj_many_size_allocs$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_many_size_allocs/TEST3
+++ b/src/test/obj_many_size_allocs/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ setup
 
 export PMEM_IS_PMEM_FORCE=1
 
-create_holey_file 16 $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
 	./obj_many_size_allocs$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_out_of_memory/TEST0
+++ b/src/test/obj_out_of_memory/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,8 +43,8 @@ setup
 export PMEM_IS_PMEM_FORCE=1
 export PMEMOBJ_LOG_LEVEL=1
 
-create_holey_file 8 $DIR/testfile1
-create_holey_file 16 $DIR/testfile2
+create_holey_file 8M $DIR/testfile1
+create_holey_file 16M $DIR/testfile2
 create_poolset $DIR/testset1 8M:$DIR/testfile11:x
 create_poolset $DIR/testset2 8M:$DIR/testfile21:x 8M:$DIR/testfile22:x
 

--- a/src/test/obj_pool/TEST1
+++ b/src/test/obj_pool/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=1
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST10
+++ b/src/test/obj_pool/TEST10
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0240 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST11
+++ b/src/test/obj_pool/TEST11
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ require_no_superuser
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0440 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST21
+++ b/src/test/obj_pool/TEST21
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=21
 setup
 umask 0
 
-create_holey_file 1 $DIR/testfile
+create_holey_file 1M $DIR/testfile
 
 #
 # TEST21 existing file, file size < min required size, layout in NULL

--- a/src/test/obj_pool/TEST23
+++ b/src/test/obj_pool/TEST23
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=23
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 
 #
 # TEST23 existing file, file size >= min required size, layout is NULL

--- a/src/test/obj_pool/TEST3
+++ b/src/test/obj_pool/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=3
 setup
 umask 0
 
-create_holey_file 20 $DIR/testfile
+create_holey_file 20M $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST7
+++ b/src/test/obj_pool/TEST7
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=7
 setup
 umask 0
 
-create_nonzeroed_file 8 0 $DIR/testfile
+create_nonzeroed_file 8M 0K $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_pool/TEST8
+++ b/src/test/obj_pool/TEST8
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=8
 setup
 umask 0
 
-create_nonzeroed_file 8 8 $DIR/testfile
+create_nonzeroed_file 8M 8K $DIR/testfile
 chmod 0640 $DIR/testfile
 
 #

--- a/src/test/obj_recovery/TEST0
+++ b/src/test/obj_recovery/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c s
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o s

--- a/src/test/obj_recovery/TEST1
+++ b/src/test/obj_recovery/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c n
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o n

--- a/src/test/obj_recovery/TEST2
+++ b/src/test/obj_recovery/TEST2
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +46,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c f
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o f

--- a/src/test/obj_recovery/TEST6
+++ b/src/test/obj_recovery/TEST6
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +51,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c s
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o s

--- a/src/test/obj_recovery/TEST7
+++ b/src/test/obj_recovery/TEST7
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +51,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c n
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o n

--- a/src/test/obj_recovery/TEST8
+++ b/src/test/obj_recovery/TEST8
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +51,7 @@ setup
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-create_holey_file 16 $DIR/testfile
+create_holey_file 16M $DIR/testfile
 
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y c f
 expect_normal_exit ./obj_recovery$EXESUFFIX $DIR/testfile y o f

--- a/src/test/obj_rpmem_basic_integration/TEST1
+++ b/src/test/obj_rpmem_basic_integration/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -80,8 +81,8 @@ copy_files_to_node 0 $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 $DIR/$TEST_SET_LOCAL
 
 # create remote holey pool files
-create_holey_file_on_node 1 8 ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
-create_holey_file_on_node 0 9 ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
+create_holey_file_on_node 1 8M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
+create_holey_file_on_node 0 9M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
 
 # execute test
 expect_normal_exit run_on_node 1 ./$EXE$EXESUFFIX $TEST_SET_LOCAL

--- a/src/test/obj_rpmem_constructor/TEST0
+++ b/src/test/obj_rpmem_constructor/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -87,8 +88,8 @@ copy_files_to_node 0 $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 $DIR/$TEST_SET_LOCAL
 
 # create remote holey pool files
-create_holey_file_on_node 1 8 ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
-create_holey_file_on_node 0 9 ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
+create_holey_file_on_node 1 8M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
+create_holey_file_on_node 0 9M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
 
 # execute test
 expect_normal_exit run_on_node 1 ./$EXE$EXESUFFIX $TEST_SET_LOCAL

--- a/src/test/obj_rpmem_heap_interrupt/TEST0
+++ b/src/test/obj_rpmem_heap_interrupt/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -83,8 +84,8 @@ copy_files_to_node 0 $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 $DIR/$TEST_SET_LOCAL
 
 # create remote holey pool files
-create_holey_file_on_node 1 8 ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
-create_holey_file_on_node 0 9 ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
+create_holey_file_on_node 1 8M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
+create_holey_file_on_node 0 9M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
 
 # execute test
 expect_normal_exit run_on_node 1 ./$EXE$EXESUFFIX $TEST_SET_LOCAL c 0

--- a/src/test/obj_rpmem_heap_state/TEST0
+++ b/src/test/obj_rpmem_heap_state/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -77,8 +78,8 @@ copy_files_to_node 0 $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 $DIR/$TEST_SET_LOCAL
 
 # create remote holey pool files
-create_holey_file_on_node 1 8 ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
-create_holey_file_on_node 0 9 ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
+create_holey_file_on_node 1 8M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
+create_holey_file_on_node 0 9M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
 
 PMEM_IS_PMEM_FORCE=1
 export_vars_node 1 PMEM_IS_PMEM_FORCE

--- a/src/test/obj_tx_alloc/TEST0
+++ b/src/test/obj_tx_alloc/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +43,7 @@ export UNITTEST_NUM=0
 
 setup
 
-create_nonzeroed_file 8 8 $DIR/testfile1
+create_nonzeroed_file 8M 8K $DIR/testfile1
 
 expect_normal_exit ./obj_tx_alloc$EXESUFFIX $DIR/testfile1
 

--- a/src/test/obj_tx_alloc/TEST1
+++ b/src/test/obj_tx_alloc/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,7 +47,7 @@ configure_valgrind pmemcheck force-enable
 export VALGRIND_OPTS="--mult-stores=no"
 setup
 
-create_nonzeroed_file 8 8 $DIR/testfile1
+create_nonzeroed_file 8M 8K $DIR/testfile1
 
 expect_normal_exit ./obj_tx_alloc$EXESUFFIX $DIR/testfile1
 

--- a/src/test/obj_tx_realloc/TEST0
+++ b/src/test/obj_tx_realloc/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +43,7 @@ export UNITTEST_NUM=0
 
 setup
 
-create_nonzeroed_file 8 8 $DIR/testfile1
+create_nonzeroed_file 8M 8K $DIR/testfile1
 
 expect_normal_exit ./obj_tx_realloc$EXESUFFIX $DIR/testfile1
 

--- a/src/test/obj_tx_realloc/TEST1
+++ b/src/test/obj_tx_realloc/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2015-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +44,7 @@ export UNITTEST_NUM=1
 configure_valgrind pmemcheck force-enable
 setup
 
-create_nonzeroed_file 8 8 $DIR/testfile1
+create_nonzeroed_file 8M 8K $DIR/testfile1
 
 expect_normal_exit ./obj_tx_realloc$EXESUFFIX $DIR/testfile1
 

--- a/src/test/pmem_is_pmem/TEST0
+++ b/src/test/pmem_is_pmem/TEST0
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type non-pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/pmem_is_pmem/TEST1
+++ b/src/test/pmem_is_pmem/TEST1
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1
 
 check

--- a/src/test/pmem_is_pmem/TEST2
+++ b/src/test/pmem_is_pmem/TEST2
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type non-pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 export PMEM_IS_PMEM_FORCE=1
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1
 

--- a/src/test/pmem_is_pmem/TEST3
+++ b/src/test/pmem_is_pmem/TEST3
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 export PMEM_IS_PMEM_FORCE=0
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1
 

--- a/src/test/pmem_is_pmem/TEST4
+++ b/src/test/pmem_is_pmem/TEST4
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type non-pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 export PMEM_IS_PMEM_FORCE=0
 # program would overwrite PMEM_IS_PMEM_FORCE
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1 1

--- a/src/test/pmem_is_pmem/TEST5
+++ b/src/test/pmem_is_pmem/TEST5
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +45,7 @@ require_fs_type pmem
 
 setup
 
-create_holey_file 2 $DIR/testfile1
+create_holey_file 2M $DIR/testfile1
 export PMEM_IS_PMEM_FORCE=1
 # program would overwrite PMEM_IS_PMEM_FORCE
 expect_normal_exit ./pmem_is_pmem$EXESUFFIX $DIR/testfile1 0

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1,5 +1,6 @@
 #
 # Copyright 2014-2016, Intel Corporation
+# Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -267,51 +268,107 @@ function get_executables() {
 }
 
 #
-# create_file -- create zeroed out files of a given length in megs
+# convert_to_bytes -- converts the string with K, M, G or T suffixes
+# to bytes
+#
+# example:
+#   "1G" --> "1073741824"
+#   "2T" --> "2199023255552"
+#   "3k" --> "3072"
+#   "1K" --> "1024"
+#   "10" --> "10"
+#
+function convert_to_bytes() {
+	size="$(echo $1 | tr '[:upper:]' '[:lower:]')"
+	if [[ $size == *kib ]]
+	then size=$(($(echo $size | tr -d 'kib') * 1024))
+	elif [[ $size == *mib ]]
+	then size=$(($(echo $size | tr -d 'mib') * 1024 * 1024))
+	elif [[ $size == *gib ]]
+	then size=$(($(echo $size | tr -d 'gib') * 1024 * 1024 * 1024))
+	elif [[ $size == *tib ]]
+	then size=$(($(echo $size | tr -d 'tib') * 1024 * 1024 * 1024 * 1024))
+	elif [[ $size == *pib ]]
+	then size=$(($(echo $size | tr -d 'pib') * 1024 * 1024 * 1024 * 1024 * 1024))
+	elif [[ $size == *kb ]]
+	then size=$(($(echo $size | tr -d 'kb') * 1000))
+	elif [[ $size == *mb ]]
+	then size=$(($(echo $size | tr -d 'mb') * 1000 * 1000))
+	elif [[ $size == *gb ]]
+	then size=$(($(echo $size | tr -d 'gb') * 1000 * 1000 * 1000))
+	elif [[ $size == *tb ]]
+	then size=$(($(echo $size | tr -d 'tb') * 1000 * 1000 * 1000 * 1000))
+	elif [[ $size == *pb ]]
+	then size=$(($(echo $size | tr -d 'pb') * 1000 * 1000 * 1000 * 1000 * 1000))
+	elif [[ $size == *b ]]
+	then size=$(($(echo $size | tr -d 'b')))
+	elif [[ $size == *k ]]
+	then size=$(($(echo $size | tr -d 'k') * 1024))
+	elif [[ $size == *m ]]
+	then size=$(($(echo $size | tr -d 'm') * 1024 * 1024))
+	elif [[ $size == *g ]]
+	then size=$(($(echo $size | tr -d 'g') * 1024 * 1024 * 1024))
+	elif [[ $size == *t ]]
+	then size=$(($(echo $size | tr -d 't') * 1024 * 1024 * 1024 * 1024))
+	elif [[ $size == *p ]]
+	then size=$(($(echo $size | tr -d 'p') * 1024 * 1024 * 1024 * 1024 * 1024))
+	fi
+
+	echo "$size"
+}
+
+#
+# create_file -- create zeroed out files of a given length
 #
 # example, to create two files, each 1GB in size:
-#	create_file 1024 testfile1 testfile2
+#	create_file 1G testfile1 testfile2
 #
 function create_file() {
-	size=$1
+	size=$(convert_to_bytes $1)
 	shift
 	for file in $*
 	do
-		dd if=/dev/zero of=$file bs=1M count=$size >> prep$UNITTEST_NUM.log
+		dd if=/dev/zero of=$file bs=1M count=$size iflag=count_bytes >> prep$UNITTEST_NUM.log
 	done
 }
 
 #
-# create_nonzeroed_file -- create non-zeroed files of a given length in megs
+# create_nonzeroed_file -- create non-zeroed files of a given length
 #
 # A given first kilobytes of the file is zeroed out.
 #
 # example, to create two files, each 1GB in size, with first 4K zeroed
-#	create_nonzeroed_file 1024 4 testfile1 testfile2
+#	create_nonzeroed_file 1G 4K testfile1 testfile2
 #
 function create_nonzeroed_file() {
-	offset=$2
-	size=$(($1 * 1024 - $offset))
+	offset=$(convert_to_bytes $2)
+	size=$(($(convert_to_bytes $1) - $offset))
 	shift 2
 	for file in $*
 	do
-		truncate -s ${offset}K $file >> prep$UNITTEST_NUM.log
-		dd if=/dev/zero bs=1K count=${size} 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $file
+		truncate -s ${offset} $file >> prep$UNITTEST_NUM.log
+		dd if=/dev/zero bs=1K count=${size} iflag=count_bytes 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $file
 	done
 }
 
 #
-# create_holey_file -- create holey files of a given length in megs
+# create_holey_file -- create holey files of a given length
 #
-# example, to create two files, each 1GB in size:
-#	create_holey_file 1024 testfile1 testfile2
+# examples:
+#	create_holey_file 1024k testfile1 testfile2
+#	create_holey_file 2048M testfile1 testfile2
+#	create_holey_file 234 testfile1
+#	create_holey_file 2340b testfile1
 #
+# Input unit size is in bytes with optional suffixes like k, KB, M, etc.
+#
+
 function create_holey_file() {
-	size=$1
+	size=$(convert_to_bytes $1)
 	shift
 	for file in $*
 	do
-		truncate -s ${size}M $file >> prep$UNITTEST_NUM.log
+		truncate -s ${size} $file >> prep$UNITTEST_NUM.log
 	done
 }
 
@@ -400,6 +457,8 @@ function create_poolset() {
 		if [ ! $asize ]; then
 			asize=$fsize
 		fi
+
+		asize=$(convert_to_bytes $asize)
 
 		case "$cmd"
 		in
@@ -1573,22 +1632,24 @@ function kill_on_node() {
 }
 
 #
-# create_holey_file_on_node -- create holey files of a given length in megs
+# create_holey_file_on_node -- create holey files of a given length
 #   usage: create_holey_file_on_node <node> <size>
 #
 # example, to create two files, each 1GB in size on node 0:
-#	create_holey_file_on_node 0 1024 testfile1 testfile2
+#	create_holey_file_on_node 0 1G testfile1 testfile2
+#
+# Input unit size is in bytes with optional suffixes like k, KB, M, etc.
 #
 function create_holey_file_on_node() {
 
 	validate_node_number $1
 
 	local N=$1
-	size=$2
+	size=$(convert_to_bytes $2)
 	shift 2
 	for file in $*
 	do
-		run_on_node $N truncate -s ${size}M $file >> prep$UNITTEST_NUM.log
+		run_on_node $N truncate -s ${size} $file >> prep$UNITTEST_NUM.log
 	done
 }
 


### PR DESCRIPTION
Fix functions that take file sizes in MB and "MB+KB" format to accept
sizes with prefixes like k, M, G, KB, KiB, etc. which convert_to_bytes
understand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1063)
<!-- Reviewable:end -->
