### PR TITLE
obj_basic_integration: Add VS project

### DIFF
--- a/src/NVML.sln
+++ b/src/NVML.sln
@@ -356,6 +356,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "blk_recovery", "test\blk_re
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_pool_lock", "test\obj_pool_lock\obj_pool_lock.vcxproj", "{63B8184D-85E0-4E6A-9729-558C567D1D1D}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obj_basic_integration", "test\obj_basic_integration\obj_basic_integration.vcxproj", "{58386481-30B7-40FC-96AF-0723A4A7B228}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -778,6 +780,14 @@ Global
 		{63B8184D-85E0-4E6A-9729-558C567D1D1D}.Static-Debug|x64.Build.0 = Static-Debug|x64
 		{63B8184D-85E0-4E6A-9729-558C567D1D1D}.Static-Release|x64.ActiveCfg = Static-Release|x64
 		{63B8184D-85E0-4E6A-9729-558C567D1D1D}.Static-Release|x64.Build.0 = Static-Release|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Debug|x64.ActiveCfg = Debug|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Debug|x64.Build.0 = Debug|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Release|x64.ActiveCfg = Release|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Release|x64.Build.0 = Release|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Static-Debug|x64.ActiveCfg = Static-Debug|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Static-Debug|x64.Build.0 = Static-Debug|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Static-Release|x64.ActiveCfg = Static-Release|x64
+		{58386481-30B7-40FC-96AF-0723A4A7B228}.Static-Release|x64.Build.0 = Static-Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -841,5 +851,6 @@ Global
 		{2DE6B085-3C19-49B1-894A-AD9376000E09} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 		{DB68AB21-510B-4BA1-9E6F-E5731D8647BC} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 		{63B8184D-85E0-4E6A-9729-558C567D1D1D} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
+		{58386481-30B7-40FC-96AF-0723A4A7B228} = {746BA101-5C93-42A5-AC7A-64DCEB186572}
 	EndGlobalSection
 EndGlobal

--- a/src/test/obj_basic_integration/TEST0.PS1
+++ b/src/test/obj_basic_integration/TEST0.PS1
@@ -1,0 +1,66 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_basic_integration/TEST0 -- unit test for
+# pmemobj APIs
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "obj_basic_integration\TEST0"
+$Env:UNITTEST_NUM = "0"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+# XXX: however we don't have valgrind in Windows yet
+#configure_valgrind memcheck force-disable
+
+require_fs_type any
+
+setup
+
+create_holey_file 8M $DIR\testfile1
+
+expect_normal_exit $Env:EXE_DIR\obj_basic_integration$Env:EXESUFFIX `
+    $DIR\testfile1 `
+
+# check will print the appropriate pass/fail message
+#check
+
+#pass

--- a/src/test/obj_basic_integration/TEST1.PS1
+++ b/src/test/obj_basic_integration/TEST1.PS1
@@ -1,0 +1,66 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_basic_integration/TEST1 -- unit test for
+# pmemobj APIs
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "obj_basic_integration\TEST1"
+$Env:UNITTEST_NUM = "1"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+# XXX: we don't have valgrind in Windows yet
+#configure_valgrind pmemcheck force-enable
+
+require_fs_type any
+
+setup
+
+create_holey_file 8M $DIR\testfile1
+
+expect_normal_exit $Env:EXE_DIR\obj_basic_integration$Env:EXESUFFIX `
+    $DIR\testfile1 `
+
+# check will print the appropriate pass/fail message
+#check
+
+#pass

