### PR TITLE
cpp: fix const correctness in examples

### DIFF
--- a/src/examples/libpmemobj/cpp/queue.cpp
+++ b/src/examples/libpmemobj/cpp/queue.cpp
@@ -158,7 +158,7 @@ public:
 	 * Prints the entire contents of the queue.
 	 */
 	void
-	show(void)
+	show(void) const
 	{
 		for (auto n = head; n != nullptr; n = n->next)
 			std::cout << n->value << std::endl;

--- a/src/examples/libpmemobj/cpp_map/ctree_map_persistent.hpp
+++ b/src/examples/libpmemobj/cpp_map/ctree_map_persistent.hpp
@@ -239,7 +239,7 @@ public:
 	 * @return 0 on
 	 */
 	int
-	lookup(key_type key)
+	lookup(key_type key) const
 	{
 		return get(key) != nullptr;
 	}
@@ -266,7 +266,7 @@ public:
 	 * @return 1 if empty, 0 otherwise.
 	 */
 	int
-	is_empty()
+	is_empty() const
 	{
 		return root->value == nullptr && root->inode == nullptr;
 	}
@@ -277,7 +277,7 @@ public:
 	 * @return 0 on success, negative values on error.
 	 */
 	int
-	check()
+	check() const
 	{
 		return 0;
 	}

--- a/src/examples/libpmemobj/cpp_map/ctree_map_transient.hpp
+++ b/src/examples/libpmemobj/cpp_map/ctree_map_transient.hpp
@@ -206,7 +206,7 @@ public:
 	 * @return 0 on
 	 */
 	int
-	lookup(key_type key)
+	lookup(key_type key) const
 	{
 		return get(key) != nullptr;
 	}
@@ -233,7 +233,7 @@ public:
 	 * @return 1 if empty, 0 otherwise.
 	 */
 	int
-	is_empty()
+	is_empty() const
 	{
 		return root->value == nullptr && root->inode == nullptr;
 	}
@@ -244,7 +244,7 @@ public:
 	 * @return 0 on success, negative values on error.
 	 */
 	int
-	check()
+	check() const
 	{
 		return 0;
 	}

--- a/src/examples/libpmemobj/list.hpp
+++ b/src/examples/libpmemobj/list.hpp
@@ -135,7 +135,7 @@ public:
 	 * Return number of elements in list
 	 */
 	unsigned
-	size()
+	size() const
 	{
 		return len;
 	}


### PR DESCRIPTION
Add const qualifiers to non modifying methods in C++ examples.

Refs: pmem/issues#232

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1211)
<!-- Reviewable:end -->
