### PR TITLE
doc: highlight NVML types

### DIFF
--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -10,6 +10,7 @@
 	<link href="http://pmem.io/feed.xml" rel="alternate" type="application/atom+xml">
 	<script type="text/javascript" src="/js/jquery.min.js"></script>
 	<script type="text/javascript" src="/js/gist-embed.min.js"></script>
+	<script type="text/javascript" src="/nvml/js/nvml_formatter.js"></script>
 </head>
 <body>
 

--- a/css/pmem.css
+++ b/css/pmem.css
@@ -124,6 +124,11 @@ pre, code {
 	-webkit-border-radius: 2px;
 }
 
+/* overwrite .highlight style for inline code elements */
+code.highlight {
+        background-color: #f8f8c0;
+}
+
 code[data-gist-id] {
 	box-shadow: none;
 	padding: 0;

--- a/js/nvml_formatter.js
+++ b/js/nvml_formatter.js
@@ -1,0 +1,67 @@
+var nvml_types = [
+        /* libpmemobj.h */
+        "PMEMobjpool",  "PMEMmutex", "PMEMrwlock", "PMEMcond", "PMEMoid",
+        "pmemobj_constr", "tx_lock", "pmemobj_constr",
+        /* libpmemblk.h */
+        "PMEMblkpool",
+        /* libpmemlog.h */
+        "PMEMlogpool",
+        /* libvmem.h */
+        "VMEM",
+        /* libpmempool.h */
+        "PMEMpoolcheck",
+        /* librpmem.h */
+        "RPMEMpool",
+        /* other headers */
+        "mode_t", "timespec"
+];
+
+/* ambiguous types can also be e.g. define names */
+var nvml_ambiguous_types = [
+        /* libpmemobj.h */
+        "POBJ_LIST_ENTRY", "POBJ_LIST_HEAD", "TOID"
+];
+
+/*
+ * nvml_format_type -- format an element
+ */
+function nvml_format_type(obj) {
+        /* inject span into inline code tag */
+        var tag = $(obj).prop("tagName");
+        if (tag == "CODE") {
+                var text = $(obj).text();
+                $(obj).html("<span>" + text + "</span>").addClass("highlight");
+                obj = $(obj).children("span");
+        }
+
+        $(obj).addClass("kt").removeClass("n");
+}
+
+/*
+ * nvml_format -- filter elements requiring formatting
+ */
+function nvml_format() {
+        var word = $(this).text();
+        if (nvml_types.indexOf(word) != -1)
+                nvml_format_type(this);
+        else if (nvml_ambiguous_types.indexOf(word) != -1) {
+                /*
+                 * if succeeding tag is a span with "(" it is a name of a
+                 * function / define but not a type
+                 */
+                var next = $(this).next("span");
+                if (next.size() == 1) {
+                        var next_word = $(next).text();
+                        if (next_word == "(")
+                                return;
+                }
+
+                nvml_format_type(this);
+        }
+}
+
+/* trigger NVML types formatting */
+$(document).ready(function() {
+        $("code span.n").each(nvml_format);
+        $("code.highlighter-rouge").each(nvml_format);
+});


### PR DESCRIPTION
Add a javascript code highlighting NVML defined types on HTML pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1170)
<!-- Reviewable:end -->
