### PR TITLE
common: fix isblank usage in set.c

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -856,7 +856,8 @@ util_poolset_parse(struct pool_set **setp, const char *path, int fd)
 					POOLSET_REPLICA_SIG_LEN) == 0) {
 			if (line[POOLSET_REPLICA_SIG_LEN] != '\0') {
 				/* something more than 'REPLICA' */
-				if (!isblank(line[POOLSET_REPLICA_SIG_LEN])) {
+				char c = line[POOLSET_REPLICA_SIG_LEN];
+				if (!isblank((unsigned char)c)) {
 					result = PARSER_REPLICA;
 					continue;
 				}


### PR DESCRIPTION
According to ISO:
"the argument is an int, the value of which shall be representable
as an unsigned char or shall equal the value of the macro EOF."

Thus a negative char value supplied to isblank ( except EOF ) is undefined
behaviour. E.g. the implementation might use a lookup table, in which
case a negative index can result in a crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1068)
<!-- Reviewable:end -->
