### PR TITLE
ut: set locale earlier

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -30,6 +30,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# make sure we have a well defined locale for string operations here
+export LC_ALL="C"
+
 . ../testconfig.sh
 
 # defaults
@@ -1596,9 +1599,6 @@ function create_holey_file_on_node() {
 # setup -- print message that test setup is commencing
 #
 function setup() {
-	# make sure we have a well defined locale for string operations here
-	export LC_ALL="C"
-
 	# fs type "none" must be explicitly enabled
 	if [ "$FS" = "none" -a "$req_fs_type" != "1" ]; then
 		exit 0


### PR DESCRIPTION
"configure_valgrind" started to call "stat" utility, which is
affected by locale settings and "configure_valgrind" is called
before "setup", so we have to set locale earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1064)
<!-- Reviewable:end -->
