### PR TITLE
obj: sync set affinity

### DIFF
--- a/src/common/pthread_windows.c
+++ b/src/common/pthread_windows.c
@@ -55,6 +55,7 @@
  */
 
 #include <pthread.h>
+#include <sched.h>
 #include <time.h>
 #include <sys/types.h>
 #include <sys/timeb.h>
@@ -486,3 +487,12 @@ pthread_join(pthread_t thread, void **result)
 
 	return 0;
 }
+
+#ifdef _GNU_SOURCE
+int
+pthread_setaffinity_np(pthread_t __th, size_t __cpusetsize,
+				const cpu_set_t *__cpuset)
+{
+	return !SetThreadAffinityMask(__th->thread_handle, __cpuset->mask);
+}
+#endif /* _GNU_SOURCE */

--- a/src/test/obj_sync/TEST7
+++ b/src/test/obj_sync/TEST7
@@ -45,7 +45,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX t 50 300
+expect_normal_exit ./obj_sync$EXESUFFIX t 10 300
 
 check
 

--- a/src/test/obj_sync/TEST8
+++ b/src/test/obj_sync/TEST8
@@ -42,10 +42,11 @@ export UNITTEST_NUM=0
 
 require_fs_type none
 require_build_type debug nondebug
+require_test_type long
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX m 10 300
+expect_normal_exit ./obj_sync$EXESUFFIX m 100 300
 
 check
 

--- a/src/test/obj_sync/TEST9
+++ b/src/test/obj_sync/TEST9
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,20 +32,21 @@
 #
 
 #
-# src/test/obj_sync/TEST0 -- unit test for PMEM-resident locks
+# src/test/obj_sync/TEST7 -- unit test for PMEM-resident locks
 #
-export UNITTEST_NAME=obj_sync/TEST0
-export UNITTEST_NUM=0
+export UNITTEST_NAME=obj_sync/TEST7
+export UNITTEST_NUM=7
 
 # standard unit test setup
 . ../unittest/unittest.sh
 
 require_fs_type none
 require_build_type debug nondebug
+require_test_type long
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX m 10 300
+expect_normal_exit ./obj_sync$EXESUFFIX t 100 300
 
 check
 

--- a/src/test/obj_sync/err7.log.match
+++ b/src/test/obj_sync/err7.log.match
@@ -1,0 +1,1 @@
+{obj_sync.c:$(N) timed_check_worker} obj_sync/TEST7: pmemobj_mutex_timedlock: Invalid argument

--- a/src/test/obj_sync/out0.log.match
+++ b/src/test/obj_sync/out0.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST0: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST0: Done

--- a/src/test/obj_sync/out1.log.match
+++ b/src/test/obj_sync/out1.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST1: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST1: Done

--- a/src/test/obj_sync/out2.log.match
+++ b/src/test/obj_sync/out2.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST2: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST2: Done

--- a/src/test/obj_sync/out3.log.match
+++ b/src/test/obj_sync/out3.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST3: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST3: Done

--- a/src/test/obj_sync/out4.log.match
+++ b/src/test/obj_sync/out4.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST4: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST4: Done

--- a/src/test/obj_sync/out5.log.match
+++ b/src/test/obj_sync/out5.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST5: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST5: Done

--- a/src/test/obj_sync/out6.log.match
+++ b/src/test/obj_sync/out6.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST6: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST6: Done

--- a/src/test/obj_sync/out7.log.match
+++ b/src/test/obj_sync/out7.log.match
@@ -1,3 +1,0 @@
-obj_sync/TEST7: START: obj_sync
- ./obj_sync$(nW) $(nW) $(N) $(N)
-obj_sync/TEST7: Done

--- a/src/windows/include/pthread.h
+++ b/src/windows/include/pthread.h
@@ -57,6 +57,7 @@
 #ifndef PTHREAD_H
 #define PTHREAD_H 1
 
+#include <sched.h>
 #include <stdint.h>
 #include <time.h>
 
@@ -167,5 +168,14 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
 	void *(*start_routine)(void *), void *arg);
 
 int pthread_join(pthread_t thread, void **result);
+
+#ifdef _GNU_SOURCE
+/*
+ * Limit specified thread TH to run only on the processors represented
+ * in CPUSET.
+ */
+int pthread_setaffinity_np(pthread_t __th, size_t __cpusetsize,
+				const cpu_set_t *__cpuset);
+#endif /* _GNU_SOURCE */
 
 #endif /* PTHREAD_H */

--- a/src/windows/include/sched.h
+++ b/src/windows/include/sched.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * sched.h -- (imperfect) scheduling implementation for Windows
+ */
+
+/*
+ * XXX - The initial approach to NVML for Windows port was to minimize the
+ * amount of changes required in the core part of the library, and to avoid
+ * preprocessor conditionals, if possible.  For that reason, some of the
+ * Linux system calls that have no equivalents on Windows have been emulated
+ * using Windows API.
+ * Note that it was not a goal to fully emulate linux behavior
+ * of mentioned functions.  They are used only internally, so current
+ * implementation is just good enough to satisfy NVML needs and to make it
+ * work on Windows.
+ *
+ * This is a subject for change in the future.  Likely, all these functions
+ * will be replaced with "util_xxx" wrappers with OS-specific implementation
+ * for Linux and Windows.
+ */
+
+#ifndef SCHED_H
+#define SCHED_H 1
+
+#include <stdint.h>
+#include <time.h>
+
+#ifdef _GNU_SOURCE
+/* Data structure to describe CPU mask. */
+typedef struct {
+	long long mask;
+} cpu_set_t;
+
+#define CPU_SET(cpu, cpusetp) (cpusetp)->mask |= 1 << (cpu)
+
+#define CPU_ZERO(cpusetp) (cpusetp)->mask = 0
+
+#endif /* _GNU_SOURCE */
+
+#endif /* SCHED_H */


### PR DESCRIPTION
Set processor affinity when starting threads.
Reduce the number of threads run in the default configuration.
Add long tests which spawn more threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1094)
<!-- Reviewable:end -->
