### PR TITLE
common: Include out.h in sys_util.h

### DIFF
--- a/src/common/sys_util.h
+++ b/src/common/sys_util.h
@@ -40,6 +40,8 @@
 #include <errno.h>
 #include <pthread.h>
 
+#include "out.h"
+
 /*
  * util_mutex_init -- pthread_mutex_init variant that never fails from
  * caller perspective. If pthread_mutex_init failed, this function aborts


### PR DESCRIPTION
So that including sys_util.h doesn't have the
non-obvious requirement of including out.h first
anymore.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1365)
<!-- Reviewable:end -->
