### PR TITLE
common: add util_convert_hdr_remote

### DIFF
--- a/src/common/pool_hdr.c
+++ b/src/common/pool_hdr.c
@@ -109,6 +109,32 @@ util_convert_hdr(struct pool_hdr *hdrp)
 }
 
 /*
+ * util_convert_hdr_remote -- convert remote header to host byte order
+ *                            and validate
+ *
+ * Returns true if header is valid, and all the integer fields are
+ * converted to host byte order.  If the header is not valid, this
+ * routine returns false and the header passed in is left in an
+ * unknown state.
+ */
+int
+util_convert_hdr_remote(struct pool_hdr *hdrp)
+{
+	LOG(3, "hdrp %p", hdrp);
+
+	util_convert2h_hdr_nocheck(hdrp);
+
+	/* and to be valid, the fields must checksum correctly */
+	if (!util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum, 0)) {
+		ERR("invalid checksum of pool header");
+		return 0;
+	}
+
+	LOG(3, "valid header, signature \"%.8s\"", hdrp->signature);
+	return 1;
+}
+
+/*
  * util_arch_flags_check -- validates arch_flags
  */
 int

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -115,6 +115,7 @@ struct pool_hdr {
 void util_convert2le_hdr(struct pool_hdr *hdrp);
 void util_convert2h_hdr_nocheck(struct pool_hdr *hdrp);
 int util_convert_hdr(struct pool_hdr *hdrp);
+int util_convert_hdr_remote(struct pool_hdr *hdrp);
 int util_get_arch_flags(struct arch_flags *arch_flags);
 int util_check_arch_flags(const struct arch_flags *arch_flags);
 

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1517,7 +1517,7 @@ util_header_check_remote(struct pool_replica *rep, unsigned partidx)
 
 	memcpy(&hdr, hdrp, sizeof(hdr));
 
-	if (!util_convert_hdr(&hdr)) {
+	if (!util_convert_hdr_remote(&hdr)) {
 		errno = EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
...that does not validate the major number
when opening a remote replica.

Ref: pmem/issues#279

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1229)
<!-- Reviewable:end -->
