### PR TITLE
pmem: add flag for not flushing CPU cache

### DIFF
--- a/doc/libpmem.3.md
+++ b/doc/libpmem.3.md
@@ -550,6 +550,12 @@ processor caches on platforms that support the instruction, but where
 **CLWB** is not available. This variable is intended for use during
 library testing.
 
++ **PMEM_NO_FLUSH**=1
+
+Setting this environment variable to 1 forces **libpmem** to never issue
+any of **CLFLUSH**, **CLFLUSHOPT** or **CLWB** instructions on Intel hardware.
+This variable is intended for use during library testing.
+
 + **PMEM_NO_MOVNT**=1
 
 Setting this environment variable to 1 forces **libpmem** to never use


### PR DESCRIPTION
The PMEM_NO_FLUSH=1 environment variable can be used to force not
flushing the CPU cache. This variable is intended for library testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1334)
<!-- Reviewable:end -->
