### PR TITLE
libpmempool: do not open poolsets with remote replicas

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1231,12 +1231,12 @@ util_poolset_read(struct pool_set **setp, const char *path)
 }
 
 /*
- * util_poolset_create_set -- (internal) create a new pool set structure
+ * util_poolset_create_set -- create a new pool set structure
  *
  * On success returns 0 and a pointer to a newly allocated structure
  * containing the info of all the parts of the pool set and replicas.
  */
-static int
+int
 util_poolset_create_set(struct pool_set **setp, const char *path,
 				size_t poolsize, size_t minsize)
 {
@@ -2266,21 +2266,14 @@ util_replica_check(struct pool_set *set, const char *sig, uint32_t major,
  * This function opens opens a pool set without checking the header values.
  */
 int
-util_pool_open_nocheck(struct pool_set **setp, const char *path, int rdonly)
+util_pool_open_nocheck(struct pool_set *set, int rdonly)
 {
-	LOG(3, "setp %p path %s rdonly %i", setp, path, rdonly);
+	LOG(3, "set %p rdonly %i", set, rdonly);
 
 	int flags = rdonly ? MAP_PRIVATE|MAP_NORESERVE : MAP_SHARED;
 	int oerrno;
 
-	int ret = util_poolset_create_set(setp, path, 0, 0);
-	if (ret < 0) {
-		LOG(2, "cannot open pool set -- '%s'", path);
-		return -1;
-	}
-
-	struct pool_set *set = *setp;
-
+	ASSERTne(set, NULL);
 	ASSERT(set->nreplicas > 0);
 
 	if (set->remote && util_remote_load()) {
@@ -2290,7 +2283,7 @@ util_pool_open_nocheck(struct pool_set **setp, const char *path, int rdonly)
 		return -1;
 	}
 
-	ret = util_poolset_files_local(set, 0, 0);
+	int ret = util_poolset_files_local(set, 0, 0);
 	if (ret != 0)
 		goto err_poolset;
 

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -118,6 +118,8 @@ struct part_file {
 
 int util_poolset_parse(struct pool_set **setp, const char *path, int fd);
 int util_poolset_read(struct pool_set **setp, const char *path);
+int util_poolset_create_set(struct pool_set **setp, const char *path,
+	size_t poolsize, size_t minsize);
 int util_poolset_open(struct pool_set *set);
 void util_poolset_close(struct pool_set *set, int del);
 void util_poolset_free(struct pool_set *set);
@@ -160,8 +162,7 @@ int util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 int util_map_hdr(struct pool_set_part *part, int flags);
 int util_unmap_hdr(struct pool_set_part *part);
 
-int util_pool_open_nocheck(struct pool_set **setp, const char *path,
-	int rdonly);
+int util_pool_open_nocheck(struct pool_set *set, int rdonly);
 int util_pool_open(struct pool_set **setp, const char *path, int rdonly,
 	size_t minsize, const char *sig, uint32_t major, uint32_t compat,
 	uint32_t incompat, uint32_t ro_compat, unsigned *nlanes);

--- a/src/test/rpmem_basic/rpmem_basic.c
+++ b/src/test/rpmem_basic/rpmem_basic.c
@@ -378,7 +378,9 @@ check_pool(const struct test_case *tc, int argc, char *argv[])
 	ret = util_parse_size(argv[2], &size);
 
 	struct pool_set *set;
-	ret = util_pool_open_nocheck(&set, pool_set, 0);
+	ret = util_poolset_create_set(&set, pool_set, 0, 0);
+	UT_ASSERTeq(ret, 0);
+	ret = util_pool_open_nocheck(set, 0);
 	UT_ASSERTeq(ret, 0);
 
 	uint8_t *data = set->replica[0]->part[0].addr;
@@ -407,7 +409,9 @@ fill_pool(const struct test_case *tc, int argc, char *argv[])
 	int ret;
 
 	struct pool_set *set;
-	ret = util_pool_open_nocheck(&set, pool_set, 0);
+	ret = util_poolset_create_set(&set, pool_set, 0, 0);
+	UT_ASSERTeq(ret, 0);
+	ret = util_pool_open_nocheck(set, 0);
 	UT_ASSERTeq(ret, 0);
 
 	uint8_t *data = set->replica[0]->part[0].addr;

--- a/src/tools/rpmemd/rpmemd_db.c
+++ b/src/tools/rpmemd/rpmemd_db.c
@@ -328,7 +328,10 @@ rpmemd_db_pool_remove(struct rpmemd_db *db, const char *pool_desc)
 		goto err_unlock;
 	}
 
-	ret = util_pool_open_nocheck(&set, path, 0);
+	ret = util_poolset_create_set(&set, path, 0, 0);
+	if (ret == 0) {
+		ret = util_pool_open_nocheck(set, 0);
+	}
 	if (ret) {
 		RPMEMD_LOG(ERR, "!cannot open pool set -- '%s'", path);
 		goto err_free_path;


### PR DESCRIPTION
Prevent from opening poolset if it contains remote replicas.
fixes pmem/issues#290

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1266)
<!-- Reviewable:end -->
