### PR TITLE
benchmarks: support for removing remote pools

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -43,6 +43,8 @@ vpath %.c $(TOP)/src/examples/libpmemobj/hashmap
 
 vpath %.c $(TOP)/src/libpmemobj
 vpath %.c $(TOP)/src/common
+vpath %.c $(TOP)/src/librpmem
+vpath %.c $(TOP)/src/rpmem_common
 
 
 BENCHMARK = pmembench
@@ -76,7 +78,12 @@ SRC=pmembench.c\
     obj_lanes.c\
     map_bench.c\
     pmemobj_tx.c\
-    pmemobj_atomic_lists.c
+    pmemobj_atomic_lists.c\
+    rpmem_ssh.c\
+    rpmem_cmd.c\
+    rpmem_common.c\
+    rpmem_util.c
+
 
 # Configuration file without the .cfg extension
 CONFIGS=pmembench_log\
@@ -117,6 +124,8 @@ CFLAGS += -I../include
 CFLAGS += -I../libpmemobj
 CFLAGS += -I../common
 CFLAGS += -I../examples/libpmemobj/map
+CFLAGS += -I../rpmem_common
+CFLAGS += -I../librpmem
 CFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
 ifeq ($(GLIB),y)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags glib-2.0)

--- a/src/benchmarks/pmembench.c
+++ b/src/benchmarks/pmembench.c
@@ -43,6 +43,7 @@
 #include <math.h>
 #include <float.h>
 #include <sys/queue.h>
+#include <sys/wait.h>
 #include <linux/limits.h>
 #include <dirent.h>
 #include <errno.h>
@@ -56,6 +57,9 @@
 #include "clo.h"
 #include "config_reader.h"
 #include "util.h"
+#include "rpmem_common.h"
+#include "rpmem_ssh.h"
+#include "rpmem_util.h"
 
 /*
  * struct pmembench -- main context
@@ -840,24 +844,41 @@ out:
 }
 
 /*
+ * remove_remote -- remove remote pool
+ */
+static int
+remove_remote(const char *node, const char *pool)
+{
+	struct rpmem_target_info *info = rpmem_target_parse(node);
+	if (!info)
+		err(1, "parsing target node -- '%s", node);
+
+	struct rpmem_ssh *ssh = rpmem_ssh_exec(info, "--remove", pool, NULL);
+	if (!ssh)
+		err(1, "rpmem_ssh_exec: remove -- '%s'", pool);
+
+	if (rpmem_ssh_monitor(ssh, 0))
+		err(1, "rpmem_ssh_monitor");
+
+	rpmem_ssh_close(ssh);
+	rpmem_target_free(info);
+
+	return 0;
+}
+
+/*
  * remove_part_cb -- callback function for removing all pool set part files
  */
 static int
 remove_part_cb(struct part_file *pf, void *arg)
 {
-	if (pf->is_remote) {
-		/*
-		 * XXX add support for remote replicas
-		 */
-		err(1, "removing remote poolset files is not supported yet");
+	if (pf->is_remote)
+		return remove_remote(pf->node_addr, pf->pool_desc);
 
-		return -1;
-	} else {
-		const char *part_file = pf->path;
+	const char *part_file = pf->path;
 
-		if (access(part_file, F_OK) == 0)
-			return remove(part_file);
-	}
+	if (access(part_file, F_OK) == 0)
+		return remove(part_file);
 
 	return 0;
 }
