### PR TITLE
common: speed up travis

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -140,6 +140,8 @@ endif
 
 INC_PREFIX ?= include
 
+test_build=$(addprefix -b, $(TEST_BUILD))
+
 export libdir := $(exec_prefix)/$(LIB_PREFIX)
 export includedir := $(prefix)/$(INC_PREFIX)
 export pkgconfigdir := $(libdir)/pkgconfig

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -369,11 +369,11 @@ memcheck-summary-leaks:
 	grep "in use at exit" */memcheck*.log | grep -v " 0 bytes in 0 blocks" || true
 
 check: test
-	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(TESTS)
+	@./RUNTESTS $(test_build) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(TESTS)
 	@echo "No failures."
 
 check-remote-quiet: test
-	@./RUNTESTS -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(REMOTE_TESTS)
+	@./RUNTESTS $(test_build) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) $(CHECK_POOL_OPT) $(REMOTE_TESTS)
 
 check-remote: check-remote-quiet
 	@echo "No failures."

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -287,10 +287,10 @@ TST=$(shell basename `pwd`)
 TSTCHECKS=$(shell ls -1 TEST* | grep -v -i -e "\.ps1" | sort -V)
 
 $(TSTCHECKS): all sync-test
-	@cd .. && ./RUNTESTS ${TST} -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) -p $(PMEMCHECK) -e $(HELGRIND) -d $(DRD) -s $@
+	@cd .. && ./RUNTESTS ${TST} $(test_build) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) -p $(PMEMCHECK) -e $(HELGRIND) -d $(DRD) -s $@
 
 check: all sync-test
-	@cd .. && ./RUNTESTS ${TST} -b $(TEST_BUILD) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) -p $(PMEMCHECK) -e $(HELGRIND) -d $(DRD)
+	@cd .. && ./RUNTESTS ${TST} $(test_build) -t $(TEST_TYPE) -f $(TEST_FS) -o $(TEST_TIME) -m $(MEMCHECK) -p $(PMEMCHECK) -e $(HELGRIND) -d $(DRD)
 
 pcheck: export NOTTY=1
 

--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -178,7 +178,7 @@ EOF
 #
 # defaults...
 #
-buildtype=all
+def_buildtype=all
 testtype=check
 fstype=all
 testconfig="./testconfig.sh"
@@ -209,9 +209,8 @@ do
 		shift
 		;;
 	-b)
-		buildtype="$2"
-		shift 2
-		case "$buildtype"
+		buildtype="$buildtype $2"
+		case "$2"
 		in
 		debug|nondebug|static-debug|static-nondebug|all)
 			;;
@@ -219,6 +218,7 @@ do
 			usage "bad build-type: $buildtype"
 			;;
 		esac
+		shift 2
 		;;
 	-t)
 		testtype="$2"
@@ -342,6 +342,9 @@ do
 		;;
 	esac
 done
+
+[ -z "$buildtype" ] && buildtype=$def_buildtype
+[[ $buildtype =~ .*all.* ]] && buildtype=all
 
 
 [ "$verbose" ] && {

--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -55,6 +55,7 @@ NODE_ADDR[1]=127.0.0.1
 NODE[2]=127.0.0.1
 NODE_WORKING_DIR[2]=/tmp/node2
 NODE_ADDR[2]=127.0.0.1
+RPMEM_PROVIDERS=sockets
 EOF
 
 	mkdir -p ~/.ssh/cm

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -44,6 +44,6 @@ make check-license \
 	&& make cstyle \
 	&& make -j2 USE_LIBUNWIND=1 \
 	&& make -j2 test USE_LIBUNWIND=1 \
-	&& make -j2 pcheck \
+	&& make -j2 pcheck TEST_BUILD="debug nondebug"\
 	&& make DESTDIR=/tmp source
 


### PR DESCRIPTION
Speed up travis builds by running tests on debug
and nondebug builds in 3 of 6 jobs and by forcing running
remote tests on sockets provider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1232)
<!-- Reviewable:end -->
