### PR TITLE
libpmempool: do not assume new_map must be in map

### DIFF
--- a/src/libpmempool/check_btt_map_flog.c
+++ b/src/libpmempool/check_btt_map_flog.c
@@ -447,15 +447,12 @@ flog_entry_check(PMEMpoolcheck *ppc, union location *loc, uint32_t i,
 		 * - current_btt_flog.seq == 0b01 and
 		 * - second flog entry in pair is zeroed
 		 * or
-		 * btt_map[current_btt_flog.lba] == current_btt_flog.new_map
+		 * current_btt_flog.old_map != current_btt_flog.new_map
 		 */
 		if (entry == new_entry)
 			flog_valid = (next == 1) && (flog_cur->seq == 1) &&
 				util_is_zeroed((const void *)&flog[1],
 				sizeof(flog[1]));
-		else
-			flog_valid = (loc->arenap->map[flog_cur->lba] &
-				BTT_MAP_ENTRY_LBA_MASK) == new_entry;
 
 		if (flog_valid) {
 			/* totally fine case */

--- a/src/test/libpmempool_map_flog/out2.log.match
+++ b/src/test/libpmempool_map_flog/out2.log.match
@@ -22,18 +22,12 @@ arena 0: checking BTT Map and Flog
 arena 0: invalid BTT Flog entry at 3
 arena 0: invalid BTT Flog entry at 4
 arena 0: invalid BTT Flog entry at 5
-arena 0: invalid BTT Flog entry at 7
-arena 0: invalid BTT Flog entry at 8
 arena 0: unmapped block 40325
 arena 0: unmapped block 40326
 arena 0: unmapped block 40327
-arena 0: unmapped block 40329
-arena 0: unmapped block 40330
-arena 0: number of unmapped blocks: 5
-arena 0: number of invalid BTT Flog entries: 5
+arena 0: number of unmapped blocks: 3
+arena 0: number of invalid BTT Flog entries: 3
 Do you want to repair invalid BTT Flog entries?
-arena 0: repairing BTT Flog at 8 with free block entry 0x40009d8a
-arena 0: repairing BTT Flog at 7 with free block entry 0x40009d89
 arena 0: repairing BTT Flog at 5 with free block entry 0x40009d87
 arena 0: repairing BTT Flog at 4 with free block entry 0x40009d86
 arena 0: repairing BTT Flog at 3 with free block entry 0x40009d85
@@ -63,18 +57,12 @@ arena 0: checking BTT Map and Flog
 arena 0: invalid BTT Flog entry at 3
 arena 0: invalid BTT Flog entry at 4
 arena 0: invalid BTT Flog entry at 5
-arena 0: invalid BTT Flog entry at 7
-arena 0: invalid BTT Flog entry at 8
 arena 0: unmapped block 40325
 arena 0: unmapped block 40326
 arena 0: unmapped block 40327
-arena 0: unmapped block 40329
-arena 0: unmapped block 40330
-arena 0: number of unmapped blocks: 5
-arena 0: number of invalid BTT Flog entries: 5
+arena 0: number of unmapped blocks: 3
+arena 0: number of invalid BTT Flog entries: 3
 Do you want to repair invalid BTT Flog entries?
-arena 0: repairing BTT Flog at 8 with free block entry 0x40009d8a
-arena 0: repairing BTT Flog at 7 with free block entry 0x40009d89
 arena 0: repairing BTT Flog at 5 with free block entry 0x40009d87
 arena 0: repairing BTT Flog at 4 with free block entry 0x40009d86
 arena 0: repairing BTT Flog at 3 with free block entry 0x40009d85
@@ -104,18 +92,12 @@ arena 0: checking BTT Map and Flog
 arena 0: invalid BTT Flog entry at 3
 arena 0: invalid BTT Flog entry at 4
 arena 0: invalid BTT Flog entry at 5
-arena 0: invalid BTT Flog entry at 7
-arena 0: invalid BTT Flog entry at 8
 arena 0: unmapped block 40325
 arena 0: unmapped block 40326
 arena 0: unmapped block 40327
-arena 0: unmapped block 40329
-arena 0: unmapped block 40330
-arena 0: number of unmapped blocks: 5
-arena 0: number of invalid BTT Flog entries: 5
+arena 0: number of unmapped blocks: 3
+arena 0: number of invalid BTT Flog entries: 3
 Do you want to repair invalid BTT Flog entries?
-arena 0: repairing BTT Flog at 8 with free block entry 0x40009d8a
-arena 0: repairing BTT Flog at 7 with free block entry 0x40009d89
 arena 0: repairing BTT Flog at 5 with free block entry 0x40009d87
 arena 0: repairing BTT Flog at 4 with free block entry 0x40009d86
 arena 0: repairing BTT Flog at 3 with free block entry 0x40009d85
@@ -145,18 +127,12 @@ arena 0: checking BTT Map and Flog
 arena 0: invalid BTT Flog entry at 3
 arena 0: invalid BTT Flog entry at 4
 arena 0: invalid BTT Flog entry at 5
-arena 0: invalid BTT Flog entry at 7
-arena 0: invalid BTT Flog entry at 8
 arena 0: unmapped block 40325
 arena 0: unmapped block 40326
 arena 0: unmapped block 40327
-arena 0: unmapped block 40329
-arena 0: unmapped block 40330
-arena 0: number of unmapped blocks: 5
-arena 0: number of invalid BTT Flog entries: 5
+arena 0: number of unmapped blocks: 3
+arena 0: number of invalid BTT Flog entries: 3
 Do you want to repair invalid BTT Flog entries?
-arena 0: repairing BTT Flog at 8 with free block entry 0x40009d8a
-arena 0: repairing BTT Flog at 7 with free block entry 0x40009d89
 arena 0: repairing BTT Flog at 5 with free block entry 0x40009d87
 arena 0: repairing BTT Flog at 4 with free block entry 0x40009d86
 arena 0: repairing BTT Flog at 3 with free block entry 0x40009d85


### PR DESCRIPTION
After write map[lba] == flog_entry.new_map. But map[lba] can be altered by
following writes to the same lba.
fixes pmem/issues#283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1274)
<!-- Reviewable:end -->
