### PR TITLE
test: fix TRACE support

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -528,7 +528,10 @@ function ignore_debug_info_errors() {
 #	usage: get_trace <check type> <log file> [<node>]
 #
 function get_trace() {
-	[ "$1" == "none" ] && return $TRACE
+	if [ "$1" == "none" ]; then
+		echo "$TRACE"
+		return
+	fi
 	local exe=$VALGRINDEXE
 	local check_type=$1
 	local log_file=$2


### PR DESCRIPTION
It was failing with this message:
../unittest/unittest.sh: line 533: return: g: numeric argument required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1374)
<!-- Reviewable:end -->
