### PR TITLE
obj: fix possible NULL dereference

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1494,6 +1494,10 @@ pmemobj_pool_by_oid(PMEMoid oid)
 {
 	LOG(3, "oid.off 0x%016jx", oid.off);
 
+	/* XXX this is a temporary fix, to be fixed properly later */
+	if (pools_ht == NULL)
+		return NULL;
+
 	return cuckoo_get(pools_ht, oid.pool_uuid_lo);
 }
 
@@ -1504,6 +1508,10 @@ PMEMobjpool *
 pmemobj_pool_by_ptr(const void *addr)
 {
 	LOG(3, "addr %p", addr);
+
+	/* XXX this is a temporary fix, to be fixed properly later */
+	if (pools_tree == NULL)
+		return NULL;
 
 	uint64_t key = (uint64_t)addr;
 	size_t pool_size = ctree_find_le(pools_tree, &key);

--- a/src/test/obj_pool_lookup/obj_pool_lookup.c
+++ b/src/test/obj_pool_lookup/obj_pool_lookup.c
@@ -52,6 +52,12 @@ main(int argc, char *argv[])
 	const char *dir = argv[1];
 	int r;
 
+	/* check before pool creation */
+	PMEMoid some_oid = {2, 3};
+
+	UT_ASSERTeq(pmemobj_pool_by_ptr(&some_oid), NULL);
+	UT_ASSERTeq(pmemobj_pool_by_oid(some_oid), NULL);
+
 	PMEMobjpool **pops = MALLOC(npools * sizeof(PMEMobjpool *));
 	void **guard_after = MALLOC(npools * sizeof(void *));
 


### PR DESCRIPTION
Add check for uninitialized global structures before first pool open
in `pmemobj_pool_by_ptr` and `pmemobj_pool_by_oid`. Introduced by
fb7cd8761ca51cfbbefcf33fba237c8ef95c42dc.

Refs: pmem/issues#238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1218)
<!-- Reviewable:end -->
