### PR TITLE
doc: fix typo in man page example

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -478,7 +478,7 @@ void *
 pmemobj_memcpy_persist(PMEMobjpool *pop, void *dest,
     const void *src, size_t len)
 {
-    void *retval = memcpy(pop, dest, src, len);
+    void *retval = memcpy(dest, src, len);
 
     pmemobj_persist(pop, dest, len);
 


### PR DESCRIPTION
Fix the signature of memcpy().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1088)
<!-- Reviewable:end -->
