### PR TITLE
obj: simplify palloc locking scheme

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -62,6 +62,8 @@
  */
 #define SIZE_TO_ALLOC_BLOCKS(_s) (1 + (((_s) - 1) / ALLOC_BLOCK_SIZE))
 
+#define BIT_IS_CLR(a, i)	(!((a) & (1ULL << (i))))
+
 int heap_boot(struct palloc_heap *heap, void *heap_start, uint64_t heap_size,
 		void *base, struct pmem_ops *p_ops);
 int heap_init(void *heap_start, uint64_t heap_size, struct pmem_ops *p_ops);
@@ -79,9 +81,6 @@ struct bucket *heap_get_auxiliary_bucket(struct palloc_heap *heap,
 void heap_drain_to_auxiliary(struct palloc_heap *heap, struct bucket *auxb,
 	uint32_t size_idx);
 void *heap_get_block_data(struct palloc_heap *heap, struct memory_block m);
-struct memory_block heap_coalesce(struct palloc_heap *heap,
-	struct memory_block *blocks[], int n, enum memblock_hdr_op op,
-	struct operation_context *ctx);
 
 int heap_get_adjacent_free_block(struct palloc_heap *heap, struct bucket *b,
 	struct memory_block *m, struct memory_block cnt, int prev);
@@ -105,10 +104,6 @@ typedef int (*object_callback)(uint64_t off, void *arg);
 
 void heap_foreach_object(struct palloc_heap *heap, object_callback cb,
 	void *arg, struct memory_block start);
-
-#ifdef DEBUG
-int heap_block_is_allocated(struct palloc_heap *heap, struct memory_block m);
-#endif /* DEBUG */
 
 void *heap_end(struct palloc_heap *heap);
 

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -154,11 +154,12 @@ enum memory_block_type {
 	MAX_MEMORY_BLOCK
 };
 
-enum memblock_hdr_op {
-	HDR_OP_ALLOC,
-	HDR_OP_FREE,
+enum memblock_state {
+	MEMBLOCK_STATE_UNKNOWN,
+	MEMBLOCK_ALLOCATED,
+	MEMBLOCK_FREE,
 
-	MAX_MEMBLOCK_HDR_OP
+	MAX_MEMBLOCK_STATE,
 };
 
 enum memory_block_type memblock_autodetect_type(struct memory_block *m,
@@ -169,9 +170,10 @@ struct memory_block_ops {
 	uint16_t (*block_offset)(struct memory_block *m,
 			struct palloc_heap *heap, void *ptr);
 	void (*prep_hdr)(struct memory_block *m, struct palloc_heap *heap,
-		enum memblock_hdr_op, struct operation_context *ctx);
-	void (*lock)(struct memory_block *m, struct palloc_heap *heap);
-	void (*unlock)(struct memory_block *m, struct palloc_heap *heap);
+		enum memblock_state, struct operation_context *ctx);
+	void *(*get_lock)(struct memory_block *m, struct palloc_heap *heap);
+	enum memblock_state (*get_state)(struct memory_block *m,
+		struct palloc_heap *heap);
 };
 
 extern const struct memory_block_ops mb_ops[MAX_MEMORY_BLOCK];

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -108,32 +108,16 @@ test_heap()
 		UT_ASSERT(blocks[i].block_off == 0);
 	}
 
-	struct memory_block *blocksp[MAX_BLOCKS] = {NULL};
-
 	struct memory_block prev;
 	heap_get_adjacent_free_block(heap, b_def, &prev, blocks[1], 1);
 	UT_ASSERT(prev.chunk_id == blocks[0].chunk_id);
-	blocksp[0] = &prev;
-
 	struct memory_block cnt;
 	heap_get_adjacent_free_block(heap, b_def, &cnt, blocks[0], 0);
 	UT_ASSERT(cnt.chunk_id == blocks[1].chunk_id);
-	blocksp[1] = &cnt;
 
 	struct memory_block next;
 	heap_get_adjacent_free_block(heap, b_def, &next, blocks[1], 0);
 	UT_ASSERT(next.chunk_id == blocks[2].chunk_id);
-	blocksp[2] = &next;
-
-	struct operation_context ctx;
-	operation_init(&ctx, pop, NULL, NULL);
-	ctx.p_ops = &pop->p_ops;
-	struct memory_block result =
-		heap_coalesce(heap, blocksp, MAX_BLOCKS, HDR_OP_FREE, &ctx);
-	operation_process(&ctx);
-
-	UT_ASSERT(result.size_idx == 3);
-	UT_ASSERT(result.chunk_id == prev.chunk_id);
 
 	UT_ASSERT(heap_check(heap_start, heap_size) == 0);
 	heap_cleanup(heap);

--- a/src/test/obj_memblock/obj_memblock.c
+++ b/src/test/obj_memblock/obj_memblock.c
@@ -178,27 +178,27 @@ test_prep_hdr()
 	run->bitmap[2] = 0ULL;
 
 	MEMBLOCK_OPS(, &mhuge_used)->prep_hdr(&mhuge_used,
-			heap, HDR_OP_FREE, NULL);
+			heap, MEMBLOCK_FREE, NULL);
 	UT_ASSERTeq(layout->zone0.chunk_headers[0].type, CHUNK_TYPE_FREE);
 
 	MEMBLOCK_OPS(, &mhuge_free)->prep_hdr(&mhuge_free,
-			heap, HDR_OP_ALLOC, NULL);
+			heap, MEMBLOCK_ALLOCATED, NULL);
 	UT_ASSERTeq(layout->zone0.chunk_headers[1].type, CHUNK_TYPE_USED);
 
 	MEMBLOCK_OPS(, &mrun_used)->prep_hdr(&mrun_used,
-			heap, HDR_OP_FREE, NULL);
+			heap, MEMBLOCK_FREE, NULL);
 	UT_ASSERTeq(run->bitmap[0], 0ULL);
 
 	MEMBLOCK_OPS(, &mrun_free)->prep_hdr(&mrun_free,
-			heap, HDR_OP_ALLOC, NULL);
+			heap, MEMBLOCK_ALLOCATED, NULL);
 	UT_ASSERTeq(run->bitmap[0], 0b11110000);
 
 	MEMBLOCK_OPS(, &mrun_large_used)->prep_hdr(&mrun_large_used,
-			heap, HDR_OP_FREE, NULL);
+			heap, MEMBLOCK_FREE, NULL);
 	UT_ASSERTeq(run->bitmap[1], 0ULL);
 
 	MEMBLOCK_OPS(, &mrun_large_free)->prep_hdr(&mrun_large_free,
-			heap, HDR_OP_ALLOC, NULL);
+			heap, MEMBLOCK_ALLOCATED, NULL);
 	UT_ASSERTeq(run->bitmap[2], ~0ULL);
 }
 


### PR DESCRIPTION
This patch reduces the number of locks acquired and released in the
duration of the palloc_operation function and also removes the recursive
attribute from the run locks. This also fixes a very rare race in which
threads freeing blocks from the same run tried to concurrently degrade
the same run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1342)
<!-- Reviewable:end -->
