### PR TITLE
win: fix warning in __sync_bool_compare_and_swap

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -103,6 +103,35 @@ util_clrbit(uint8_t *b, uint32_t i)
 #define util_flag_isclr(a, f) (((a) & (f)) == 0)
 
 /*
+ * util_compare_and_swap -- perform an atomic compare and swap
+ */
+#ifndef _MSC_VER
+#define util_bool_compare_and_swap32 __sync_bool_compare_and_swap
+#define util_bool_compare_and_swap64 __sync_bool_compare_and_swap
+#else
+static __inline int
+__sync_bool_compare_and_swap32(volatile LONG *ptr,
+		LONG oldval, LONG newval)
+{
+	LONG old = InterlockedCompareExchange(ptr, newval, oldval);
+	return (old == oldval);
+}
+
+static __inline int
+__sync_bool_compare_and_swap64(volatile LONG64 *ptr,
+		LONG64 oldval, LONG64 newval)
+{
+	LONG64 old = InterlockedCompareExchange64(ptr, newval, oldval);
+	return (old == oldval);
+}
+
+#define util_bool_compare_and_swap32(p, o, n)\
+	__sync_bool_compare_and_swap32((LONG *)(p), (LONG)(o), (LONG)(n))
+#define util_bool_compare_and_swap64(p, o, n)\
+	__sync_bool_compare_and_swap64((LONG64 *)(p), (LONG64)(o), (LONG64)(n))
+#endif
+
+/*
  * util_get_printable_ascii -- convert non-printable ascii to dot '.'
  */
 static inline char

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -180,6 +180,7 @@
 #include "pmem.h"
 #include "cpu.h"
 #include "out.h"
+#include "util.h"
 #include "mmap.h"
 #include "file.h"
 #include "valgrind_internal.h"
@@ -459,7 +460,7 @@ pmem_is_pmem_init(void)
 	static volatile unsigned init;
 
 	while (init != 2) {
-		if (!__sync_bool_compare_and_swap(&init, 0, 1))
+		if (!util_bool_compare_and_swap32(&init, 0, 1))
 			continue;
 
 		/*
@@ -484,8 +485,8 @@ pmem_is_pmem_init(void)
 			LOG(4, "PMEM_IS_PMEM_FORCE=%d", val);
 		}
 
-		if (!__sync_bool_compare_and_swap(&init, 1, 2))
-			FATAL("__sync_bool_compare_and_swap");
+		if (!util_bool_compare_and_swap32(&init, 1, 2))
+			FATAL("util_bool_compare_and_swap32");
 	}
 }
 

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -42,6 +42,7 @@
 
 #include "heap.h"
 #include "out.h"
+#include "util.h"
 #include "sys_util.h"
 #include "valgrind_internal.h"
 
@@ -71,7 +72,7 @@
 /*
  * Value used to mark a reserved spot in the bucket array.
  */
-#define BUCKET_RESERVED ((void *)0xFFFFFFFF)
+#define BUCKET_RESERVED ((void *)0xFFFFFFFFULL)
 
 /*
  * The last size that is handled by runs.
@@ -493,8 +494,8 @@ heap_find_first_free_bucket_slot(struct heap_rt *h)
 {
 	int n;
 	for (n = 0; n < MAX_BUCKETS; ++n)
-		if (__sync_bool_compare_and_swap(&h->buckets[n],
-			NULL, BUCKET_RESERVED))
+		if (util_bool_compare_and_swap64(&h->buckets[n],
+				NULL, BUCKET_RESERVED))
 			return (uint8_t)n;
 
 	return MAX_BUCKETS;

--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -46,6 +46,7 @@
 #include "cuckoo.h"
 #include "lane.h"
 #include "out.h"
+#include "util.h"
 #include "obj.h"
 #include "valgrind_internal.h"
 
@@ -347,7 +348,7 @@ get_lane(uint64_t *locks, uint64_t *index, uint64_t nlocks)
 	while (1) {
 		do {
 			*index %= nlocks;
-			if (likely(__sync_bool_compare_and_swap(
+			if (likely(util_bool_compare_and_swap64(
 					&locks[*index], 0, 1)))
 				return;
 
@@ -463,10 +464,10 @@ lane_release(PMEMobjpool *pop)
 	if (unlikely(lane->nest_count == 0)) {
 		FATAL("lane_release");
 	} else if (--(lane->nest_count) == 0) {
-		if (unlikely(!__sync_bool_compare_and_swap(
+		if (unlikely(!util_bool_compare_and_swap64(
 				&pop->lanes_desc.lane_locks[lane->lane_idx],
 				1, 0))) {
-			FATAL("__sync_bool_compare_and_swap");
+			FATAL("util_bool_compare_and_swap64");
 		}
 	}
 }

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -36,6 +36,7 @@
 
 #include "obj.h"
 #include "out.h"
+#include "util.h"
 #include "sync.h"
 #include "sys_util.h"
 #include "valgrind_internal.h"
@@ -81,7 +82,7 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 		if (tmp_runid == pop_runid - 1)
 			continue;
 
-		if (!__sync_bool_compare_and_swap(runid, tmp_runid,
+		if (!util_bool_compare_and_swap64(runid, tmp_runid,
 				pop_runid - 1))
 			continue;
 
@@ -91,7 +92,7 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 			return NULL;
 		}
 
-		if (__sync_bool_compare_and_swap(runid, pop_runid - 1,
+		if (util_bool_compare_and_swap64(runid, pop_runid - 1,
 				pop_runid) == 0) {
 			ERR("error setting lock runid");
 			return NULL;

--- a/src/windows/include/platform.h
+++ b/src/windows/include/platform.h
@@ -128,21 +128,6 @@ __sync_fetch_and_add(volatile uint32_t *a, uint32_t val)
 	return InterlockedExchangeAdd(a, val);
 }
 
-__inline uint64_t
-__sync_fetch_and_add64(volatile uint64_t *a, uint64_t val)
-{
-	return InterlockedExchangeAdd64((LONG64 *)a, (LONG64)val);
-}
-
-__inline long
-__sync_bool_compare_and_swap(volatile uint64_t *ptr,
-				uint64_t oldval, uint64_t newval)
-{
-	uint64_t old = InterlockedCompareExchange64((volatile LONG64 *)ptr,
-		(LONG64)newval, (LONG64)oldval);
-	return (old == oldval);
-}
-
 __inline void
 __sync_synchronize()
 {


### PR DESCRIPTION
Add wrapper macros for 32- and 64-bit variant of CAS intrinsics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1072)
<!-- Reviewable:end -->
