### PR TITLE
common: disable pmemxxx_check() function for device dax

### DIFF
--- a/doc/libpmemblk.3.md
+++ b/doc/libpmemblk.3.md
@@ -371,7 +371,7 @@ inconsistencies found will cause **pmemblk_check**() to return 0, in which case 
 debug version of **libpmemblk** will provide additional details on inconsistencies when **PMEMBLK_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
 ERROR HANDLING** section below. When *bsize* is non-zero **pmemblk_check**() will compare it to the block size of the pool and return 0 when they don't
 match. **pmemblk_check**() will return -1 and set *errno* if it cannot perform the consistency check due to other errors. **pmemblk_check**() opens the given
-*path* read-only so it never makes any changes to the file.
+*path* read-only so it never makes any changes to the file. This function is not supported on device dax.
 
 
 # DEBUGGING AND ERROR HANDLING #

--- a/doc/libpmemlog.3.md
+++ b/doc/libpmemlog.3.md
@@ -328,7 +328,7 @@ The **pmemlog_check**() function performs a consistency check of the file indica
 inconsistencies found will cause **pmemlog_check**() to return 0, in which case the use of the file with **libpmemlog** will result in undefined behavior. The
 debug version of **libpmemlog** will provide additional details on inconsistencies when **PMEMLOG_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
 ERROR HANDLING** section below. **pmemlog_check**() will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
-**pmemlog_check**() opens the given *path* read-only so it never makes any changes to the file.
+**pmemlog_check**() opens the given *path* read-only so it never makes any changes to the file. This function is not supported on device dax.
 
 
 # DEBUGGING AND ERROR HANDLING #

--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -2088,7 +2088,7 @@ The **pmemobj_check**() function performs a consistency check of the file indica
 inconsistencies found will cause **pmemobj_check**() to return 0, in which case the use of the file with **libpmemobj** will result in undefined behavior. The
 debug version of **libpmemobj** will provide additional details on inconsistencies when **PMEMOBJ_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
 ERROR HANDLING** section below. **pmemobj_check**() will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
-**pmemobj_check**() opens the given *path* read-only so it never makes any changes to the file.
+**pmemobj_check**() opens the given *path* read-only so it never makes any changes to the file. This function is not supported on device dax.
 
 
 # DEBUGGING AND ERROR HANDLING #

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -2396,6 +2396,12 @@ util_pool_open_nocheck(struct pool_set *set, int rdonly)
 {
 	LOG(3, "set %p rdonly %i", set, rdonly);
 
+	if (rdonly && set->replica[0]->part[0].is_dax) {
+		ERR("device dax cannot be mapped privately");
+		errno = ENOTSUP;
+		return -1;
+	}
+
 	int flags = rdonly ? MAP_PRIVATE|MAP_NORESERVE : MAP_SHARED;
 	int oerrno;
 
@@ -2467,6 +2473,12 @@ util_pool_open(struct pool_set **setp, const char *path, int rdonly,
 	int ret = util_poolset_create_set(setp, path, 0, minsize);
 	if (ret < 0) {
 		LOG(2, "cannot open pool set -- '%s'", path);
+		return -1;
+	}
+
+	if (rdonly && (*setp)->replica[0]->part[0].is_dax) {
+		ERR("device dax cannot be mapped privately");
+		errno = ENOTSUP;
 		return -1;
 	}
 
@@ -2548,6 +2560,12 @@ util_pool_open_remote(struct pool_set **setp, const char *path, int rdonly,
 	int ret = util_poolset_create_set(setp, path, 0, minsize);
 	if (ret < 0) {
 		LOG(2, "cannot open pool set -- '%s'", path);
+		return -1;
+	}
+
+	if (rdonly && (*setp)->replica[0]->part[0].is_dax) {
+		ERR("device dax cannot be mapped privately");
+		errno = ENOTSUP;
 		return -1;
 	}
 

--- a/src/test/obj_basic_integration/obj_basic_integration.c
+++ b/src/test/obj_basic_integration/obj_basic_integration.c
@@ -607,8 +607,11 @@ main(int argc, char *argv[])
 
 	pmemobj_close(pop);
 
-	if (pmemobj_check(path, POBJ_LAYOUT_NAME(basic)) != 1)
-		UT_FATAL("!pmemobj_check: %s", path);
+	int result = pmemobj_check(path, POBJ_LAYOUT_NAME(basic));
+	if (result < 0)
+		UT_OUT("!%s: pmemobj_check", path);
+	else if (result == 0)
+		UT_OUT("%s: pmemobj_check: not consistent", path);
 
 	DONE(NULL);
 }


### PR DESCRIPTION
Individual libraries API depend on being able to create a private
mapping of the pool, which is sadly impossible for device dax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1417)
<!-- Reviewable:end -->
