### PR TITLE
benchmark: fix result time calculation

### DIFF
--- a/src/benchmarks/pmembench.c
+++ b/src/benchmarks/pmembench.c
@@ -644,9 +644,11 @@ pmembench_get_total_results(struct latency *stats, double *workers_times,
 	qsort(workers_times, nresults, sizeof(double), compare_doubles);
 	total->min = workers_times[0];
 	total->max = workers_times[nresults - 1];
-	total->med = nresults % 2 ? (workers_times[nresults / 2] +
-				workers_times[nresults / 2 + 1]) / 2:
-				workers_times[nresults / 2];
+	if (nresults % 2 == 0)
+		total->med = (workers_times[nresults / 2] +
+		    workers_times[nresults / 2 - 1]) / 2;
+	else
+		total->med = workers_times[nresults / 2];
 
 	for (i = 0; i < repeats; i++) {
 		d = stats[i].std_dev > latency->avg


### PR DESCRIPTION
In case of odd nresults use the middle element.
In case of even nresults use the two middle elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1071)
<!-- Reviewable:end -->
