### PR TITLE
libpmempool: fix transform poolset to one with too small parts

### DIFF
--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -194,7 +194,7 @@ copy_data_to_broken_parts(struct pool_set *set, unsigned healthy_replica,
 
 			/* do not allow copying too much data */
 			if (off >= poolsize)
-				return 0;
+				continue;
 
 			if (off + len > poolsize)
 				len = poolsize - off;
@@ -313,7 +313,6 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	/* set uuids in the previous replica */
 	for (unsigned p = 0; p < prev_r->nparts; ++p) {
 		struct pool_hdr *prev_hdrp = HDR(prev_r, p);
-
 		memcpy(prev_hdrp->next_repl_uuid, PART(rep, 0).uuid,
 				POOL_HDR_UUID_LEN);
 		util_checksum(prev_hdrp, sizeof(*prev_hdrp),
@@ -351,6 +350,9 @@ update_poolset_uuids(struct pool_set *set, unsigned repn,
 		struct pool_hdr *hdrp = HDR(rep, p);
 		memcpy(hdrp->poolset_uuid, set->uuid, POOL_HDR_UUID_LEN);
 		util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum, 1);
+
+		/* store pool's header */
+		pmem_msync(hdrp, sizeof(*hdrp));
 	}
 	return 0;
 }

--- a/src/libpmempool/transform.c
+++ b/src/libpmempool/transform.c
@@ -75,6 +75,17 @@ validate_args(struct pool_set *set_in, struct pool_set *set_out)
 	}
 
 	/*
+	 * check if all parts in the target poolset are large enough
+	 */
+	for (unsigned r = 0; r < set_out->nreplicas; ++r) {
+		struct pool_replica *rep = set_out->replica[r];
+		for (unsigned p = 0; p < rep->nparts; ++p) {
+			if (PART(rep, p).filesize < PMEMOBJ_MIN_POOL)
+				goto err;
+		}
+	}
+
+	/*
 	 * check if set_out has enough size, i.e. if the target poolset
 	 * structure has enough capacity to accommodate the effective size of
 	 * the source poolset


### PR DESCRIPTION
A fix for https://github.com/pmem/issues/issues/252

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1213)
<!-- Reviewable:end -->
