### PR TITLE
common: fix compilation warning/error on Fedora 26

### DIFF
--- a/src/common/file.c
+++ b/src/common/file.c
@@ -42,6 +42,11 @@
 #include <unistd.h>
 #include <limits.h>
 #include <sys/file.h>
+
+#ifndef _WIN32
+#include <sys/sysmacros.h>
+#endif
+
 #include "file.h"
 #include "out.h"
 #include "mmap.h"


### PR DESCRIPTION
Use <sys/sysmacros.h> for makedev(), major() and minor() decls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1474)
<!-- Reviewable:end -->
