### PR TITLE
common: prepare for submodule-based Valgrind repo

### DIFF
--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -34,11 +34,10 @@
 # install-valgrind.sh - installs valgrind for persistent memory
 #
 
-git clone https://github.com/pmem/valgrind.git
+git clone --recursive https://github.com/pmem/valgrind.git
 cd valgrind
 ./autogen.sh
 ./configure
 make
 make install
 rm -rf valgrind
-


### PR DESCRIPTION
Currently pmem branch in our Valgrind repository contains both Valgrind
and VEX, while upstream have it separated.

We are going to follow upstream on this soon (and have per-version
branches with full history), so prepare our docker scripts to download
both Valgrind and VEX submodule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1181)
<!-- Reviewable:end -->
