### PR TITLE
cpp: fix condition_variable

### DIFF
--- a/src/include/libpmemobj++/condition_variable.hpp
+++ b/src/include/libpmemobj++/condition_variable.hpp
@@ -361,7 +361,7 @@ public:
 	std::cv_status
 	wait_for(Lock &lock, const std::chrono::duration<Rep, Period> &rel_time)
 	{
-		return this->wait_until_impl(lock,
+		return this->wait_until_impl(*lock.mutex(),
 					     clock_type::now() + rel_time);
 	}
 
@@ -395,7 +395,8 @@ public:
 	wait_for(Lock &lock, const std::chrono::duration<Rep, Period> &rel_time,
 		 Predicate pred)
 	{
-		return this->wait_until_impl(lock, clock_type::now() + rel_time,
+		return this->wait_until_impl(*lock.mutex(),
+					     clock_type::now() + rel_time,
 					     std::move(pred));
 	}
 

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -138,7 +138,7 @@ reader_lock(nvobj::persistent_ptr<struct root> proot)
 {
 	std::unique_lock<nvobj::mutex> lock(proot->pmutex);
 	while (proot->counter != limit)
-		proot->cond.wait(proot->pmutex);
+		proot->cond.wait(lock);
 
 	UT_ASSERTeq(proot->counter, limit);
 	lock.unlock();
@@ -216,7 +216,7 @@ reader_lock_until(nvobj::persistent_ptr<struct root> proot)
 	std::unique_lock<nvobj::mutex> lock(proot->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = proot->cond.wait_until(proot->pmutex, until);
+	auto ret = proot->cond.wait_until(lock, until);
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout) {
@@ -240,9 +240,8 @@ reader_lock_until_pred(nvobj::persistent_ptr<struct root> proot)
 	std::unique_lock<nvobj::mutex> lock(proot->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = proot->cond.wait_until(proot->pmutex, until, [&]() {
-		return proot->counter == limit;
-	});
+	auto ret = proot->cond.wait_until(
+		lock, until, [&]() { return proot->counter == limit; });
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false) {
@@ -316,7 +315,7 @@ reader_lock_for(nvobj::persistent_ptr<struct root> proot)
 	std::unique_lock<nvobj::mutex> lock(proot->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = proot->cond.wait_for(proot->pmutex, wait_time);
+	auto ret = proot->cond.wait_for(lock, wait_time);
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout) {
@@ -340,9 +339,8 @@ reader_lock_for_pred(nvobj::persistent_ptr<struct root> proot)
 	std::unique_lock<nvobj::mutex> lock(proot->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = proot->cond.wait_for(proot->pmutex, wait_time, [&]() {
-		return proot->counter == limit;
-	});
+	auto ret = proot->cond.wait_for(
+		lock, wait_time, [&]() { return proot->counter == limit; });
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false) {

--- a/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
+++ b/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
@@ -145,7 +145,7 @@ reader_lock(void *arg)
 		static_cast<nvobj::persistent_ptr<struct root> *>(arg);
 	std::unique_lock<nvobj::mutex> lock((*proot)->pmutex);
 	while ((*proot)->counter != limit)
-		(*proot)->cond.wait((*proot)->pmutex);
+		(*proot)->cond.wait(lock);
 
 	UT_ASSERTeq((*proot)->counter, limit);
 	lock.unlock();
@@ -241,7 +241,7 @@ reader_lock_until(void *arg)
 	std::unique_lock<nvobj::mutex> lock((*proot)->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = (*proot)->cond.wait_until((*proot)->pmutex, until);
+	auto ret = (*proot)->cond.wait_until(lock, until);
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout) {
@@ -270,9 +270,8 @@ reader_lock_until_pred(void *arg)
 	std::unique_lock<nvobj::mutex> lock((*proot)->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = (*proot)->cond.wait_until((*proot)->pmutex, until, [&]() {
-		return (*proot)->counter == limit;
-	});
+	auto ret = (*proot)->cond.wait_until(
+		lock, until, [&]() { return (*proot)->counter == limit; });
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false) {
@@ -361,7 +360,7 @@ reader_lock_for(void *arg)
 	std::unique_lock<nvobj::mutex> lock((*proot)->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = (*proot)->cond.wait_for((*proot)->pmutex, wait_time);
+	auto ret = (*proot)->cond.wait_for(lock, wait_time);
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == std::cv_status::timeout) {
@@ -390,9 +389,8 @@ reader_lock_for_pred(void *arg)
 	std::unique_lock<nvobj::mutex> lock((*proot)->pmutex);
 	auto until = std::chrono::system_clock::now();
 	until += wait_time;
-	auto ret = (*proot)->cond.wait_for((*proot)->pmutex, wait_time, [&]() {
-		return (*proot)->counter == limit;
-	});
+	auto ret = (*proot)->cond.wait_for(
+		lock, wait_time, [&]() { return (*proot)->counter == limit; });
 
 	auto now = std::chrono::system_clock::now();
 	if (ret == false) {


### PR DESCRIPTION
Fix wait_for to work with locks in condition_variable.hpp . Fix tests that did not checked locks (obj_cpp_con_var and obj_cpp_con_var_posix).

Refs: pmem/issues#225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1144)
<!-- Reviewable:end -->
