### PR TITLE
common: fix two valgrind issues

### DIFF
--- a/src/common/file.c
+++ b/src/common/file.c
@@ -114,6 +114,9 @@ util_file_is_device_dax(const char *path)
 	int olderrno = errno;
 	int ret = 0;
 
+	if (path == NULL)
+		goto out;
+
 	if (util_stat(path, &st) < 0)
 		goto out;
 

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -763,6 +763,7 @@ util_parse_add_part(struct pool_set *set, const char *path, size_t filesize)
 	rep->part[p].created = 0;
 	rep->part[p].hdr = NULL;
 	rep->part[p].addr = NULL;
+	rep->part[p].remote_hdr = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
Fixes two following valgrind's issues (found by
the obj_rpmem_basic_integration/TEST9 unit test):

==24880== Syscall param stat(file_name) points to unaddressable byte(s)
==24880==    at 0x5BB82F5: _xstat (xstat.c:37)
==24880==    by 0x504D05B: util_file_is_device_dax (file.c:117)
==24880==    by 0x50526CB: util_parse_add_part (set.c:742)
==24880==    by 0x5052CC3: util_parse_add_remote_replica (set.c:853)
==24880==    by 0x50531DF: util_poolset_parse (set.c:989)
==24880==    by 0x5054244: util_poolset_create_set (set.c:1432)
==24880==    by 0x5056591: util_pool_create_uuids (set.c:2034)
==24880==    by 0x5056B0C: util_pool_create (set.c:2164)
==24880==    by 0x5069C47: pmemobj_create (obj.c:1061)
==24880==    by 0x406A6A: main (obj_basic_integration.c:589)
==24880==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==24880== 
==24880== Conditional jump or move depends on uninitialised value(s)
==24880==    at 0x4C2AC8A: free (vg_replace_malloc.c:473)
==24880==    by 0x505641D: util_replica_close (set.c:1990)
==24880==    by 0x5051FA4: util_poolset_close (set.c:549)
==24880==    by 0x50581D4: util_pool_open (set.c:2534)
==24880==    by 0x506A5A4: pmemobj_open_common (obj.c:1267)
==24880==    by 0x506ABA5: pmemobj_open (obj.c:1407)
==24880==    by 0x406B2D: main (obj_basic_integration.c:605)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1443)
<!-- Reviewable:end -->
