### PR TITLE
win: RUNTEST.ps1 add missing timeout msg

### DIFF
--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -288,7 +288,7 @@ function runtest {
                     Write-Host -NoNewline $error
                 }
                 if ($p.ExitCode -ne 0) {
-                    Write-Error "RUNTESTS: stopping: $testName/$runscript FAILED errorcde= $p.ExitCode, TEST=$testtype FS=$fs BUILD=$build"
+                    Write-Error "RUNTESTS: stopping: $testName/$runscript $msg errorcde= $p.ExitCode, TEST=$testtype FS=$fs BUILD=$build"
                     cd ..
                     exit $p.ExitCode
                 }


### PR DESCRIPTION
Changed FAILED to TIMED OUT error msg in case of a RUNTEST.ps1 timeout

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1201)
<!-- Reviewable:end -->
