### PR TITLE
obj: fix benign race in the huge chunk free logic

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -735,7 +735,15 @@ heap_ensure_bucket_filled(struct palloc_heap *heap, struct bucket *b)
 
 		ASSERT(m.block_off == 0);
 
+		/*
+		 * The default bucket is still the owner of the chunk, up to the
+		 * moment that the chunk type is changed to run. This lock is
+		 * especially important in the free codepath when we are
+		 * searching for neighbour blocks in blocks list.
+		 */
+		util_mutex_lock(&def_bucket->lock);
 		heap_create_run(heap, b, m.chunk_id, m.zone_id);
+		util_mutex_unlock(&def_bucket->lock);
 	} else {
 		heap_reuse_run(heap, b, m.chunk_id, m.zone_id);
 	}


### PR DESCRIPTION
The free code path includes a coalescing step that searches for the
neighbouring blocks by traversing the on-media layout and than it verified
the ownership of the block by looking it up in the bucket tree. Due to the
fact that the lock during that process is the bucket lock, the layout was
left unprotected. In general that algorithm was correct but it produced
errors in helgrind, so for correctness sake from now on the on-media layout
is protected by the default bucket lock. This should have minimal impact
on scaling but will ensure that the thread error detecting tools will be
happy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1283)
<!-- Reviewable:end -->
