### PR TITLE
obj: remove now unecessery tx_free optimization

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -2101,10 +2101,6 @@ constructor_alloc_root(void *ctx, void *ptr, size_t usable_size, void *arg)
 
 	VALGRIND_REMOVE_FROM_TX(ro, OBJ_OOB_SIZE + usable_size);
 
-	pmemops_persist(p_ops, &ro->size,
-		/* there's no padding between these, so we can add sizes */
-		sizeof(ro->size) + sizeof(ro->type_num));
-
 	return ret;
 }
 

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1595,7 +1595,6 @@ constructor_alloc_bytype(void *ctx, void *ptr, size_t usable_size, void *arg)
 	struct oob_header *pobj = OOB_HEADER_FROM_PTR(ptr);
 	struct carg_bytype *carg = arg;
 
-	pobj->undo_entry_offset = 0;
 	pobj->type_num = carg->user_type;
 	pobj->size = 0;
 	memset(pobj->unused, 0, sizeof(pobj->unused));
@@ -1746,7 +1745,6 @@ constructor_realloc(void *ctx, void *ptr, size_t usable_size, void *arg)
 	struct oob_header *pobj = OOB_HEADER_FROM_PTR(ptr);
 
 	if (ptr != carg->ptr) {
-		pobj->undo_entry_offset = 0;
 		pobj->type_num = carg->user_type;
 		pobj->size = 0;
 	}
@@ -2098,7 +2096,6 @@ constructor_alloc_root(void *ctx, void *ptr, size_t usable_size, void *arg)
 	else
 		pmemops_memset_persist(p_ops, ptr, 0, usable_size);
 
-	ro->undo_entry_offset = 0;
 	ro->type_num = POBJ_ROOT_TYPE_NUM;
 	ro->size = carg->size | OBJ_INTERNAL_OBJECT_MASK;
 

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -95,9 +95,6 @@
 #define OOB_HEADER_FROM_OID(pop, oid)\
 	((struct oob_header *)((uintptr_t)(pop) + (oid).off - OBJ_OOB_SIZE))
 
-#define OBJ_OID_IS_IN_UNDO_LOG(pop, oid)\
-	(OOB_HEADER_FROM_OID(pop, oid)->undo_entry_offset != 0)
-
 #define OOB_HEADER_FROM_PTR(ptr)\
 	((struct oob_header *)((uintptr_t)(ptr) - OBJ_OOB_SIZE))
 
