### PR TITLE
obj: fix clearing ctree map

### DIFF
--- a/src/examples/libpmemobj/tree_map/ctree_map.c
+++ b/src/examples/libpmemobj/tree_map/ctree_map.c
@@ -91,6 +91,9 @@ ctree_map_new(PMEMobjpool *pop, TOID(struct ctree_map) *map, void *arg)
 static void
 ctree_map_clear_node(PMEMoid p)
 {
+	if (OID_IS_NULL(p))
+		return;
+
 	if (OID_INSTANCEOF(p, struct tree_map_node)) {
 		TOID(struct tree_map_node) node;
 		TOID_ASSIGN(node, p);


### PR DESCRIPTION
Check if node is OID_NULL before checking the type number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1197)
<!-- Reviewable:end -->