@@ -1221,6 +1242,7 @@ int
 main(int argc, char *argv[])
 {
 	util_init();
+	rpmem_util_cmds_init();
 	util_mmap_init();
 	int ret = 0;
 	struct pmembench *pb = calloc(1, sizeof(*pb));

--- a/src/benchmarks/pmembench.c
+++ b/src/benchmarks/pmembench.c
@@ -843,10 +843,22 @@ out:
  * remove_part_cb -- callback function for removing all pool set part files
  */
 static int
-remove_part_cb(const char *part_file, void *arg)
+remove_part_cb(struct part_file *pf, void *arg)
 {
-	if (access(part_file, F_OK) == 0)
-		return remove(part_file);
+	if (pf->is_remote) {
+		/*
+		 * XXX add support for remote replicas
+		 */
+		err(1, "removing remote poolset files is not supported yet");
+
+		return -1;
+	} else {
+		const char *part_file = pf->path;
+
+		if (access(part_file, F_OK) == 0)
+			return remove(part_file);
+	}
+
 	return 0;
 }
 

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -99,6 +99,14 @@ struct pool_set {
 	struct pool_replica *replica[];
 };
 
+struct part_file {
+	int is_remote;
+	const char *path;	/* not-NULL only for a local part file */
+	const char *node_addr;	/* address of a remote node */
+	/* poolset descriptor is a pool set file name on a remote node */
+	const char *pool_desc;	/* descriptor of a poolset */
+};
+
 #define REP(set, r)\
 	((set)->replica[((set)->nreplicas + (r)) % (set)->nreplicas])
 
@@ -117,7 +125,7 @@ int util_poolset_chmod(struct pool_set *set, mode_t mode);
 void util_poolset_fdclose(struct pool_set *set);
 int util_is_poolset_file(const char *path);
 int util_poolset_foreach_part(const char *path,
-	int (*cb)(const char *part_file, void *arg), void *arg);
+	int (*cb)(struct part_file *pf, void *arg), void *arg);
 size_t util_poolset_size(const char *path);
 
 int util_pool_create(struct pool_set **setp, const char *path, size_t poolsize,

--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -229,7 +229,7 @@ static int
 rpmem_remove_pool(const struct rpmem_target_info *info, const char *pool_set)
 {
 	RPMEM_LOG(NOTICE, "removing pool -- '%s'", pool_set);
-	struct rpmem_ssh *ssh = rpmem_ssh_run(info, "--remove",
+	struct rpmem_ssh *ssh = rpmem_ssh_exec(info, "--remove",
 			pool_set, NULL);
 	if (!ssh) {
 		RPMEM_LOG(ERR, "executing remove command failed");

--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -140,11 +140,11 @@ err:
 }
 
 /*
- * rpmem_ssh_run -- open ssh connection and run $RPMEMD_CMD with
+ * rpmem_ssh_exec -- open ssh connection and run $RPMEMD_CMD with
  * additional NULL-terminated list of arguments.
  */
 struct rpmem_ssh *
-rpmem_ssh_run(const struct rpmem_target_info *info, ...)
+rpmem_ssh_exec(const struct rpmem_target_info *info, ...)
 {
 	struct rpmem_ssh *rps = calloc(1, sizeof(*rps));
 	if (!rps)
@@ -240,7 +240,7 @@ err_zalloc:
 struct rpmem_ssh *
 rpmem_ssh_open(const struct rpmem_target_info *info)
 {
-	struct rpmem_ssh *ssh = rpmem_ssh_run(info, NULL);
+	struct rpmem_ssh *ssh = rpmem_ssh_exec(info, NULL);
 	if (!ssh)
 		return NULL;
 

--- a/src/librpmem/rpmem_ssh.h
+++ b/src/librpmem/rpmem_ssh.h
@@ -38,7 +38,7 @@
 struct rpmem_ssh;
 
 struct rpmem_ssh *rpmem_ssh_open(const struct rpmem_target_info *info);
-struct rpmem_ssh *rpmem_ssh_run(const struct rpmem_target_info *info, ...);
+struct rpmem_ssh *rpmem_ssh_exec(const struct rpmem_target_info *info, ...);
 int rpmem_ssh_close(struct rpmem_ssh *rps);
 
 int rpmem_ssh_send(struct rpmem_ssh *rps, const void *buff, size_t len);

--- a/src/test/util_poolset_foreach/TEST1
+++ b/src/test/util_poolset_foreach/TEST1
@@ -1,0 +1,69 @@
+#!/bin/bash -e
+#
+# Copyright 2016, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/util_poolset_foreach/TEST1 -- unit test for util_poolset_foreach
+#
+export UNITTEST_NAME=util_poolset_foreach/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_fs_type any
+
+setup
+
+create_poolset $DIR/pool.set1 32K:$DIR/testfile:x\
+	M remote_node1:remote_pool.set1
+create_poolset $DIR/pool.set2 32K:$DIR/testfile1:x 32M:$DIR/testfile2:x\
+	M remote_node2:remote_pool.set2
+create_poolset $DIR/pool.set3\
+	32M:$DIR/testfile11:x 32M:$DIR/testfile12:x\
+	R 64M:$DIR/testfile21:x 32M:$DIR/testfile22:x\
+	M remote_node3:remote_pool.set3
+create_poolset $DIR/pool.set4\
+	32M:$DIR/testfile11:x 32M:$DIR/testfile12:x\
+	R 64M:$DIR/testfile21:x 32M:$DIR/testfile22:x\
+	R 64M:$DIR/testfile31:x 64M:$DIR/testfile32:x\
+	M remote_node4:remote_pool.set4
+
+expect_normal_exit ./util_poolset_foreach$EXESUFFIX\
+	$DIR/pool.set1\
+	$DIR/pool.set2\
+	$DIR/pool.set3\
+	$DIR/pool.set4
+
+check
+
+pass

--- a/src/test/util_poolset_foreach/out1.log.match
+++ b/src/test/util_poolset_foreach/out1.log.match
@@ -1,0 +1,24 @@
+util_poolset_foreach$(nW)TEST1: START: util_poolset_foreach
+ $(nW)util_poolset_foreach$(nW) $(*)pool.set1 $(*)pool.set2 $(*)pool.set3 $(*)pool.set4
+$(*)pool.set1: $(*)testfile
+$(*)pool.set1: remote_node1 remote_pool.set1
+util_poolset_foreach_part($(*)pool.set1): 0
+$(*)pool.set2: $(*)testfile1
+$(*)pool.set2: $(*)testfile2
+$(*)pool.set2: remote_node2 remote_pool.set2
+util_poolset_foreach_part($(*)pool.set2): 0
+$(*)pool.set3: $(*)testfile11
+$(*)pool.set3: $(*)testfile12
+$(*)pool.set3: $(*)testfile21
+$(*)pool.set3: $(*)testfile22
+$(*)pool.set3: remote_node3 remote_pool.set3
+util_poolset_foreach_part($(*)pool.set3): 0
+$(*)pool.set4: $(*)testfile11
+$(*)pool.set4: $(*)testfile12
+$(*)pool.set4: $(*)testfile21
+$(*)pool.set4: $(*)testfile22
+$(*)pool.set4: $(*)testfile31
+$(*)pool.set4: $(*)testfile32
+$(*)pool.set4: remote_node4 remote_pool.set4
+util_poolset_foreach_part($(*)pool.set4): 0
+util_poolset_foreach$(nW)TEST1: Done

--- a/src/test/util_poolset_foreach/util_poolset_foreach.c
+++ b/src/test/util_poolset_foreach/util_poolset_foreach.c
@@ -48,10 +48,20 @@
 #define MINOR_VERSION 0
 
 static int
-cb(const char *name, void *arg)
+cb(struct part_file *pf, void *arg)
 {
-	char *set_name = (char *)arg;
-	UT_OUT("%s: %s", set_name, name);
+	if (pf->is_remote) {
+		/* remote replica */
+		const char *node_addr = pf->node_addr;
+		const char *pool_desc = pf->pool_desc;
+		char *set_name = (char *)arg;
+		UT_OUT("%s: %s %s", set_name, node_addr, pool_desc);
+	} else {
+		const char *name = pf->path;
+		char *set_name = (char *)arg;
+		UT_OUT("%s: %s", set_name, name);
+	}
+
 	return 0;
 }
 

--- a/src/tools/pmempool/rm.c
+++ b/src/tools/pmempool/rm.c
@@ -135,23 +135,32 @@ rm_file(const char *file)
 }
 
 static int
-rm_poolset_cb(const char *part_file, void *arg)
+rm_poolset_cb(struct part_file *pf, void *arg)
 {
-	outv(2, "part file   : %s\n", part_file);
-
-	int exists = access(part_file, F_OK) == 0;
-	if (!exists) {
+	if (pf->is_remote) {
 		/*
-		 * Ignore not accessible file if force
-		 * flag is set
+		 * XXX add support for remote replicas
 		 */
-		if (force)
-			return 0;
+		err(1, "removing remote poolset files is not supported yet");
+	} else {
+		const char *part_file = pf->path;
 
-		err(1, "cannot remove file '%s'", part_file);
+		outv(2, "part file   : %s\n", part_file);
+
+		int exists = access(part_file, F_OK) == 0;
+		if (!exists) {
+			/*
+			 * Ignore not accessible file if force
+			 * flag is set
+			 */
+			if (force)
+				return 0;
+
+			err(1, "cannot remove file '%s'", part_file);
+		}
+
+		rm_file(part_file);
 	}
-
-	rm_file(part_file);
 
 	return 0;
 }


### PR DESCRIPTION
Add support for removing remote pools in pmembench. This is required to run any scenario with pool set file configured with remote replication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1193)
<!-- Reviewable:end -->
