### PR TITLE
obj: fix overzealous vg instrumentation of chunk hdrs

### DIFF
--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -173,10 +173,6 @@ huge_prep_operation_hdr(struct memory_block *m, struct palloc_heap *heap,
 
 	operation_add_entry(ctx, hdr, val, OPERATION_SET);
 
-	VALGRIND_DO_MAKE_MEM_NOACCESS(hdr + 1,
-			(hdr->size_idx - 1) *
-			sizeof(struct chunk_header));
-
 	/*
 	 * In the case of chunks larger than one unit the footer must be
 	 * created immediately AFTER the persistent state is safely updated.


### PR DESCRIPTION
Currently each used or free huge chunk with size index
larger than two has multiple unused headers in the
metadata. Those headers can be sometimes read from the
queue of unused runs to verify if those runs are still
valid. This patch removes the instrumentation that
marked those headers as undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1390)
<!-- Reviewable:end -->
