### PR TITLE
win: RUNTESTS.PS1 cleanup

### DIFF
--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -50,8 +50,6 @@ Param(
     $mreceivetype = "auto",
     [alias("p")]
     $preceivetype = "auto",
-    [alias("h")]
-    $hreceivetype = "auto",
     [alias("d")]
     $dreceivetype = "auto",
     [alias("o")]
@@ -61,7 +59,9 @@ Param(
     [alias("i")]
     $testdir = "all",
     [alias("c")]
-    $check_pool = "0"
+    $check_pool = "0",
+    [alias("h")][switch]
+    $help= $false
     )
 
 # -v is a built in PS thing
@@ -69,6 +69,11 @@ if ($VerbosePreference -ne 'SilentlyContinue') {
     $verbose = 1
 } else {
     $verbose = 0
+}
+
+if ($help) {
+    usage
+    exit 0
 }
 
 #
@@ -321,10 +326,10 @@ RUNTESTS: stopping because no testconfig.ps1 is found.
 
 if ($verbose -eq "1") {
     Write-Host -NoNewline "Options:"
-    if ($dryrun) {
+    if ($dryrun -eq "1") {
         Write-Host -NoNewline " -n"
     }
-    if ($verbose) {
+    if ($verbose -eq "1") {
         Write-Host -NoNewline " -v"
     }
     Write-Host ""


### PR DESCRIPTION
1. Fixed broken ifs
2. -h | -help should now print usage
3. removed unused command line parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1331)
<!-- Reviewable:end -->
