### PR TITLE
rpmem: fix detecting libibverbs

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -148,26 +148,19 @@ export pkgconfigdir := $(libdir)/pkgconfig
 export bindir := $(exec_prefix)/bin
 export bashcompdir := $(sysconfdir)/bash_completion.d
 
-export HAS_LIBFABRIC = $(call check_package, libfabric)
-export HAS_LIBIBVERBS = $(shell fi_info --list 2>/dev/null | grep -q verbs && echo y || echo n)
+check_ibv_fork_init = $(shell echo "\#include <infiniband/verbs.h> int main(void) { return ibv_fork_init(); }" |\
+	$(CC) -c $(CFLAGS) -x c -o /dev/null -libverbs - 2>/dev/null && echo y || echo n)
 
-ifeq ($(HAS_LIBFABRIC)$(HAS_LIBIBVERBS),ny)
-$(error HAS_LIBFABRIC=$(HAS_LIBFABRIC) and HAS_LIBIBVERBS=$(HAS_LIBIBVERBS) not possible)
-endif
+export HAS_LIBFABRIC := $(call check_package, libfabric)
 
-ifeq ($(HAS_LIBFABRIC)$(HAS_LIBIBVERBS),nn)
-export BUILD_RPMEM := n
-endif
-
-ifeq ($(HAS_LIBFABRIC)$(HAS_LIBIBVERBS),yy)
-export BUILD_RPMEM := y
-endif
-
-ifeq ($(HAS_LIBFABRIC)$(HAS_LIBIBVERBS),yn)
+ifeq ($(HAS_LIBFABRIC),y)
 ifeq ($(RPMEM_DISABLE_LIBIBVERBS),y)
+export HAS_LIBIBVERBS := n
 export BUILD_RPMEM := y
+else
+export HAS_LIBIBVERBS := $(call check_ibv_fork_init)
+export BUILD_RPMEM := $(HAS_LIBIBVERBS)
+endif
 else
 export BUILD_RPMEM := n
 endif
-endif
-

--- a/src/examples/librpmem/Makefile
+++ b/src/examples/librpmem/Makefile
@@ -44,8 +44,8 @@ LIBS = -lrpmem -pthread $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS = $(shell $(PKG_CONFIG) --cflags libfabric)
 else
 ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libfabric is not compiled \
-with verbs provider. Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
+$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
+Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
 else
 $(info NOTE: Skipping librpmem because libfabric is missing \
 -- see src/librpmem/README for details.)

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -53,8 +53,8 @@ SOURCE = $(COMMON)/util.c\
 	rpmem_fip.c
 else
 ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libfabric is not compiled \
-with verbs provider. Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
+$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
+Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
 else
 $(info NOTE: Skipping librpmem because libfabric is missing \
 -- see src/librpmem/README for details.)

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -66,8 +66,8 @@ INSTALL_TARGET=$(EXPERIMENTAL)
 
 else
 ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libfabric is not compiled \
-with verbs provider. Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
+$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
+Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
 else
 $(info NOTE: Skipping rpmemd because libfabric is missing \
 -- see src/tools/rpmemd/README for details.)


### PR DESCRIPTION
Detect libibverbs availability by compilation minimal program with
ibverbs API. The fi_info turned out to be too slow in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1328)
<!-- Reviewable:end -->
