### PR TITLE
pkg: fix git describe matching

### DIFF
--- a/utils/pkg-common.sh
+++ b/utils/pkg-common.sh
@@ -73,28 +73,27 @@ function get_version_item() {
 	local INPUT=$1
 	local TARGET=$2
 	local REGEX="([^0-9]*)(([0-9]+\.){,2}[0-9]+)([.+-]?.*)"
+	local VERSION="0.0"
+	local RELEASE="-$INPUT"
 
 	if [[ $INPUT =~ $REGEX ]]
 	then
-		local VERSION="${BASH_REMATCH[2]}"
-		local RELEASE="${BASH_REMATCH[4]}"
-
-		case $TARGET in
-			version)
-				echo -n $VERSION
-				;;
-			release)
-				echo -n $RELEASE
-				;;
-			*)
-				error "Wrong target"
-				exit 1
-				;;
-		esac
-	else
-		error "Wrong tag format"
-		exit 1
+		VERSION="${BASH_REMATCH[2]}"
+		RELEASE="${BASH_REMATCH[4]}"
 	fi
+
+	case $TARGET in
+		version)
+			echo -n $VERSION
+			;;
+		release)
+			echo -n $RELEASE
+			;;
+		*)
+			error "Wrong target"
+			exit 1
+			;;
+	esac
 }
 
 function get_version() {


### PR DESCRIPTION
When cloning with a limited depth, the git describe does not include the last
tag version. Fix by adding an artificial 0.0 source version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1426)
<!-- Reviewable:end -->
