### PR TITLE
obj: fix memcheck instrumentation

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -67,11 +67,11 @@
 int heap_boot(struct palloc_heap *heap, void *heap_start, uint64_t heap_size,
 		void *base, struct pmem_ops *p_ops);
 int heap_init(void *heap_start, uint64_t heap_size, struct pmem_ops *p_ops);
-void heap_vg_open(void *heap_start, uint64_t heap_size);
 void heap_cleanup(struct palloc_heap *heap);
 int heap_check(void *heap_start, uint64_t heap_size);
 int heap_check_remote(void *heap_start, uint64_t heap_size,
 		struct remote_ops *ops);
+int heap_buckets_init(struct palloc_heap *heap);
 
 struct bucket *heap_get_best_bucket(struct palloc_heap *heap, size_t size);
 struct bucket *heap_get_chunk_bucket(struct palloc_heap *heap,
@@ -99,12 +99,12 @@ pthread_mutex_t *heap_get_run_lock(struct palloc_heap *heap,
 struct memory_block heap_free_block(struct palloc_heap *heap, struct bucket *b,
 	struct memory_block m, struct operation_context *ctx);
 
-/* foreach callback, terminates iteration if return value is non-zero */
-typedef int (*object_callback)(uint64_t off, void *arg);
-
 void heap_foreach_object(struct palloc_heap *heap, object_callback cb,
 	void *arg, struct memory_block start);
 
 void *heap_end(struct palloc_heap *heap);
+
+void heap_vg_open(struct palloc_heap *heap, object_callback cb,
+		void *arg, int objects);
 
 #endif

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -170,9 +170,11 @@ struct pmemobjpool {
 
 	persist_remote_fn persist_remote; /* remote persist function */
 
+	int vg_boot;
+
 	/* padding to align size of this structure to page boundary */
 	/* sizeof(unused2) == 8192 - offsetof(struct pmemobjpool, unused2) */
-	char unused2[1594];
+	char unused2[1590];
 };
 
 /*
@@ -181,6 +183,9 @@ struct pmemobjpool {
  * functions.
  */
 #define OBJ_INTERNAL_OBJECT_MASK ((1ULL) << 63)
+#define OBJ_ROOT_SIZE(oobh) ((oobh)->size & ~OBJ_INTERNAL_OBJECT_MASK)
+#define OBJ_IS_INTERNAL(oobh) (((oobh)->size & OBJ_INTERNAL_OBJECT_MASK))
+#define OBJ_IS_ROOT(oobh) (OBJ_IS_INTERNAL(oobh) && OBJ_ROOT_SIZE(oobh))
 
 /*
  * Out-Of-Band Header - it is padded to 48B to fit one cache line (64B)
@@ -239,6 +244,10 @@ void obj_init(void);
 void obj_fini(void);
 int obj_read_remote(void *ctx, uintptr_t base, void *dest, void *addr,
 		size_t length);
+
+#ifdef USE_VG_MEMCHECK
+int obj_vg_register(uint64_t off, void *arg);
+#endif
 
 /*
  * (debug helper macro) logs notice message if used inside a transaction

--- a/src/libpmemobj/palloc.h
+++ b/src/libpmemobj/palloc.h
@@ -71,6 +71,7 @@ size_t palloc_usable_size(struct palloc_heap *heap, uint64_t off);
 
 int palloc_boot(struct palloc_heap *heap, void *heap_start,
 		uint64_t heap_size, void *base, struct pmem_ops *p_ops);
+int palloc_buckets_init(struct palloc_heap *heap);
 
 int palloc_init(void *heap_start, uint64_t heap_size, struct pmem_ops *p_ops);
 void *palloc_heap_end(struct palloc_heap *h);
@@ -79,8 +80,12 @@ int palloc_heap_check_remote(void *heap_start, uint64_t heap_size,
 		struct remote_ops *ops);
 void palloc_heap_cleanup(struct palloc_heap *heap);
 
-void palloc_vg_register_object(struct palloc_heap *heap, void *addr,
-		size_t size);
-void palloc_heap_vg_open(void *heap_start, uint64_t heap_size);
+/* foreach callback, terminates iteration if return value is non-zero */
+typedef int (*object_callback)(uint64_t off, void *arg);
+
+#ifdef USE_VG_MEMCHECK
+void palloc_heap_vg_open(struct palloc_heap *heap,
+		object_callback cb, void *arg, int objects);
+#endif
 
 #endif

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -38,6 +38,7 @@
  * in a reasonable time and with an acceptable common-case fragmentation.
  */
 
+#include "valgrind_internal.h"
 #include "heap.h"
 #include "lane.h"
 #include "memops.h"
@@ -45,7 +46,6 @@
 #include "out.h"
 #include "palloc.h"
 #include "pmalloc.h"
-#include "valgrind_internal.h"
 
 /*
  * pmalloc_redo_hold -- acquires allocator lane section and returns a pointer to
@@ -282,8 +282,20 @@ pmalloc_boot(PMEMobjpool *pop)
 	COMPILE_ERROR_ON(PALLOC_DATA_OFF != OBJ_OOB_SIZE);
 	COMPILE_ERROR_ON(ALLOC_BLOCK_SIZE != _POBJ_CL_ALIGNMENT);
 
-	return palloc_boot(&pop->heap, (char *)pop + pop->heap_offset,
+	int ret = palloc_boot(&pop->heap, (char *)pop + pop->heap_offset,
 			pop->heap_size, pop, &pop->p_ops);
+	if (ret)
+		return ret;
+
+#ifdef USE_VG_MEMCHECK
+	palloc_heap_vg_open(&pop->heap, obj_vg_register, pop, pop->vg_boot);
+#endif
+
+	ret = palloc_buckets_init(&pop->heap);
+	if (ret)
+		palloc_heap_cleanup(&pop->heap);
+
+	return ret;
 }
 
 static struct section_operations allocator_ops = {

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -83,6 +83,7 @@ test_heap()
 	UT_ASSERT(heap_check(heap_start, heap_size) != 0);
 	UT_ASSERT(heap_init(heap_start, heap_size, p_ops) == 0);
 	UT_ASSERT(heap_boot(heap, heap_start, heap_size, pop, p_ops) == 0);
+	UT_ASSERT(heap_buckets_init(heap) == 0);
 	UT_ASSERT(pop->heap.rt != NULL);
 
 	struct bucket *b_small = heap_get_best_bucket(heap, 1);

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -212,6 +212,7 @@ test_mock_pool_allocs()
 	heap_init(heap_start, heap_size, &mock_pop->p_ops);
 	heap_boot(&mock_pop->heap, heap_start, heap_size, mock_pop,
 			&mock_pop->p_ops);
+	heap_buckets_init(&mock_pop->heap);
 
 	/* initialize runtime lanes structure */
 	mock_pop->lanes_desc.runtime_nlanes = (unsigned)mock_pop->nlanes;


### PR DESCRIPTION
The original problem was that if root object was allocated from chunks
(huge allocation) the memcheck reported errors:
	Conditional jump or move depends on uninitialised value(s)

in pmemobj_vg_boot() function, because the root object's size was
accessed before registering it's header to valgrind.

This issue doesn't reproduce if root object is allocated from run
because the entire run space was registered as defined in valgrind -
which is wrong because only allocated objects with its headers should
be registered as defined.

The problem also applies to normal objects, because the loop which
registers the objects to valgrind was touching object's headers which
are not registered yet.

This patch fixes above issues by registering allocated objects during
booting the heap and at the same time when heap's metadata is
registered.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1372)
<!-- Reviewable:end -->
