### PR TITLE
obj: Rename the macro specifying lock sizes

### DIFF
--- a/src/benchmarks/obj_locks.c
+++ b/src/benchmarks/obj_locks.c
@@ -96,7 +96,7 @@ struct prog_args {
  * mutex similar to PMEMmutex, but with pthread_mutex_t in RAM
  */
 typedef union padded_volatile_pmemmutex {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 	struct {
 		uint64_t runid;
 		pthread_mutex_t *mutexp; /* pointer to pthread mutex in RAM */

--- a/src/include/libpmemobj/thread.h
+++ b/src/include/libpmemobj/thread.h
@@ -47,18 +47,18 @@ extern "C" {
 /*
  * Locking.
  */
-#define _POBJ_CL_ALIGNMENT 64 /* cache line alignment for performance */
+#define _POBJ_CL_SIZE 64 /* cache line size */
 
 typedef struct {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 } PMEMmutex;
 
 typedef struct {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 } PMEMrwlock;
 
 typedef struct {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 } PMEMcond;
 
 void pmemobj_mutex_zero(PMEMobjpool *pop, PMEMmutex *mutexp);

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -280,7 +280,7 @@ static int
 pmalloc_boot(PMEMobjpool *pop)
 {
 	COMPILE_ERROR_ON(PALLOC_DATA_OFF != OBJ_OOB_SIZE);
-	COMPILE_ERROR_ON(ALLOC_BLOCK_SIZE != _POBJ_CL_ALIGNMENT);
+	COMPILE_ERROR_ON(ALLOC_BLOCK_SIZE != _POBJ_CL_SIZE);
 
 	int ret = palloc_boot(&pop->heap, (char *)pop + pop->heap_offset,
 			pop->heap_size, pop, &pop->p_ops);

--- a/src/libpmemobj/sync.h
+++ b/src/libpmemobj/sync.h
@@ -48,7 +48,7 @@
  * internal definitions of PMEM-locks
  */
 typedef union padded_pmemmutex {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 	struct {
 		uint64_t runid;
 		pthread_mutex_t mutex;
@@ -56,7 +56,7 @@ typedef union padded_pmemmutex {
 } PMEMmutex_internal;
 
 typedef union padded_pmemrwlock {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 	struct {
 		uint64_t runid;
 		pthread_rwlock_t rwlock;
@@ -64,7 +64,7 @@ typedef union padded_pmemrwlock {
 } PMEMrwlock_internal;
 
 typedef union padded_pmemcond {
-	char padding[_POBJ_CL_ALIGNMENT];
+	char padding[_POBJ_CL_SIZE];
 	struct {
 		uint64_t runid;
 		pthread_cond_t cond;

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -464,9 +464,9 @@ tx_remove_range(struct txr *tx_ranges, void *begin, void *end)
 static void
 tx_restore_range(PMEMobjpool *pop, struct tx_range *range)
 {
-	COMPILE_ERROR_ON(sizeof(PMEMmutex) != _POBJ_CL_ALIGNMENT);
-	COMPILE_ERROR_ON(sizeof(PMEMrwlock) != _POBJ_CL_ALIGNMENT);
-	COMPILE_ERROR_ON(sizeof(PMEMcond) != _POBJ_CL_ALIGNMENT);
+	COMPILE_ERROR_ON(sizeof(PMEMmutex) != _POBJ_CL_SIZE);
+	COMPILE_ERROR_ON(sizeof(PMEMrwlock) != _POBJ_CL_SIZE);
+	COMPILE_ERROR_ON(sizeof(PMEMcond) != _POBJ_CL_SIZE);
 
 	struct lane_tx_runtime *runtime =
 			(struct lane_tx_runtime *)tx.section->runtime;
@@ -491,7 +491,7 @@ tx_restore_range(PMEMobjpool *pop, struct tx_range *range)
 	SLIST_FOREACH(txl, &(runtime->tx_locks), tx_lock) {
 		void *lock_begin = txl->lock.mutex;
 		/* all PMEM locks have the same size */
-		void *lock_end = (char *)lock_begin + _POBJ_CL_ALIGNMENT;
+		void *lock_end = (char *)lock_begin + _POBJ_CL_SIZE;
 
 		tx_remove_range(&tx_ranges, lock_begin, lock_end);
 	}


### PR DESCRIPTION
The name _POBJ_CL_ALIGNMENT was very confusing,
as it is never used to sepcify alignment. It is always
used to specify size, and is compared with results of
sizeof(), not with results of alignof().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1471)
<!-- Reviewable:end -->
