### PR TITLE
blk: remove dead code

### DIFF
--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -384,8 +384,6 @@ pmemblk_runtime_init(PMEMblkpool *pbp, size_t bsize, int rdonly, int is_pmem)
 err:
 	LOG(4, "error clean up");
 	int oerrno = errno;
-	if (locks)
-		Free((void *)locks);
 	if (bttp)
 		btt_fini(bttp);
 	errno = oerrno;


### PR DESCRIPTION
The locks will never be allocated in the err label, hence no need to
free them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1329)
<!-- Reviewable:end -->
