### PR TITLE
test: add support for Valgrind 3.12

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1060,6 +1060,18 @@ function require_valgrind_dev_3_7() {
 }
 
 #
+# valgrind_version -- returns Valgrind version
+#
+function valgrind_version() {
+	echo "#include <valgrind/valgrind.h>
+#if defined (__VALGRIND_MAJOR__) && defined (__VALGRIND_MINOR__)
+__VALGRIND_MAJOR__*100+__VALGRIND_MINOR__
+#else
+0
+#endif" | gcc ${EXTRA_CFLAGS} -E - | tail -n 1 | bc
+}
+
+#
 # require_valgrind_dev_3_8 -- continue script execution only if
 #	version 3.8 (or later) of valgrind-devel package is installed
 #

--- a/src/test/vmmalloc_valgrind/TEST1
+++ b/src/test/vmmalloc_valgrind/TEST1
@@ -51,6 +51,10 @@ set_valgrind_exe_name
 configure_valgrind memcheck force-enable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 setup
 
+if [ $(valgrind_version) -ge 312 ]; then
+	export VALGRIND_OPTS="$VALGRIND_OPTS --soname-synonyms=somalloc=nouserintercepts"
+fi
+
 unset VMMALLOC_LOG_LEVEL
 unset VMMALLOC_LOG_FILE
 export TEST_LD_PRELOAD=libvmmalloc.so

--- a/src/test/vmmalloc_valgrind/TEST2
+++ b/src/test/vmmalloc_valgrind/TEST2
@@ -51,6 +51,10 @@ set_valgrind_exe_name
 configure_valgrind memcheck force-enable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 setup
 
+if [ $(valgrind_version) -ge 312 ]; then
+	 export VALGRIND_OPTS="$VALGRIND_OPTS --soname-synonyms=somalloc=nouserintercepts"
+fi
+
 unset VMMALLOC_LOG_LEVEL
 unset VMMALLOC_LOG_FILE
 


### PR DESCRIPTION
From Valgrind 3.12 release notes (http://valgrind.org/docs/manual/dist.news.html):
- Replacement/wrapping of malloc/new related functions is now done not just
  for system libraries by default, but for any globally defined malloc/new
  related function (both in shared libraries and statically linked alternative
  malloc implementations).  The dynamic (runtime) linker is excluded, though.
  To only intercept malloc/new related functions in
  system libraries use --soname-synonyms=somalloc=nouserintercepts (where
  "nouserintercepts" can be any non-existing library name).
  This new functionality is not implemented for MacOS X.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1346)

<!-- Reviewable:end -->
