### PR TITLE
cpp remove the EXPERIMENTAL status from C++

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -125,7 +125,6 @@ clobber: clean
 		$(MANPAGES_1_GROFF_EXP) $(MANPAGES_3_GROFF_EXP) \
 		LICENSE
 
-ifeq ($(EXPERIMENTAL),y)
 install-cpp: doxygen_docs
 	$(call install_recursive,$(DOXYGEN_HTMLDIR),0644,$(CPP_DOCS_DESTDIR))
 
@@ -135,7 +134,6 @@ uninstall-cpp:
 	$(RM) -rf $(CPP_DOCS_DESTDIR)
 
 uninstall: uninstall-cpp
-endif
 
 install: compress
 	install -d $(MANPAGES_DESTDIR_1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,10 +63,9 @@ CPP_HEADERS_DESTDIR = $(DESTDIR)$(includedir)/libpmemobj++
 MAKE_PKG_CONFIG = $(TOP)/utils/make-pkg-config.sh
 PKG_CONFIG_DESTDIR = $(DESTDIR)$(pkgconfigdir)
 PKG_CONFIG_FILES = libpmem.pc libvmem.pc libvmmalloc.pc libpmemobj.pc\
-		libpmemlog.pc libpmemblk.pc libpmempool.pc
+		libpmemlog.pc libpmemblk.pc libpmempool.pc libpmemobj++.pc
 
 ifeq ($(EXPERIMENTAL),y)
-	PKG_CONFIG_FILES += libpmemobj++.pc
 ifeq ($(BUILD_RPMEM),y)
 	PKG_CONFIG_FILES += librpmem.pc
 	HEADERS_INSTALL += include/librpmem.h
@@ -140,7 +139,6 @@ ifeq ($(custom_build),)
 	$(MAKE) -C jemalloc -f Makefile.nvml $@ DEBUG=1
 endif
 
-ifeq ($(EXPERIMENTAL),y)
 install-cpp:
 	$(call install_recursive_filter,include/libpmemobj++,*.hpp,0644,$(CPP_HEADERS_DESTDIR))
 
@@ -150,7 +148,6 @@ uninstall-cpp:
 	$(RM) -r $(CPP_HEADERS_DESTDIR)
 
 uninstall: uninstall-cpp
-endif
 
 install: all
 	install -d $(HEADERS_DESTDIR)

--- a/src/include/libpmemobj++/README.md
+++ b/src/include/libpmemobj++/README.md
@@ -30,10 +30,8 @@ seamless persistent memory integration in mind. It is designed to be used with
 basic types within classes, to signify that these members in fact reside in
 persistent memory and need to be handled appropriately.
 
-Please keep in mind that these C++ bindings are still in the experimental stage
-and *SHOULD NOT* be used in production quality code. If you find any issues or
-have suggestion about these bindings please file an issue in
-https://github.com/pmem/issues. There are also blog articles in
+If you find any issues or have suggestion about these bindings please file an
+issue in https://github.com/pmem/issues. There are also blog articles in
 http://pmem.io/blog/ which you might find helpful.
 
 Have fun!

--- a/src/test/tools/fip/Makefile
+++ b/src/test/tools/fip/Makefile
@@ -32,14 +32,13 @@
 # Makefile -- Makefile for fip tool
 #
 
-SCP_TO_REMOTE_NODES = y
-
 TOP = ../../../..
 include $(TOP)/src/common.inc
 
 vpath %.c $(TOP)/src/rpmem_common/
 
 ifeq ($(BUILD_RPMEM),y)
+SCP_TO_REMOTE_NODES = y
 TARGET = fip
 
 OBJS = fip.o rpmem_fip_common.o rpmem_common.o

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -31,14 +31,13 @@
 # Makefile -- top Makefile for rpmemd
 #
 
-SCP_TO_REMOTE_NODES = y
-
 vpath %.c ../../rpmem_common/
 
 TOP = ../../..
 include $(TOP)/src/common.inc
 
 ifeq ($(BUILD_RPMEM),y)
+SCP_TO_REMOTE_NODES = y
 TARGET = rpmemd
 OBJS = rpmemd.o\
        rpmemd_log.o\

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -73,39 +73,6 @@ function convert_changelog() {
 	done < $1
 }
 
-function experimental_install_triggers_overrides() {
-cat << EOF > debian/${OBJ_CPP_NAME}.install
-usr/include/libpmemobj++/*.hpp
-usr/include/libpmemobj++/detail/*.hpp
-usr/share/doc/${OBJ_CPP_DOC_DIR}/*
-EOF
-
-cat << EOF > debian/${OBJ_CPP_NAME}.triggers
-interest doc-base
-EOF
-
-cat << EOF > debian/${OBJ_CPP_NAME}.lintian-overrides
-$ITP_BUG_EXCUSE
-new-package-should-close-itp-bug
-# The following warnings are triggered by a bug in debhelper:
-# http://bugs.debian.org/204975
-postinst-has-useless-call-to-ldconfig
-postrm-has-useless-call-to-ldconfig
-EOF
-
-cat << EOF > debian/${OBJ_CPP_NAME}.doc-base
-Document: ${OBJ_CPP_NAME}
-Title: NVML libpmemobj C++ bindings Manual
-Author: NVML Developers
-Abstract: This is the HTML docs for the C++ bindings for NVML's libpmemobj.
-Section: Programming
-
-Format: HTML
-Index: /usr/share/doc/${OBJ_CPP_DOC_DIR}/index.html
-Files: /usr/share/doc/${OBJ_CPP_DOC_DIR}/*
-EOF
-}
-
 function rpmem_install_triggers_overrides() {
 cat << EOF > debian/librpmem.install
 usr/lib/librpmem.so.*
@@ -154,18 +121,6 @@ EOF
 cat << EOF > debian/rpmemd.lintian-overrides
 $ITP_BUG_EXCUSE
 new-package-should-close-itp-bug
-EOF
-}
-
-function append_experimental_control() {
-cat << EOF >> $CONTROL_FILE
-
-Package: ${OBJ_CPP_NAME}
-Section: libdevel
-Architecture: any
-Depends: libpmemobj-dev (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
-Description: C++ bindings for libpmemobj (EXPERIMENTAL)
- Headers-only C++ library for libpmemobj.
 EOF
 }
 
@@ -250,7 +205,7 @@ Maintainer: $PACKAGE_MAINTAINER
 Section: misc
 Priority: optional
 Standards-version: 3.9.4
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 9), doxygen, pandoc
 
 Package: libpmem
 Architecture: any
@@ -358,6 +313,13 @@ Priority: optional
 Depends: \${shlibs:Depends}, \${misc:Depends}
 Description: Tools for $PACKAGE_NAME
  Utilities for $PACKAGE_NAME.
+
+Package: ${OBJ_CPP_NAME}
+Section: libdevel
+Architecture: any
+Depends: libpmemobj-dev (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
+Description: C++ bindings for libpmemobj
+ Headers-only C++ library for libpmemobj.
 EOF
 
 cp LICENSE debian/copyright
@@ -670,13 +632,38 @@ $ITP_BUG_EXCUSE
 new-package-should-close-itp-bug
 EOF
 
-# Experimental features
-if [ "${EXPERIMENTAL}" = "y" ]
-then
-	append_experimental_control;
-	experimental_install_triggers_overrides;
-fi
+cat << EOF > debian/${OBJ_CPP_NAME}.install
+usr/include/libpmemobj++/*.hpp
+usr/include/libpmemobj++/detail/*.hpp
+usr/share/doc/${OBJ_CPP_DOC_DIR}/*
+EOF
 
+cat << EOF > debian/${OBJ_CPP_NAME}.triggers
+interest doc-base
+EOF
+
+cat << EOF > debian/${OBJ_CPP_NAME}.lintian-overrides
+$ITP_BUG_EXCUSE
+new-package-should-close-itp-bug
+# The following warnings are triggered by a bug in debhelper:
+# http://bugs.debian.org/204975
+postinst-has-useless-call-to-ldconfig
+postrm-has-useless-call-to-ldconfig
+EOF
+
+cat << EOF > debian/${OBJ_CPP_NAME}.doc-base
+Document: ${OBJ_CPP_NAME}
+Title: NVML libpmemobj C++ bindings Manual
+Author: NVML Developers
+Abstract: This is the HTML docs for the C++ bindings for NVML's libpmemobj.
+Section: Programming
+
+Format: HTML
+Index: /usr/share/doc/${OBJ_CPP_DOC_DIR}/index.html
+Files: /usr/share/doc/${OBJ_CPP_DOC_DIR}/*
+EOF
+
+# Experimental features
 if [ "${BUILD_RPMEM}" = "y" -a "${RPMEM_DPKG}" = "y" ]
 then
 	append_rpmem_control;

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -73,26 +73,6 @@ function create_changelog() {
 	done < $1
 }
 
-function add_experimental_packages() {
-cat << EOF >> $RPM_SPEC_FILE
-
-%package -n ${OBJ_CPP_NAME}
-Summary: C++ bindings for libpmemobj
-Group: Development/Libraries
-Requires: libpmemobj-devel = %{version}
-%description -n ${OBJ_CPP_NAME}
-Development files for NVML C++ libpmemobj bindings - EXPERIMENTAL
-
-%files -n ${OBJ_CPP_NAME}
-%defattr(-,root,root,-)
-%{_libdir}/pkgconfig/libpmemobj++.pc
-%{_includedir}/libpmemobj++/*.hpp
-%{_includedir}/libpmemobj++/detail/*.hpp
-%{_docdir}/${OBJ_CPP_NAME}-%{version}/*
-
-EOF
-}
-
 function add_rpmem_packages() {
 cat << EOF >> $RPM_SPEC_FILE
 %package -n librpmem
@@ -217,7 +197,7 @@ Source0:	$PACKAGE_TARBALL
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:	gcc glibc-devel
-BuildRequires:	autoconf, automake, make
+BuildRequires:	autoconf, automake, make, pandoc, doxygen
 BuildArch:	x86_64
 
 %description
@@ -420,6 +400,20 @@ Development files for NVML libvmmalloc library
 %{_includedir}/libvmmalloc.h
 %{_mandir}/man3/libvmmalloc.3.gz
 
+%package -n ${OBJ_CPP_NAME}
+Summary: C++ bindings for libpmemobj
+Group: Development/Libraries
+Requires: libpmemobj-devel = %{version}
+%description -n ${OBJ_CPP_NAME}
+Development files for NVML C++ libpmemobj bindings - EXPERIMENTAL
+
+%files -n ${OBJ_CPP_NAME}
+%defattr(-,root,root,-)
+%{_libdir}/pkgconfig/libpmemobj++.pc
+%{_includedir}/libpmemobj++/*.hpp
+%{_includedir}/libpmemobj++/detail/*.hpp
+%{_docdir}/${OBJ_CPP_NAME}-%{version}/*
+
 %package tools
 Group:		%{package_group}
 Summary:	Tools for %{name}
@@ -478,7 +472,6 @@ EOF
 # Experimental features
 if [ "${EXPERIMENTAL}" = "y" ]
 then
-	add_experimental_packages;
 	if [ "${BUILD_RPMEM}" = "y" ]
 	then
 		add_rpmem_packages;


### PR DESCRIPTION
The C++ binding are no longer considered experimental.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1209)
<!-- Reviewable:end -->
