### PR TITLE
test: fix pmempool_sync/TEST5

### DIFF
--- a/src/test/pmempool_sync/TEST5
+++ b/src/test/pmempool_sync/TEST5
@@ -74,8 +74,8 @@ rm -f $DIR/testfile01
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-ls -l $DIR/testfile00 | cut -f1 -d' ' >> $LOG_TEMP
-ls -l $DIR/testfile01 | cut -f1 -d' ' >> $LOG_TEMP
+stat -c %A $DIR/testfile00 >> $LOG_TEMP
+stat -c %A $DIR/testfile01 >> $LOG_TEMP
 
 # Delete the first part in the second replica
 rm -f $DIR/testfile10
@@ -87,8 +87,8 @@ chmod 600 $DIR/testfile*
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-ls -l $DIR/testfile10 | cut -f1 -d' ' >> $LOG_TEMP
-ls -l $DIR/testfile11 | cut -f1 -d' ' >> $LOG_TEMP
+stat -c %A $DIR/testfile10 >> $LOG_TEMP
+stat -c %A $DIR/testfile11 >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG
 check


### PR DESCRIPTION
Use 'stat -c %A <file>' instead of 'ls -l <file> | cut -f1 -d' ' '
because there can be one additional character ('.' or '+')
following the file mode bits (specifing whether an alternate
access method such as an access control list (ACL) applies to the file)
and in such case the 'out5.log.match' file does not match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1273)
<!-- Reviewable:end -->