@@ -192,9 +189,7 @@ struct pmemobjpool {
  * together with allocator's header (of size 16B) located just before it.
  */
 struct oob_header {
-	uint8_t unused[24];
-
-	uint64_t undo_entry_offset;
+	uint8_t unused[32];
 
 	/* used only in root object, last bit used as a mask */
 	uint64_t size;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -44,20 +44,6 @@
 #include "tx.h"
 #include "valgrind_internal.h"
 
-/*
- * A special value that is used to mark previously used, but now invalid, undo
- * log entries - those that are meant to be skipped during processing.
- */
-#define TX_SKIP_ENTRY_VALUE UINT64_MAX
-
-/* Safely modify a single variable during a transaction */
-#define SET_TX_VAR(_pop, _var, _nval)\
-do {\
-	VALGRIND_ADD_TO_TX(&(_var), sizeof(_var));\
-	(_var) = (_nval);\
-	VALGRIND_REMOVE_FROM_TX(&(_var), sizeof(_var));\
-} while (0)
-
 struct tx_data {
 	SLIST_ENTRY(tx_data) tx_entry;
 	jmp_buf env;
@@ -186,13 +172,8 @@ constructor_tx_alloc(void *ctx, void *ptr, size_t usable_size, void *arg)
 	/* temporarily add the OOB header */
 	VALGRIND_ADD_TO_TX(oobh, OBJ_OOB_SIZE);
 
-	/*
-	 * no need to flush and persist because this
-	 * will be done in pre-commit phase
-	 */
 	oobh->type_num = args->type_num;
 	oobh->size = 0;
-	oobh->undo_entry_offset = args->entry_offset;
 	memset(oobh->unused, 0, sizeof(oobh->unused));
 
 	VALGRIND_REMOVE_FROM_TX(oobh, OBJ_OOB_SIZE);
@@ -354,11 +335,6 @@ tx_clear_undo_log(PMEMobjpool *pop, struct pvector_context *undo,
 	uint64_t val;
 
 	while ((val = pvector_last(undo)) != 0) {
-		if (val == TX_SKIP_ENTRY_VALUE) {
-			pvector_pop_back(undo, tx_clear_vec_entry);
-			continue;
-		}
-
 		tx_clear_undo_log_vg(pop, val, flags);
 
 		if (flags & TX_CLR_FLAG_FREE) {
@@ -587,32 +563,6 @@ tx_abort_set(PMEMobjpool *pop, struct tx_undo_runtime *tx_rt, int recovery)
 }
 
 /*
- * tx_pre_commit_alloc -- (internal) do pre-commit operations for
- * allocated objects
- */
-static void
-tx_pre_commit_alloc(PMEMobjpool *pop, struct tx_undo_runtime *tx_rt)
-{
-	LOG(3, NULL);
-
-	struct pvector_context *ctx = tx_rt->ctx[UNDO_ALLOC];
-
-	uint64_t offset;
-	for (offset = pvector_first(ctx); offset != 0;
-			offset = pvector_next(ctx)) {
-
-		if (offset == TX_SKIP_ENTRY_VALUE)
-			continue;
-
-		struct oob_header *oobh = OOB_HEADER_FROM_OFF(pop, offset);
-		SET_TX_VAR(pop, oobh->undo_entry_offset, 0);
-
-		size_t size = sizeof(*oobh) - sizeof(oobh->unused);
-		pmemops_flush(&pop->p_ops, &oobh->undo_entry_offset, size);
-	}
-}
-
-/*
  * tx_post_commit_alloc -- (internal) do post commit operations for
  * allocated objects
  */
@@ -724,8 +674,6 @@ tx_pre_commit(PMEMobjpool *pop, struct lane_tx_runtime *lane)
 
 	ASSERTne(tx.section->runtime, NULL);
 
-	tx_pre_commit_alloc(pop, &lane->undo);
-
 	/* Flush all regions and destroy the whole tree. */
 	ctree_delete_cb(lane->ranges, tx_flush_range, pop);
 	lane->ranges = NULL;
@@ -808,9 +756,6 @@ tx_abort_register_valgrind(PMEMobjpool *pop, struct pvector_context *ctx)
 {
 	uint64_t off;
 	for (off = pvector_first(ctx); off != 0; off = pvector_next(ctx)) {
-		if (off == TX_SKIP_ENTRY_VALUE)
-			continue;
-
 		/*
 		 * Can't use pmemobj_direct and pmemobj_alloc_usable_size
 		 * because pool has not been registered yet.
@@ -1815,15 +1760,7 @@ pmemobj_tx_add_range(PMEMoid oid, uint64_t hoff, size_t size)
 		.flags = 0,
 	};
 
-	/*
-	 * If internal type is in undo log it means
-	 * the object was allocated within this transaction
-	 * and there is no need to create a snapshot.
-	 */
-	if (!OBJ_OID_IS_IN_UNDO_LOG(lane->pop, oid))
-		return pmemobj_tx_add_common(&args);
-
-	return 0;
+	return pmemobj_tx_add_common(&args);
 }
 
 /*
@@ -1858,15 +1795,7 @@ pmemobj_tx_xadd_range(PMEMoid oid, uint64_t hoff, size_t size, uint64_t flags)
 		.flags = flags,
 	};
 
-	/*
-	 * If internal type is in undo log it means
-	 * the object was allocated within this transaction
-	 * and there is no need to create a snapshot.
-	 */
-	if (!OBJ_OID_IS_IN_UNDO_LOG(lane->pop, oid))
-		return pmemobj_tx_add_common(&args);
-
-	return 0;
+	return pmemobj_tx_add_common(&args);
 }
 
 /*
@@ -2019,49 +1948,13 @@ pmemobj_tx_free(PMEMoid oid)
 	}
 	ASSERT(OBJ_OID_IS_VALID(pop, oid));
 
-	if (!OBJ_OID_IS_IN_UNDO_LOG(pop, oid)) {
-		/* the object is in object store */
-		uint64_t *entry = pvector_push_back(lane->undo.ctx[UNDO_FREE]);
-		if (entry == NULL) {
-			ERR("free undo log too large");
-			return obj_tx_abort_err(ENOMEM);
-		}
-		*entry = oid.off;
-		pmemops_persist(&pop->p_ops, entry, sizeof(*entry));
-	} else {
-
-		struct oob_header *oobh = OOB_HEADER_FROM_OID(pop, oid);
-#ifdef USE_VG_PMEMCHECK
-		if (On_valgrind) {
-			size_t size = palloc_usable_size(&pop->heap, oid.off);
-			VALGRIND_SET_CLEAN(oobh, size);
-			VALGRIND_REMOVE_FROM_TX(oobh, size);
-		}
-#endif
-
-		if (ctree_remove_unlocked(lane->ranges, oid.off, 1) != oid.off)
-			FATAL("TX undo state mismatch");
-
-		struct redo_log *redo = pmalloc_redo_hold(pop);
-
-		struct operation_context ctx;
-		operation_init(&ctx, pop, pop->redo, redo);
-
-		/*
-		 * The object has been allocated within the same transaction.
-		 * To avoid having to shuffle the undo vector around, we mark
-		 * the removed entry with a special value which is skipped
-		 * during processing.
-		 */
-		uint64_t *entry_offset = (uint64_t *)oobh->undo_entry_offset;
-		operation_add_entry(&ctx, entry_offset, TX_SKIP_ENTRY_VALUE,
-				OPERATION_SET);
-
-		pmalloc_operation(&pop->heap, *entry_offset,
-			entry_offset, 0, NULL, NULL, &ctx);
-
-		pmalloc_redo_release(pop);
+	uint64_t *entry = pvector_push_back(lane->undo.ctx[UNDO_FREE]);
+	if (entry == NULL) {
+		ERR("free undo log too large");
+		return obj_tx_abort_err(ENOMEM);
 	}
+	*entry = oid.off;
+	pmemops_persist(&pop->p_ops, entry, sizeof(*entry));
 
 	return 0;
 }

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -2,7 +2,7 @@ obj_persist_count$(nW)TEST0: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 persist	;msync	;flush	;drain	;task
 0	;10	;0	;0	;pool_create
-0	;8	;0	;0	;root_alloc
+0	;7	;0	;0	;root_alloc
 0	;2	;0	;0	;atomic_alloc
 0	;1	;0	;0	;atomic_free
 0	;11	;0	;0	;tx_alloc

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -5,8 +5,8 @@ persist	;msync	;flush	;drain	;task
 0	;8	;0	;0	;root_alloc
 0	;2	;0	;0	;atomic_alloc
 0	;1	;0	;0	;atomic_free
-0	;12	;0	;0	;tx_alloc
-0	;11	;0	;0	;tx_alloc_next
+0	;11	;0	;0	;tx_alloc
+0	;10	;0	;0	;tx_alloc_next
 0	;9	;0	;0	;tx_free
 0	;8	;0	;0	;tx_free_next
 0	;20	;0	;0	;tx_add

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -5,8 +5,8 @@ persist	;msync	;flush	;drain	;task
 6	;0	;1	;0	;root_alloc
 2	;0	;0	;0	;atomic_alloc
 1	;0	;0	;0	;atomic_free
-9	;0	;3	;1	;tx_alloc
-8	;0	;3	;1	;tx_alloc_next
+9	;0	;2	;1	;tx_alloc
+8	;0	;2	;1	;tx_alloc_next
 8	;0	;1	;1	;tx_free
 7	;0	;1	;1	;tx_free_next
 14	;0	;3	;1	;tx_add

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -2,7 +2,7 @@ obj_persist_count$(nW)TEST1: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 persist	;msync	;flush	;drain	;task
 7	;0	;0	;0	;pool_create
-6	;0	;1	;0	;root_alloc
+5	;0	;1	;0	;root_alloc
 2	;0	;0	;0	;atomic_alloc
 1	;0	;0	;0	;atomic_free
 9	;0	;2	;1	;tx_alloc

--- a/src/test/pmempool_info/out12.log.match
+++ b/src/test/pmempool_info/out12.log.match
@@ -58,7 +58,6 @@ Size idx                 : $(*)
    Size                     : $(*)
 
    OOB Header:
-   Undo offset              : $(*)
    Type Number              : $(*)
  
  Chunk                    : $(*)
@@ -77,7 +76,6 @@ Size idx                 : $(*)
    Size                     : $(*)
 
    OOB Header:
-   Undo offset              : $(*)
    Type Number              : $(*)
  
  Chunk                    : $(*)

--- a/src/test/pmempool_info/out13.log.match
+++ b/src/test/pmempool_info/out13.log.match
@@ -58,7 +58,6 @@ Size idx                 : $(*)
    Size                     : $(*)
 
    OOB Header:
-   Undo offset              : $(*)
    Type Number              : $(*)
 
 Statistics:

--- a/src/test/pmempool_info/out14.log.match
+++ b/src/test/pmempool_info/out14.log.match
@@ -121,7 +121,6 @@ Lane:
    Offset                   : $(*)
 
     OOB Header:
-    Undo offset              : $(*)
     Type Number              : $(*)
   Undo Log - free          : 0 elements
   Undo Log - set           : 0 elements
@@ -269,7 +268,6 @@ Lane:
    Offset                   : $(*)
 
     OOB Header:
-    Undo offset              : $(*)
     Type Number              : 0x0000000000000001
   Undo Log - set           : 0 elements
   Undo Log - set cache     : 1 element
@@ -278,5 +276,4 @@ Lane:
    Offset                   : $(*)
 
     OOB Header:
-    Undo offset              : $(*)
     Type Number              : 0x0000000000000000

--- a/src/test/pmempool_info/out15.log.match
+++ b/src/test/pmempool_info/out15.log.match
@@ -76,5 +76,4 @@ Size                     : 1
  Size                     : $(*)
 
  OOB Header:
- Undo offset              : $(*)
  Type Number              : $(*)

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -338,7 +338,6 @@ info_obj_oob_hdr(struct pmem_info *pip, int v, struct oob_header *oob)
 	outv_title(v, "OOB Header");
 	outv_hexdump(v && pip->args.vhdrdump, oob, sizeof(*oob),
 		PTR_TO_OFF(pip->obj.pop, oob), 1);
-	outv_field(v, "Undo offset", "%llx", oob->undo_entry_offset);
 	outv_field(v, "Type Number", "0x%016lx", oob->type_num);
 
 }


### PR DESCRIPTION
First patch from the series related to pmem/issues#347

Lots of code removed and even a tiny performance gain /w transactional allocations - their performance is now on par with atomic allocations ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1435)
<!-- Reviewable:end -->
