### PR TITLE
pmempool: use master replica size for mprotect

### DIFF
--- a/src/tools/pmempool/common.c
+++ b/src/tools/pmempool/common.c
@@ -661,7 +661,15 @@ pmem_pool_parse_params(const char *fname, struct pmem_pool_params *paramsp,
 
 		paramsp->size = set->poolsize;
 		addr = set->replica[0]->part[0].addr;
-		if (mprotect(addr, set->poolsize, PROT_READ) < 0) {
+
+		/*
+		 * XXX mprotect for device dax with length not aligned to its
+		 * page granularity causes SIGBUS on the next page fault.
+		 * The length argument of this call should be changed to
+		 * set->poolsize once the kernel issue is solved.
+		 */
+		if (mprotect(addr, set->replica[0]->repsize,
+			PROT_READ) < 0) {
 			ERR("!mprotect");
 			goto out_close;
 		}


### PR DESCRIPTION
This is a workaround for a kernel issue in which an mprotect with len
not aligned to page boundry causes a SIGBUS on the next page fault with a
"__dax_dev_pmd_fault: fail, unaligned vma" message. This caused issues
with poolsets that had non-dax replicas with sizes that weren't aligned
to the dax replica page size - that was the case of pmempool_sync/TEST7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1433)
<!-- Reviewable:end -->
