### PR TITLE
test: add explicit dependencies between obj_rpmem* and obj_*

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -335,6 +335,14 @@ $(TESTS) $(OBJ_DEPS) $(LIBPMEMPOOL_DEPS): $(TEST_DEPS)
 $(OBJ_TESTS): $(OBJ_DEPS)
 $(LIBPMEMPOOL_TESTS): $(LIBPMEMPOOL_DEPS)
 
+obj_rpmem_basic_integration: obj_basic_integration
+
+obj_rpmem_constuctor: obj_constructor
+
+obj_rpmem_heap_interrupt: obj_heap_interrupt
+
+obj_rpmem_heap_state: obj_heap_state
+
 $(TESTS_BUILD):
 	$(MAKE) -C $@ $(TARGET)
 


### PR DESCRIPTION
Parallel build sometimes fails with errors like:
cc: obj_basic_integration.o: No such file or directory
obj_basic_integration.o: file not recognized: File truncated

Reported by krzycz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1138)
<!-- Reviewable:end -->
