### PR TITLE
win: arch flags compatibility

### DIFF
--- a/src/common/pool_hdr_windows.c
+++ b/src/common/pool_hdr_windows.c
@@ -36,6 +36,56 @@
 
 #include <Shlwapi.h>
 #include "pool_hdr.h"
+#include "out.h"
+
+/* ELF-compatible enums */
+
+/* machine */
+#define MACHINE_NONE 0
+#define MACHINE_386 3
+#define MACHINE_IA_64 50
+#define MACHINE_X86_64 62
+
+/* class */
+#define CLASS_NONE 0
+#define CLASS_32 1
+#define CLASS_64 2
+
+/* data */
+#define DATA_NONE 0
+#define DATA_2LSB 1
+#define DATA_2MSB 2
+
+/*
+ * arch_machine -- (internal) translate CPU arch into ELF-compatible machine id
+ */
+static int
+arch_machine(WORD cpuarch)
+{
+	/* XXX: no support for other architectures yet */
+
+	switch (cpuarch) {
+		case PROCESSOR_ARCHITECTURE_AMD64:
+			return MACHINE_X86_64;
+		case PROCESSOR_ARCHITECTURE_IA64:
+			return MACHINE_IA_64;
+		case PROCESSOR_ARCHITECTURE_INTEL:
+			return MACHINE_386;
+		default:
+			ASSERT(0); /* shouldn't happen */
+			return MACHINE_NONE;
+	}
+}
+
+/*
+ * arch_endianess -- (internal) determine endianess
+ */
+static int
+arch_endianess(void)
+{
+	short word = (DATA_2MSB << 8) + DATA_2LSB;
+	return ((char *)&word)[0];
+}
 
 /*
  * util_get_arch_flags -- get architecture identification flags
@@ -46,9 +96,17 @@ util_get_arch_flags(struct arch_flags *arch_flags)
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 
-	arch_flags->e_machine = si.wProcessorArchitecture;
-	arch_flags->ei_class = 0; /* XXX - si.dwProcessorType */
-	arch_flags->ei_data = 0;
+	arch_flags->e_machine = arch_machine(si.wProcessorArchitecture);
+#ifdef _WIN64
+	arch_flags->ei_class = CLASS_64;
+#else
+	/*
+	 * XXX - Just in case someone would remove the guard from platform.h
+	 * and attempt to compile NVML for 32-bit.
+	 */
+	arch_flags->ei_class = CLASS_32;
+#endif
+	arch_flags->ei_data = arch_endianess();
 	arch_flags->alignment_desc = alignment_desc();
 
 	return 0;


### PR DESCRIPTION
Make sure that CPU-specific arch flags in the pool header have
the same values on each OS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1394)
<!-- Reviewable:end -->
