### PR TITLE
win: duplicate file handles in mmap()...

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1032,7 +1032,7 @@ void
 util_part_fdclose(struct pool_set_part *part)
 {
 	if (part->fd != -1) {
-		close(part->fd);
+		(void) close(part->fd);
 		part->fd = -1;
 	}
 }

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -452,6 +452,8 @@ pmemblk_create(const char *path, size_t bsize, size_t poolsize,
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
+	util_poolset_fdclose(set);
+
 	LOG(3, "pbp %p", pbp);
 	return pbp;
 
@@ -518,6 +520,8 @@ pmemblk_open_common(const char *path, size_t bsize, int cow)
 		ERR("pool initialization failed");
 		goto err;
 	}
+
+	util_poolset_fdclose(set);
 
 	LOG(3, "pbp %p", pbp);
 	return pbp;

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -208,6 +208,8 @@ pmemlog_create(const char *path, size_t poolsize, mode_t mode)
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
+	util_poolset_fdclose(set);
+
 	LOG(3, "plp %p", plp);
 	return plp;
 
@@ -270,6 +272,8 @@ pmemlog_open_common(const char *path, int cow)
 		ERR("pool initialization failed");
 		goto err;
 	}
+
+	util_poolset_fdclose(set);
 
 	LOG(3, "plp %p", plp);
 	return plp;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1076,6 +1076,8 @@ pmemobj_create(const char *path, const char *layout, size_t poolsize,
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
+	util_poolset_fdclose(set);
+
 	LOG(3, "pop %p", pop);
 
 	return pop;
@@ -1339,6 +1341,8 @@ pmemobj_open_common(const char *path, const char *layout, int cow, int boot)
 	if (boot)
 		pmemobj_vg_boot(pop);
 #endif
+
+	util_poolset_fdclose(set);
 
 	LOG(3, "pop %p", pop);
 

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -50,14 +50,14 @@ struct mock_pop {
 static void
 obj_heap_persist(void *ctx, const void *ptr, size_t sz)
 {
-	pmem_msync(ptr, sz);
+	UT_ASSERTeq(pmem_msync(ptr, sz), 0);
 }
 
 static void *
 obj_heap_memset_persist(void *ctx, void *ptr, int c, size_t sz)
 {
 	memset(ptr, c, sz);
-	pmem_msync(ptr, sz);
+	UT_ASSERTeq(pmem_msync(ptr, sz), 0);
 	return ptr;
 }
 

--- a/src/test/obj_list/obj_list_mocks.c
+++ b/src/test/obj_list/obj_list_mocks.c
@@ -199,7 +199,7 @@ FUNC_MOCK_END
  */
 FUNC_MOCK(pmemobj_close, void, PMEMobjpool *pop)
 	FUNC_MOCK_RUN_DEFAULT {
-		munmap(Pop, Pop->size);
+		UT_ASSERTeq(pmem_unmap(Pop, Pop->size), 0);
 		Pop = NULL;
 	}
 FUNC_MOCK_END

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -118,7 +118,7 @@ static void *
 obj_memset(void *ctx, void *ptr, int c, size_t sz)
 {
 	memset(ptr, c, sz);
-	pmem_msync(ptr, sz);
+	UT_ASSERTeq(pmem_msync(ptr, sz), 0);
 	return ptr;
 }
 

--- a/src/test/obj_redo_log/obj_redo_log.c
+++ b/src/test/obj_redo_log/obj_redo_log.c
@@ -159,7 +159,7 @@ pmemobj_close_mock(PMEMobjpool *pop)
 {
 	redo_log_config_delete(pop->redo);
 
-	munmap(pop, pop->size);
+	UT_ASSERTeq(pmem_unmap(pop, pop->size), 0);
 }
 
 int

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -324,7 +324,7 @@ cleanup(char test_type)
 static void
 obj_sync_persist(void *ctx, const void *ptr, size_t sz)
 {
-	pmem_msync(ptr, sz);
+	/* no-op */
 }
 
 int

--- a/src/test/pmem_map/pmem_map.c
+++ b/src/test/pmem_map/pmem_map.c
@@ -153,7 +153,9 @@ do_check(int fd, void *addr, size_t mlen)
 	memset(pat, 0xA5, CHECK_BYTES);
 	memcpy(addr, pat, CHECK_BYTES);
 
-	pmem_unmap(addr, mlen);
+	UT_ASSERTeq(pmem_msync(addr, CHECK_BYTES), 0);
+
+	UT_ASSERTeq(pmem_unmap(addr, mlen), 0);
 
 	if (!sigsetjmp(Jmp, 1)) {
 		/* same memcpy from above should now fail */
@@ -244,7 +246,7 @@ main(int argc, char *argv[])
 							argv[i]);
 				}
 			} else {
-				pmem_unmap(addr, mlen);
+				UT_ASSERTeq(pmem_unmap(addr, mlen), 0);
 			}
 		}
 	}

--- a/src/test/pmem_memset/pmem_memset.c
+++ b/src/test/pmem_memset/pmem_memset.c
@@ -64,7 +64,7 @@ main(int argc, char *argv[])
 	char *buf = MALLOC(bytes);
 
 	memset(dest, 0, bytes);
-	dest1 = malloc(bytes);
+	dest1 = MALLOC(bytes);
 	memset(dest1, 0, bytes);
 
 	/*
@@ -101,8 +101,9 @@ main(int argc, char *argv[])
 				argv[1], bytes / 2);
 	}
 
-	pmem_unmap(dest, mapped_len);
+	UT_ASSERTeq(pmem_unmap(dest, mapped_len), 0);
 
+	FREE(dest1);
 	FREE(buf);
 	CLOSE(fd);
 

--- a/src/test/pmem_valgr_simple/pmem_valgr_simple.c
+++ b/src/test/pmem_valgr_simple/pmem_valgr_simple.c
@@ -67,7 +67,7 @@ main(int argc, char *argv[])
 	if (is_pmem) {
 		pmem_persist(tmp64dst, sizeof(*tmp64dst));
 	} else {
-		pmem_msync(tmp64dst, sizeof(*tmp64dst));
+		UT_ASSERTeq(pmem_msync(tmp64dst, sizeof(*tmp64dst)), 0);
 	}
 
 	uint16_t *tmp16dst = (void *)((uintptr_t)dest + 1024);
@@ -78,7 +78,7 @@ main(int argc, char *argv[])
 	/* shows strange behavior of memset in some cases */
 	memset(dest + dest_off, 0, bytes);
 
-	pmem_unmap(dest, mapped_len);
+	UT_ASSERTeq(pmem_unmap(dest, mapped_len), 0);
 
 	DONE(NULL);
 }

--- a/src/test/rpmem_basic/rpmem_basic.c
+++ b/src/test/rpmem_basic/rpmem_basic.c
@@ -116,7 +116,7 @@ free_pool(struct pool_entry *pool)
 	if (pool->is_mem)
 		FREE(pool->pool);
 	else
-		pmem_unmap(pool->pool, pool->size);
+		UT_ASSERTeq(pmem_unmap(pool->pool, pool->size), 0);
 
 	pool->pool = NULL;
 	pool->rpp = NULL;


### PR DESCRIPTION
... to make sure that msync/mprotect/munmap would still work on an existing file mapping, even though the file is closed (on Windows).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1367)
<!-- Reviewable:end -->
