### PR TITLE
rpmem: do not print 'unexpected data received' log

### DIFF
--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -408,7 +408,6 @@ rpmem_ssh_monitor(struct rpmem_ssh *rps, int nonblock)
 	int ret = rpmem_xread(rps->cmd->fd_out, &buff, sizeof(buff), flags);
 
 	if (!ret) {
-		RPMEM_LOG(ERR, "unexpected data received");
 		errno = EPROTO;
 		return -1;
 	}


### PR DESCRIPTION
When closing the out-of-band connection the monitor thread was
receiving close request response message and reported an error.

This patch disables printing this error if closing the connection.

Ref: pmem/issues#346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1428)
<!-- Reviewable:end -->
