### PR TITLE
rpmemd: add removing pool functionality

### DIFF
--- a/doc/rpmemd.1.md
+++ b/doc/rpmemd.1.md
@@ -101,6 +101,10 @@ and **--use-syslog** should not be followed by any value. Presence of each of th
 in the command line turns on an appropriate option.
 See **CONFIGURATION FILES** section for details.
 
+`-r, --remove <poolset>`
+
+Remove a pool described by given pool set file descriptor. It is interpreted
+as a path to the pool set file relative to the pool set directory.
 
 # CONFIGURATION FILES #
 

--- a/src/test/rpmem_basic/TEST5
+++ b/src/test/rpmem_basic/TEST5
@@ -1,0 +1,80 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/rpmem_basic/TEST5 -- unit test for rpmemd --remove
+#
+export UNITTEST_NAME=rpmem_basic/TEST5
+export UNITTEST_NUM=5
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type any
+require_build_type nondebug debug
+
+rpmem_foreach_provider
+rpmem_foreach_persist
+
+setup
+
+. setup.sh
+
+cat > $DIR/pool0.set << EOF
+PMEMPOOLSET
+8M $PART_DIR/pool0.part0
+8M $PART_DIR/pool0.part1
+EOF
+
+expect_normal_exit run_on_node 0 rm -rf $POOLS_PART
+expect_normal_exit run_on_node 0 mkdir -p $POOLS_DIR
+expect_normal_exit run_on_node 0 mkdir -p $POOLS_PART
+expect_normal_exit copy_files_to_node 0 $POOLS_DIR $DIR/pool0.set
+
+expect_abnormal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool0.set"
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_create 0 pool0.set ${NODE_ADDR[0]} mem 8M test_close 0
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_open 0 pool0.set ${NODE_ADDR[0]} pool 8M\
+	test_close 0
+
+expect_normal_exit run_on_node 1 ssh ${NODE_ADDR[0]} "\$RPMEM_CMD --remove pool0.set"
+
+expect_normal_exit run_on_node 1 ./rpmem_basic$EXESUFFIX\
+	test_open 0 pool0.set ${NODE_ADDR[0]} pool 8M
+
+check
+
+pass

--- a/src/test/rpmem_basic/node_1_out5.log.match
+++ b/src/test/rpmem_basic/node_1_out5.log.match
@@ -1,0 +1,4 @@
+rpmem_basic/TEST5: START: rpmem_basic$(nW)
+ ./rpmem_basic test_open 0 pool0.set $(nW) pool 8M
+pool0.set: No such file or directory
+rpmem_basic/TEST5: Done

--- a/src/test/rpmemd_config/stdout0.log.match
+++ b/src/test/rpmemd_config/stdout0.log.match
@@ -10,6 +10,7 @@ rpmemd version $(*)
 Options:
   -c, --config <path>           configuration file location
   -f, --foreground              run in foreground - do not run as a daemon
+  -r, --remove <poolset>        remove pool described by given poolset file
   -h, --help                    display help message and exit
   -V, --version                 display target daemon version and exit
       --log-file <path>         log file location
@@ -32,6 +33,7 @@ rpmemd version $(*)
 Options:
   -c, --config <path>           configuration file location
   -f, --foreground              run in foreground - do not run as a daemon
+  -r, --remove <poolset>        remove pool described by given poolset file
   -h, --help                    display help message and exit
   -V, --version                 display target daemon version and exit
       --log-file <path>         log file location

--- a/src/tools/rpmemd/rpmemd_config.c
+++ b/src/tools/rpmemd/rpmemd_config.c
@@ -66,6 +66,7 @@ enum rpmemd_option {
 	RPD_OPT_PERSIST_GENERAL,
 	RPD_OPT_USE_SYSLOG,
 	RPD_OPT_LOG_LEVEL,
+	RPD_OPT_RM_POOLSET,
 
 	RPD_OPT_MAX_VALUE,
 	RPD_OPT_INVALID			= UINT64_MAX,
@@ -86,6 +87,7 @@ static const struct option options[] = {
 {"persist-general",	no_argument,		0, RPD_OPT_PERSIST_GENERAL},
 {"use-syslog",		no_argument,		0, RPD_OPT_USE_SYSLOG},
 {"log-level",		required_argument,	0, RPD_OPT_LOG_LEVEL},
+{"remove",		required_argument,	0, 'r'},
 {0,			0,			0, 0},
 };
 
@@ -96,6 +98,7 @@ static const char *help_str =
 "Options:\n"
 "  -c, --config <path>           configuration file location\n"
 "  -f, --foreground              run in foreground - do not run as a daemon\n"
+"  -r, --remove <poolset>        remove pool described by given poolset file\n"
 "  -h, --help                    display help message and exit\n"
 "  -V, --version                 display target daemon version and exit\n"
 "      --log-file <path>         log file location\n"
@@ -446,6 +449,9 @@ parse_cl_args(int argc, char *argv[], struct rpmemd_config *config,
 		case 'c':
 			(*config_file) = optarg;
 			break;
+		case 'r':
+			config->rm_poolset = optarg;
+			break;
 		case 'h':
 			print_help(argv[0]);
 			exit(0);
@@ -561,6 +567,7 @@ config_set_default(struct rpmemd_config *config, const char *poolset_dir)
 	config->use_syslog	= true;
 	config->max_lanes	= RPMEM_DEFAULT_MAX_LANES;
 	config->log_level	= RPD_LOG_ERR;
+	config->rm_poolset	= NULL;
 }
 
 /*

--- a/src/tools/rpmemd/rpmemd_config.h
+++ b/src/tools/rpmemd/rpmemd_config.h
@@ -57,6 +57,7 @@
 struct rpmemd_config {
 	char *log_file;
 	char *poolset_dir;
+	const char *rm_poolset;
 	bool persist_apm;
 	bool persist_general;
 	bool use_syslog;


### PR DESCRIPTION
Make it possible to remove pool using rpmemd. The benefit of doing this
by rpmemd is that it parses config file and command line arguments
which can set the poolset-dir option. Thus it is possible to remove
pool using the same pool descriptor as for rpmem API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1187)
<!-- Reviewable:end -->
