### PR TITLE
common: fix mocking in util_poolset test

### DIFF
--- a/src/test/util_poolset/TEST0
+++ b/src/test/util_poolset/TEST0
@@ -115,7 +115,7 @@ expect_normal_exit ./util_poolset$EXESUFFIX c $MIN_POOL\
 	$DIR/testset6\
 	-mo:/proc/testfile72 $DIR/testset7\
 	-mf:$((1024*1024*1024)) $DIR/testset8\
-	-mo:`readlink -mn $DIR/testfile102` $DIR/testset10\
+	-mo:$DIR/testfile102 $DIR/testset10\
 	$DIR/testset11\
 	$DIR/testset12 $DIR/testset13\
 	$DIR/testset14 $DIR/testset15\

--- a/src/test/util_poolset/TEST1
+++ b/src/test/util_poolset/TEST1
@@ -78,7 +78,7 @@ expect_normal_exit ./util_poolset$EXESUFFIX o $MIN_POOL\
 	$DIR/testset3 $DIR/testset4\
 	$DIR/testset5 $DIR/testset6\
 	$DIR/testset7\
-	-mo:`readlink -mn $DIR/testfile82` $DIR/testset8\
+	-mo:$DIR/testfile82 $DIR/testset8\
 	$DIR/testset9 $DIR/testset10\
 	$DIR/testset11
 


### PR DESCRIPTION
In 61d6bb2c3783f9be51710320c3b21e998078bfc6 resolving symbolic links in
create_poolset function has been removed, but util_poolset/TEST{0,1}
assumed they are resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1421)
<!-- Reviewable:end -->
