### PR TITLE
rpmemd: fix dereferencing freed pointer

### DIFF
--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -571,11 +571,11 @@ main(int argc, char *argv[])
 			break;
 	}
 
-	rpmemd_obc_fini(rpmemd->obc);
 	rpmemd_db_fini(rpmemd->db);
-	free(rpmemd);
-	rpmemd_log_close();
 	rpmemd_config_free(&rpmemd->config);
+	rpmemd_log_close();
+	rpmemd_obc_fini(rpmemd->obc);
+	free(rpmemd);
 
 	return 0;
 err:


### PR DESCRIPTION
Rpmem handle 'rpmemd' should be freed at the end.
Reorder function calls like in the error handling path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1189)
<!-- Reviewable:end -->
