### PR TITLE
doc: pmempool does not support remote replicas

### DIFF
--- a/doc/libpmempool.3.md
+++ b/doc/libpmempool.3.md
@@ -191,6 +191,9 @@ described by the *backup_path* *poolset*.
 
 Backup is supported only if the source *poolset* has no defined replicas.
 
+Poolsets with remote replicas are not supported neither as *path* nor as
+*backup_path*.
+
 This is an example of a *check context* initialization:
 
 ```c

--- a/doc/pmempool-check.1.md
+++ b/doc/pmempool-check.1.md
@@ -122,5 +122,5 @@ increased verbosity level.
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemlog**(3), **libpmemblk**(3), **libpmemobj**(3)
-and **<http://pmem.io>**
+**pmempool**(1), **libpmempool**(3), **libpmemlog**(3), **libpmemblk**(3),
+**libpmemobj**(3) and **<http://pmem.io>**

--- a/doc/pmempool-convert.1.md
+++ b/doc/pmempool-convert.1.md
@@ -79,5 +79,5 @@ Updates pool.obj to the latest layout version.
 
 # SEE ALSO #
 
-**pmempool**(1), **libpmemlog**(3), **libpmemblk**(3), **libpmemobj**(3)
-and **<http://pmem.io>**
+**pmempool**(1), **libpmempool**(3), **libpmemlog**(3), **libpmemblk**(3),
+**libpmemobj**(3) and **<http://pmem.io>**

--- a/doc/pmempool-sync.1.md
+++ b/doc/pmempool-sync.1.md
@@ -77,4 +77,4 @@ viability of synchronization.
 
 # SEE ALSO #
 
-**libpmemblk(3)**, **libpmemlog(3)**, **pmempool(1)**
+**libpmempool(3)**, **libpmemblk(3)**, **libpmemlog(3)**, **pmempool(1)**

--- a/doc/pmempool-transform.1.md
+++ b/doc/pmempool-transform.1.md
@@ -164,4 +164,4 @@ unchanged and the size of the pool is still 60M.
 
 # SEE ALSO #
 
-**libpmemblk(3)**, **libpmemlog(3)**, **pmempool(1)**
+**libpmempool(3)**, **libpmemblk(3)**, **libpmemlog(3)**, **pmempool(1)**


### PR DESCRIPTION
Add missing references to libpmempool and add information about lack
of support for remote replicas.
fixes pmem/issues#290

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1294)
<!-- Reviewable:end -->
