### PR TITLE
test: fix one reason why obj_pmalloc_mt test fails

### DIFF
--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -206,5 +206,7 @@ main(int argc, char *argv[])
 	run_worker(tx_worker, args);
 	run_worker(alloc_free_worker, args);
 
+	pmemobj_close(pop);
+
 	DONE(NULL);
 }


### PR DESCRIPTION
It's marked as "long", so it's not executed on each pull request.

It fails because framework detects resource leak:
{ut.c:254 open_file_remove} obj_pmalloc_mt/TEST0: unexpected open file: fd 9 => "/tmp/nvml-qa/test_obj_pmalloc_mt0/testfile"
{ut.c:373 check_open_files} obj_pmalloc_mt/TEST0: Error: open file list changed between START() and DONE()

The other reason it fails is much deeper (helgrind finds some races)
and needs to be investigated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1261)
<!-- Reviewable:end -->
