### PR TITLE
obj: increase the pool size for pmalloc_mt test

### DIFF
--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -176,7 +176,9 @@ main(int argc, char *argv[])
 
 	if (access(argv[1], F_OK) != 0) {
 		pop = pmemobj_create(argv[1], "TEST",
-		THREADS * OPS_PER_THREAD * ALLOC_SIZE * FRAGMENTATION, 0666);
+		PMEMOBJ_MIN_POOL +
+		(THREADS * OPS_PER_THREAD * ALLOC_SIZE * FRAGMENTATION),
+		0666);
 	} else {
 		if ((pop = pmemobj_open(argv[1], "TEST")) == NULL) {
 			printf("failed to open pool\n");


### PR DESCRIPTION
This test had narrowly calculated pool size that did not account for
metadata nor the per-thread allocator caches, which manifested itself as
sporadic fails in environments with high number of CPUs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1324)
<!-- Reviewable:end -->
