### PR TITLE
common: remove pandoc dependency from spec

### DIFF
--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -197,7 +197,7 @@ Source0:	$PACKAGE_TARBALL
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:	gcc glibc-devel
-BuildRequires:	autoconf, automake, make, pandoc, doxygen
+BuildRequires:	autoconf, automake, make, doxygen
 BuildArch:	x86_64
 
 %description


### PR DESCRIPTION
A temporary workaround for RPM's build issue on RedHat.
Since there is no pandoc package available, rpm build fails on pandoc
dependency, even if pandoc is actually installed (from source).