--- a/src/test/obj_basic_integration/TEST2.PS1
+++ b/src/test/obj_basic_integration/TEST2.PS1
@@ -1,0 +1,64 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_basic_integration/TEST2 -- unit test for
+# pmemobj APIs
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "obj_basic_integration\TEST2"
+$Env:UNITTEST_NUM = "2"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type any
+
+setup
+
+create_poolset $DIR\testset1 8M:$DIR\testfile1:x 8M:$DIR\testfile2:x `
+    r 16M:$DIR\testfile3:x
+
+expect_normal_exit $Env:EXE_DIR\obj_basic_integration$Env:EXESUFFIX `
+    $DIR\testset1 `
+
+# check will print the appropriate pass/fail message
+#check
+
+#pass

--- a/src/test/obj_basic_integration/TEST3.PS1
+++ b/src/test/obj_basic_integration/TEST3.PS1
@@ -1,0 +1,67 @@
+#
+# Copyright 2015-2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# src/test/obj_basic_integration/TEST3 -- unit test for
+# pmemobj APIs
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "obj_basic_integration\TEST3"
+$Env:UNITTEST_NUM = "3"
+# XXX:  bash has a few calls to tools that we don't have on
+# windows (yet) that set PMEM_IS_PMEM and NON_PMEM_IS_PMEM based
+# on their output
+$Env:PMEM_IS_PMEM = $true
+$Env:NON_PMEM_IS_PMEM = $true
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_fs_type any
+
+setup
+
+create_poolset $DIR\testset1 8M:$DIR\testfile1:x r 8M:$DIR\testfile2:x
+
+expect_normal_exit $Env:EXE_DIR\obj_basic_integration$Env:EXESUFFIX `
+    $DIR\testset1 `
+
+# XXX: Not ready yet in unittest.ps1
+#compare_replicas "-soOaAb -l -Z -H -C" `
+#    $DIR\testfile1 $DIR\testfile2 > diff$UNITTEST_NUM.log
+
+# XXX: No diff log yet
+#check
+
+#pass

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -77,8 +77,8 @@ struct dummy_root {
 static int
 dummy_node_constructor(PMEMobjpool *pop, void *ptr, void *arg)
 {
-	struct dummy_node *n = ptr;
-	int *test_val = arg;
+	struct dummy_node *n = (struct dummy_node *)ptr;
+	int *test_val = (int *)arg;
 	n->value = *test_val;
 	pmemobj_persist(pop, &n->value, sizeof(n->value));
 
@@ -95,7 +95,7 @@ test_alloc_api(PMEMobjpool *pop)
 
 	UT_ASSERT_rt(OID_INSTANCEOF(node_zeroed.oid, struct dummy_node));
 
-	int *test_val = MALLOC(sizeof(*test_val));
+	int *test_val = (int *)MALLOC(sizeof(*test_val));
 	*test_val = TEST_VALUE;
 	POBJ_NEW(pop, &node_constructed, struct dummy_node_c,
 			dummy_node_constructor, test_val);
@@ -415,7 +415,7 @@ test_tx_api(PMEMobjpool *pop)
 	int *vstate = NULL; /* volatile state */
 
 	TX_BEGIN_LOCK(pop, TX_LOCK_MUTEX, &D_RW(root)->lock) {
-		vstate = MALLOC(sizeof(*vstate));
+		vstate = (int *)MALLOC(sizeof(*vstate));
 		*vstate = TEST_VALUE;
 		TX_ADD(root);
 		D_RW(root)->value = *vstate;
@@ -520,7 +520,7 @@ test_tx_api(PMEMobjpool *pop)
 
 	errno = 0;
 	TX_BEGIN(pop) {
-		TX_BEGIN((void *)(uintptr_t)7) {
+		TX_BEGIN((PMEMobjpool *)(uintptr_t)7) {
 		} TX_ONCOMMIT {
 			UT_ASSERT(0);
 		} TX_END

--- a/src/test/obj_basic_integration/obj_basic_integration.vcxproj
+++ b/src/test/obj_basic_integration/obj_basic_integration.vcxproj
@@ -1,0 +1,194 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Debug|x64">
+      <Configuration>Static-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Static-Release|x64">
+      <Configuration>Static-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{58386481-30B7-40FC-96AF-0723A4A7B228}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>obj_basic_integration</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Static-Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>
+    </LinkIncremental>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static-Release|x64'">
+    <LinkIncremental>
+    </LinkIncremental>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\test\unittest;$(SolutionDir)\windows\include;$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DbgHelp.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\test\unittest;$(SolutionDir)\windows\include;$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <PrecompiledHeaderFile />
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;libpmemcommon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\test\unittest;$(SolutionDir)\windows\include;$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <OptimizeReferences>
+      </OptimizeReferences>
+      <GenerateDebugInformation>Debug</GenerateDebugInformation>
+      <AdditionalDependencies>DbgHelp.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <LinkTimeCodeGeneration />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static-Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;WINAPI_PARTITION_SYSTEM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)\test\unittest;$(SolutionDir)\windows\include;$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <CompileAs>CompileAsCpp</CompileAs>
+      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
+      <ForcedIncludeFiles>platform.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>DbgHelp.lib;Shlwapi.lib;libpmemcommon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_basic_integration.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1" />
+    <None Include="TEST1.PS1" />
+    <None Include="TEST2.PS1" />
+    <None Include="TEST3.PS1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\libpmemobj\libpmemobj.vcxproj">
+      <Project>{1baa1617-93ae-4196-8a1a-bd492fb18aef}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\libpmem\libpmem.vcxproj">
+      <Project>{9e9e3d25-2139-4a5d-9200-18148ddead45}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\unittest\libut.vcxproj">
+      <Project>{ce3f2dfb-8470-4802-ad37-21caf6cb2681}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test/obj_basic_integration/obj_basic_integration.vcxproj.filters
+++ b/src/test/obj_basic_integration/obj_basic_integration.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Test scripts">
+      <UniqueIdentifier>{c0f52631-8f99-42f0-8d94-07ddeba87436}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{fdf90df9-299e-4772-9987-80b460bd2573}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="obj_basic_integration.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="TEST0.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST1.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST2.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+    <None Include="TEST3.PS1">
+      <Filter>Test scripts</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/test/obj_basic_integration/out0.log.match
+++ b/src/test/obj_basic_integration/out0.log.match
@@ -1,5 +1,5 @@
-obj_basic_integration/TEST0: START: obj_basic_integration
- ./obj_basic_integration$(nW) $(nW)/testfile1
+obj_basic_integration$(nW)TEST0: START: obj_basic_integration
+ $(nW)obj_basic_integration$(nW) $(nW)testfile1
 alloc: 128, size: 128
 realloc: 128 => 655360, size: 786368
 realloc: 655360 => 1, size: 64
@@ -30,4 +30,4 @@ POBJ_LIST_PREV: dummy_node 7
 POBJ_LIST_PREV: dummy_node 5
 nested transaction for different pool
 explicit transaction abort: Operation canceled
-obj_basic_integration/TEST0: Done
+obj_basic_integration$(nW)TEST0: Done

--- a/src/test/obj_basic_integration/out1.log.match
+++ b/src/test/obj_basic_integration/out1.log.match
@@ -1,5 +1,5 @@
-obj_basic_integration/TEST1: START: obj_basic_integration
- ./obj_basic_integration$(nW) $(nW)/testfile1
+obj_basic_integration$(nW)TEST1: START: obj_basic_integration
+ $(nW)obj_basic_integration$(nW) $(nW)$(nW)testfile1
 alloc: 128, size: 128
 realloc: 128 => 655360, size: 786368
 realloc: 655360 => 1, size: 64
@@ -30,4 +30,4 @@ POBJ_LIST_PREV: dummy_node 7
 POBJ_LIST_PREV: dummy_node 5
 nested transaction for different pool
 explicit transaction abort: Operation canceled
-obj_basic_integration/TEST1: Done
+obj_basic_integration$(nW)TEST1: Done

--- a/src/test/obj_basic_integration/out2.log.match
+++ b/src/test/obj_basic_integration/out2.log.match
@@ -1,5 +1,5 @@
-obj_basic_integration/TEST2: START: obj_basic_integration
- ./obj_basic_integration$(nW) $(nW)/testset1
+obj_basic_integration$(nW)TEST2: START: obj_basic_integration
+ $(nW)obj_basic_integration$(nW) $(nW)testset1
 alloc: 128, size: 128
 realloc: 128 => 655360, size: 786368
 realloc: 655360 => 1, size: 64
@@ -30,4 +30,4 @@ POBJ_LIST_PREV: dummy_node 7
 POBJ_LIST_PREV: dummy_node 5
 nested transaction for different pool
 explicit transaction abort: Operation canceled
-obj_basic_integration/TEST2: Done
+obj_basic_integration$(nW)TEST2: Done

--- a/src/test/obj_basic_integration/out3.log.match
+++ b/src/test/obj_basic_integration/out3.log.match
@@ -1,5 +1,5 @@
-obj_basic_integration/TEST3: START: obj_basic_integration
- ./obj_basic_integration$(nW) $(nW)/testset1
+obj_basic_integration$(nW)TEST3: START: obj_basic_integration
+ $(nW)obj_basic_integration$(nW) $(nW)testset1
 alloc: 128, size: 128
 realloc: 128 => 655360, size: 786368
 realloc: 655360 => 1, size: 64
@@ -30,4 +30,4 @@ POBJ_LIST_PREV: dummy_node 7
 POBJ_LIST_PREV: dummy_node 5
 nested transaction for different pool
 explicit transaction abort: Operation canceled
-obj_basic_integration/TEST3: Done
+obj_basic_integration$(nW)TEST3: Done


### PR DESCRIPTION
Add project into VS solution
Add scripts TEST0-TEST3
Known issue: There is a error after added pmemobj_tx_abort. I guess it works in Linux only. Currently, I disable "check" in scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1077)
<!-- Reviewable:end -->
