### PR TITLE
pmem: fix dev dax map /w create flag and non-zero size

### DIFF
--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -555,17 +555,6 @@ pmem_map_file(const char *path, size_t len, int flags, mode_t mode,
 		return NULL;
 	}
 
-	if (dax) {
-		if (flags & ~(PMEM_DAX_VALID_FLAGS)) {
-			ERR("invalid flag for device dax %x", flags);
-			errno = EINVAL;
-			return NULL;
-		} else {
-			/* we are ignoring all of the flags anyway */
-			flags = 0;
-		}
-	}
-
 	if (flags & PMEM_FILE_CREATE) {
 		if ((off_t)len < 0) {
 			ERR("invalid file length %zu", len);
@@ -594,6 +583,18 @@ pmem_map_file(const char *path, size_t len, int flags, mode_t mode,
 		ERR("PMEM_FILE_TMPFILE not allowed without PMEM_FILE_CREATE");
 		errno = EINVAL;
 		return NULL;
+	}
+
+	if (dax) {
+		if (flags & ~(PMEM_DAX_VALID_FLAGS)) {
+			ERR("invalid flag for device dax %x", flags);
+			errno = EINVAL;
+			return NULL;
+		} else {
+			/* we are ignoring all of the flags anyway */
+			flags = 0;
+			open_flags = O_RDWR;
+		}
 	}
 
 #if USE_O_TMPFILE

--- a/src/test/pmem_map/TEST2
+++ b/src/test/pmem_map/TEST2
@@ -59,5 +59,6 @@ expect_normal_exit ./pmem_map$EXESUFFIX\
     $DEVICE_DAX_PATH 0 DSC 0666 1 1\
     $DEVICE_DAX_PATH 0 DT 0666 1 1\
     $DEVICE_DAX_PATH 0 DCE 0666 1 1\
+    $DEVICE_DAX_PATH 2097152 DC 0666 1 1\ # hardcoded 2 megabytes
 
 pass


### PR DESCRIPTION
Don't know why would anyone ever do this on purpose, but might be useful for cross-compatible stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1414)
<!-- Reviewable:end -->
