### PR TITLE
Bash 4.4 compatibility fixes

### DIFF
--- a/src/test/libpmempool_bttdev/TEST8
+++ b/src/test/libpmempool_bttdev/TEST8
@@ -57,7 +57,7 @@ declare -A btt_info_dic_err=(["sig"]="ERROR" ["uuid"]="01-02"
 	["dataoff"]="7" ["infooff"]="7" ["unused"]="7"
 	["parent_uuid"]="03-04" ["mapoff"]="7" ["flogoff"]="7")
 
-for field in "${!btt_info_dic_err[@]}";
+for field in flags unused major sig nextoff infosize infooff dataoff nfree mapoff uuid parent_uuid flogoff minor
 do
 	spcmd="bttdevice.arena(0).btt_info.$field=${btt_info_dic_err["$field"]}"
 

--- a/src/test/libpmempool_bttdev/TEST9
+++ b/src/test/libpmempool_bttdev/TEST9
@@ -56,7 +56,7 @@ declare -A btt_info_dic_err=(["sig"]="ERROR" ["uuid"]="01-02"
 	["nfree"]="7" ["infosize"]="7" ["nextoff"]="7"
 	["dataoff"]="7" ["infooff"]="7" ["unused"]="7")
 
-for field in "${!btt_info_dic_err[@]}";
+for field in flags unused major sig nextoff infosize infooff dataoff nfree uuid minor
 do
 	spcmd=$spcmd"bttdevice.arena(0).btt_info.$field=${btt_info_dic_err["$field"]} "
 

--- a/src/test/libpmempool_map_flog/TEST0
+++ b/src/test/libpmempool_map_flog/TEST0
@@ -54,7 +54,7 @@ declare -A map_err=(["Initial"]="0" ["Error"]="4"
 
 ent_val=2
 
-for field in "${!map_err[@]}";
+for field in Zeroed Error Initial Normal;
 do
 	for((i=0;i<ent_val;i++));
 	do

--- a/src/test/libpmempool_map_flog/TEST1
+++ b/src/test/libpmempool_map_flog/TEST1
@@ -54,7 +54,7 @@ declare -A map_err=(["Initial"]="0" ["Error"]="4"
 
 ent_val=6
 
-for field in "${!map_err[@]}";
+for field in Zeroed Error Initial Normal;
 do
 	expect_normal_exit $BTTCREATE $POOL
 

--- a/src/test/libpmempool_map_flog/TEST2
+++ b/src/test/libpmempool_map_flog/TEST2
@@ -54,7 +54,7 @@ declare -A map_err=(["Initial"]="0" ["Error"]="4"
 
 ent_val=9
 
-for field in "${!map_err[@]}";
+for field in Zeroed Error Initial Normal;
 do
 	expect_normal_exit $BTTCREATE $POOL
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -456,7 +456,7 @@ function create_poolset() {
 		fpath=`readlink -mn ${fparms[1]}`
 		cmd=${fparms[2]}
 		asize=${fparams[3]}
-		mode=${fparms[4]]}
+		mode=${fparms[4]}
 
 		if [ ! $asize ]; then
 			asize=$fsize

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1860,7 +1860,7 @@ check_signature()
 {
 	local sig=$1
 	local file=$2
-	local file_sig=$(dd if=$file bs=1 count=$SIG_LEN 2>/dev/null)
+	local file_sig=$(dd if=$file bs=1 count=$SIG_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $sig != $file_sig ]]
 	then
@@ -1890,7 +1890,7 @@ check_layout()
 	local layout=$1
 	local file=$2
 	local file_layout=$(dd if=$file bs=1\
-		skip=$LAYOUT_OFFSET count=$LAYOUT_LEN 2>/dev/null)
+		skip=$LAYOUT_OFFSET count=$LAYOUT_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $layout != $file_layout ]]
 	then
@@ -1905,7 +1905,7 @@ check_layout()
 check_arena()
 {
 	local file=$1
-	local sig=$(dd if=$file bs=1 skip=$ARENA_OFF count=$ARENA_SIG_LEN 2>/dev/null)
+	local sig=$(dd if=$file bs=1 skip=$ARENA_OFF count=$ARENA_SIG_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $sig != $ARENA_SIG ]]
 	then


### PR DESCRIPTION
Bash 4.4 got stricter in parsing (patch 1), started to warn about suspicious operations (patch 2) and changed "map.keys()" implementation, which broke our tests (patch 3).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1248)
<!-- Reviewable:end -->
