### PR TITLE
test: workaround clang bug

### DIFF
--- a/src/test/obj_tx_callbacks/obj_tx_callbacks.c
+++ b/src/test/obj_tx_callbacks/obj_tx_callbacks.c
@@ -100,7 +100,8 @@ allocate_pmem(struct free_info *f, TOID(struct pmem_root) root, int val)
 static void
 do_something_fishy(TOID(struct pmem_root) root)
 {
-	(void) TX_ALLOC(struct pmem_obj, 1 << 30);
+	TX_ADD_FIELD(root, obj);
+	D_RW(root)->obj = TX_ALLOC(struct pmem_obj, 1 << 30);
 }
 
 static void


### PR DESCRIPTION
Old versions of clang optimize away TX_ALLOC with void cast.
Just save its value to root->obj.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1323)
<!-- Reviewable:end -->
