### PR TITLE
obj: fix status returned by pmemobj_list_insert()

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -2232,7 +2232,8 @@ pmemobj_list_insert(PMEMobjpool *pop, size_t pe_offset, void *head,
 
 	if (pe_offset >= pop->size) {
 		ERR("pe_offset (%lu) too big", pe_offset);
-		return EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	return list_insert(pop, (ssize_t)pe_offset, head, dest, before, oid);
@@ -2297,7 +2298,8 @@ pmemobj_list_remove(PMEMobjpool *pop, size_t pe_offset, void *head,
 
 	if (pe_offset >= pop->size) {
 		ERR("pe_offset (%lu) too big", pe_offset);
-		return EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	if (free) {
@@ -2329,12 +2331,14 @@ pmemobj_list_move(PMEMobjpool *pop, size_t pe_old_offset, void *head_old,
 
 	if (pe_old_offset >= pop->size) {
 		ERR("pe_old_offset (%lu) too big", pe_old_offset);
-		return EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	if (pe_new_offset >= pop->size) {
 		ERR("pe_new_offset (%lu) too big", pe_new_offset);
-		return EINVAL;
+		errno = EINVAL;
+		return -1;
 	}
 
 	return list_move(pop, pe_old_offset, head_old,


### PR DESCRIPTION
... pmemobj_list_move() and pmemobj_list_remove().
On failure, these functions should return -1, not errno.

Ref: pmem/issues#226

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1155)
<!-- Reviewable:end -->
