### PR TITLE
libpmempool: add missing include

### DIFF
--- a/src/include/libpmempool.h
+++ b/src/include/libpmempool.h
@@ -44,6 +44,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 /*
  * pool types


### PR DESCRIPTION
The <sys/types.h> include is required to use size_t type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1134)
<!-- Reviewable:end -->
