### PR TITLE
obj: don't include pmalloc.h from heap.h and memblock.h

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -45,7 +45,7 @@
 #include "heap_layout.h"
 #include "memblock.h"
 #include "memops.h"
-#include "pmalloc.h"
+#include "palloc.h"
 
 #define MAX_BUCKETS (UINT8_MAX)
 #define RUN_UNIT_MAX 64U

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -42,7 +42,7 @@
 
 #include "heap_layout.h"
 #include "memops.h"
-#include "pmalloc.h"
+#include "palloc.h"
 
 struct memory_block {
 	uint32_t chunk_id; /* index of the memory block in its zone */

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -603,13 +603,13 @@ pmemobj_vg_boot(struct pmemobjpool *pop)
 	size_t rs = pmemobj_root_size(pop);
 	if (rs) {
 		oid = pmemobj_root(pop, rs);
-		palloc_vg_register_object(&pop->heap, oid,
+		palloc_vg_register_object(&pop->heap, pmemobj_direct(oid),
 				pmemobj_root_size(pop));
 	}
 
 	for (oid = pmemobj_first(pop);
 			!OID_IS_NULL(oid); oid = pmemobj_next(oid)) {
-		palloc_vg_register_object(&pop->heap, oid,
+		palloc_vg_register_object(&pop->heap, pmemobj_direct(oid),
 				pmemobj_alloc_usable_size(oid));
 	}
 

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -192,8 +192,8 @@ alloc_prep_block(struct palloc_heap *heap, struct memory_block m,
 
 	uint64_t real_size = unit_size * m.size_idx;
 
-	ASSERT((uint64_t)block_data % _POBJ_CL_ALIGNMENT == 0);
-	ASSERT((uint64_t)userdatap % _POBJ_CL_ALIGNMENT == 0);
+	ASSERT((uint64_t)block_data % ALLOC_BLOCK_SIZE == 0);
+	ASSERT((uint64_t)userdatap % ALLOC_BLOCK_SIZE == 0);
 
 	/* mark everything (including headers) as accessible */
 	VALGRIND_DO_MAKE_MEM_UNDEFINED(block_data, real_size);
@@ -648,9 +648,8 @@ palloc_heap_cleanup(struct palloc_heap *heap)
  * palloc_vg_register_object -- registers object in Valgrind
  */
 void
-palloc_vg_register_object(struct palloc_heap *heap, PMEMoid oid, size_t size)
+palloc_vg_register_object(struct palloc_heap *heap, void *addr, size_t size)
 {
-	void *addr = pmemobj_direct(oid);
 	size_t headers = sizeof(struct allocation_header) + PALLOC_DATA_OFF;
 
 	VALGRIND_DO_MEMPOOL_ALLOC(heap->layout, addr, size);

--- a/src/libpmemobj/palloc.h
+++ b/src/libpmemobj/palloc.h
@@ -79,7 +79,7 @@ int palloc_heap_check_remote(void *heap_start, uint64_t heap_size,
 		struct remote_ops *ops);
 void palloc_heap_cleanup(struct palloc_heap *heap);
 
-void palloc_vg_register_object(struct palloc_heap *heap, PMEMoid oid,
+void palloc_vg_register_object(struct palloc_heap *heap, void *addr,
 		size_t size);
 void palloc_heap_vg_open(void *heap_start, uint64_t heap_size);
 


### PR DESCRIPTION
pmalloc is an outer layer of the real allocator (palloc + heap + bucket + memblock).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1373)
<!-- Reviewable:end -->
