### PR TITLE
win: fix srcversion project

### DIFF
--- a/src/windows/srcversion/srcversion.vcxproj
+++ b/src/windows/srcversion/srcversion.vcxproj
@@ -72,7 +72,7 @@
       </Command>
     </PreBuildEvent>
     <CustomBuildStep>
-      <Command>powershell.exe -file $(SolutionDir)..\utils\SRCVERSION.ps1</Command>
+      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1"</Command>
       <Outputs>__NON_EXISTENT_FILE__</Outputs>
       <Message>generate srcversion.h</Message>
     </CustomBuildStep>
@@ -99,7 +99,7 @@
       </Command>
     </PreBuildEvent>
     <CustomBuildStep>
-      <Command>powershell.exe -file $(SolutionDir)..\utils\SRCVERSION.ps1</Command>
+      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1"</Command>
       <Outputs>__NON_EXISTENT_FILE__</Outputs>
       <Message>generate srcversion.h</Message>
     </CustomBuildStep>


### PR DESCRIPTION
fixed an issue when building solution fails if it is located in path
including whitespace

Ref: pmem/issues#322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1405)
<!-- Reviewable:end -->
