### PR TITLE
bugfix: reallocation of int array

### DIFF
--- a/src/examples/libpmemobj/array/array.c
+++ b/src/examples/libpmemobj/array/array.c
@@ -235,7 +235,7 @@ realloc_int(PMEMoid *info, size_t prev_size, size_t size)
 {
 	TOID(int) array;
 	TOID_ASSIGN(array, *info);
-	POBJ_REALLOC(pop, &array, int, size);
+	POBJ_REALLOC(pop, &array, int, size * sizeof(int));
 	for (int i = prev_size; i < size; i++)
 			D_RW(array)[i] = i;
 	return array.oid;
@@ -309,7 +309,7 @@ alloc_int(size_t size)
 
 	for (int i = 0; i < size; i++)
 		D_RW(array)[i] = i;
-	pmemobj_persist(pop, D_RW(array), sizeof(*D_RW(array)));
+	pmemobj_persist(pop, D_RW(array), size * sizeof(*D_RW(array)));
 	return array.oid;
 }
 
@@ -339,7 +339,7 @@ alloc_pmemoid(size_t size)
 			fprintf(stderr, "pmemobj_alloc\n");
 		}
 	}
-	pmemobj_persist(pop, D_RW(array), sizeof(*D_RW(array)));
+
 	return array.oid;
 }
 
@@ -372,7 +372,6 @@ alloc_toid(size_t size)
 			assert(0);
 		}
 	}
-	pmemobj_persist(pop, D_RW(array), sizeof(*D_RW(array)));
 	return array.oid;
 }
 


### PR DESCRIPTION
Hi NVML Team,

I have fixed a small error in the libpmemobj array example a couple of weeks ago. After receiving an E-Mail from one of your maintainers I submit this fix as a pull request.

Best,
Roger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1257)
<!-- Reviewable:end -->
