### PR TITLE
test: redirect stderr in two unit tests

### DIFF
--- a/src/test/obj_rpmem_basic_integration/TEST4
+++ b/src/test/obj_rpmem_basic_integration/TEST4
@@ -60,6 +60,8 @@ require_node_libfabric 1 $RPMEM_PROVIDER
 
 init_rpmem_on_node 1 0
 
+STDERR=stderr${UNITTEST_NUM}.log
+
 # binary for this test
 EXE=obj_basic_integration
 
@@ -88,6 +90,6 @@ rm_files_from_node 0 $TEST_FILE_REMOTE
 rm_files_from_node 1 $TEST_FILE_LOCAL
 
 # execute test
-expect_abnormal_exit run_on_node 1 ./$EXE$EXESUFFIX $TEST_SET_LOCAL
+expect_abnormal_exit run_on_node 1 ./$EXE$EXESUFFIX $TEST_SET_LOCAL 2>$STDERR
 
 pass

--- a/src/test/obj_rpmem_basic_integration/TEST8
+++ b/src/test/obj_rpmem_basic_integration/TEST8
@@ -61,6 +61,8 @@ require_node_libfabric 2 $RPMEM_PROVIDER
 
 init_rpmem_on_node 0 1 2
 
+STDERR=stderr${UNITTEST_NUM}.log
+
 # binary for this test
 EXE=obj_basic_integration
 
@@ -87,6 +89,6 @@ copy_files_to_node 1 . $DIR/${TEST_SET_REMOTE}1
 copy_files_to_node 2 . $DIR/${TEST_SET_REMOTE}2
 
 # execute test
-expect_abnormal_exit run_on_node 0 ./$EXE$EXESUFFIX $TEST_SET_LOCAL
+expect_abnormal_exit run_on_node 0 ./$EXE$EXESUFFIX $TEST_SET_LOCAL 2>$STDERR
 
 pass


### PR DESCRIPTION
Redirect stderr in obj_rpmem_basic_integration/TEST4 and TEST8 to a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1215)
<!-- Reviewable:end -->
