### PR TITLE
doc: change behavior of generating manpages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -123,8 +123,8 @@ $(MANPAGES_BUILDDIR)/%.1: %.1.md default.man ../utils/md2man.sh FORCE
 
 compress: $(GZFILES_BUILD)
 
-%.gz: %
-	gzip -c ./$< > $@
+%.gz:
+	gzip -c ./$* > $@
 
 clean:
 


### PR DESCRIPTION
This patch f66c711ecdf5404d4fc034ee77303675e0aeeb69 introcuced forcing
generating of manpages. This resulted in having a dependency on pandoc
again because the 'make install' depends on documentation and manapges
were generated always. This patch changes the behavior so the generating
manpages is done only explicitly by calling 'make doc' from top
directory or 'make' inside doc directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1473)
<!-- Reviewable:end -->
