### PR TITLE
pmempool: fixes incorrect obj poolset size

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1242,6 +1242,7 @@ pmemobj_open_common(const char *path, const char *layout, int cow, int boot)
 
 	/* pop is master replica from now on */
 	pop = set->replica[0]->part[0].addr;
+	set->poolsize = pop->heap_offset + pop->heap_size;
 
 	for (unsigned r = 0; r < set->nreplicas; r++) {
 		struct pool_replica *repset = set->replica[r];

--- a/src/test/pmempool_transform/TEST4
+++ b/src/test/pmempool_transform/TEST4
@@ -115,8 +115,8 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX transform \
 	$POOLSET_IN $POOLSET_OUT >> $LOG_TEMP
 
 # Check if correctly read
-#expect_normal_exit $PMEMOBJCLI$EXESUFFIX -s $READ_SCRIPT $POOLSET_OUT >> \
-#	$LOG_TEMP
+expect_normal_exit $PMEMOBJCLI$EXESUFFIX -s $READ_SCRIPT $POOLSET_OUT >> \
+	$LOG_TEMP
 
 # Check metadata by pmempool info
 dump_pool_info $DIR/testfile00 >> $LOG_TEMP

--- a/src/test/pmempool_transform/out4.log.match
+++ b/src/test/pmempool_transform/out4.log.match
@@ -18,6 +18,8 @@ REPLICA
 pr(26214400): off = 0x382440 uuid = $(nW)
 TestOK111
 TestOK111
+TestOK111
+TestOK111
 POOL Header:
 Signature                : PMEMOBJ [part file]
 Major                    : 2


### PR DESCRIPTION
Ref: pmem/issues#261

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1319)
<!-- Reviewable:end -->
