### PR TITLE
ut: disable timeouts when TRACE var is used

### DIFF
--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -378,6 +378,10 @@ if [ $? != 0 ]; then
 	unset use_timeout
 fi
 
+if [ -n "$TRACE" ]; then
+	unset use_timeout
+fi
+
 if [ "$1" ]; then
 	for test in $*
 	do


### PR DESCRIPTION
Useful when gdb session takes more than 3 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1284)
<!-- Reviewable:end -->
