### PR TITLE
common: integrate Coverity scans with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,39 @@
+language: c
+
+addons:
+  coverity_scan:
+    project:
+      name: $TRAVIS_REPO_SLUG
+      description: "NVM Library"
+    build_command: "make -j all"
+    branch_pattern: coverity_scan
+
+env:
+  matrix:
+    - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=gcc OS=ubuntu OS_VER=16.04
+    - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=clang OS=ubuntu OS_VER=16.04
+    - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=clang OS=fedora OS_VER=23
+    - MAKE_PKG=1 CC=gcc OS=ubuntu OS_VER=16.04 EXPERIMENTAL=y
+    - MAKE_PKG=1 CC=clang OS=ubuntu OS_VER=16.04 EXPERIMENTAL=y
+    - MAKE_PKG=1 CC=gcc OS=fedora OS_VER=23 EXPERIMENTAL=y
+    - COVERITY=1
+
 before_install:
-  - export HOST_WORKDIR=`pwd`
-  - cd utils/docker
-  - ./prepare-environment.sh
-  - ./pull-or-rebuild-image.sh
+  - test "$TRAVIS_BRANCH" != "coverity_scan" -o "$COVERITY" == "1" || exit 0
+  - test "$TRAVIS_BRANCH" == "coverity_scan" -o "$COVERITY" != "1" || exit 0
+  - if [[ "$TRAVIS_BRANCH" == "coverity_scan" ]]; then
+      echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-;
+    else
+      export HOST_WORKDIR=`pwd` &&
+      cd utils/docker &&
+      ./prepare-environment.sh &&
+      ./pull-or-rebuild-image.sh;
+    fi
   - if [[ -f push_image_to_repo_flag ]]; then PUSH_THE_IMAGE=1; fi
   - rm -f push_image_to_repo_flag
 
 script:
-  - ./build.sh
-
-env:
-  - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=gcc OS=ubuntu OS_VER=16.04
-  - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=clang OS=ubuntu OS_VER=16.04
-  - MAKE_PKG=0 EXTRA_CFLAGS=-DUSE_VALGRIND REMOTE_TESTS=1 CC=clang OS=fedora OS_VER=23
-  - MAKE_PKG=1 CC=gcc OS=ubuntu OS_VER=16.04 EXPERIMENTAL=y
-  - MAKE_PKG=1 CC=clang OS=ubuntu OS_VER=16.04 EXPERIMENTAL=y
-  - MAKE_PKG=1 CC=gcc OS=fedora OS_VER=23 EXPERIMENTAL=y
+  - test "$TRAVIS_BRANCH" == "coverity_scan" -o "$COVERITY" == "1" || ./build.sh
 
 after_success:
   - if [[ $PUSH_THE_IMAGE -eq 1 ]]; then images/push-image.sh $OS:$OS_VER; fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ nvml: Non-Volatile Memory Library
 
 [![Build Status](https://travis-ci.org/pmem/nvml.svg)](https://travis-ci.org/pmem/nvml)
 [![Build status](https://ci.appveyor.com/api/projects/status/1f5jwqpqs89itr2k?svg=true)](https://ci.appveyor.com/project/krzycz/nvml-10qrw)
+[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/3015.svg)](https://scan.coverity.com/projects/pmem-nvml)
 [![NVML release version](https://img.shields.io/github/release/pmem/nvml.svg)](https://github.com/pmem/nvml/releases/latest)
 
 This is the top-level README.md the NVM Library.


### PR DESCRIPTION
The new travis.yml introduces a new entry/job in the build matrix to
trigger the Coverity Scan build for static code analysis.
The "COVERITY" job is executed only if the build is made from
"coverity_scan" branch and skipped (early exit) otherwise.
On the other hand, the normal build jobs are skipped for "coverity_scan"
branch.
Thanks to that, we can have a single travis.yml file on all the branches
and simply push the code from "master" to "coverity_scan" periodically
(i.e. daily) to trigger Coverity scans.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1475)
<!-- Reviewable:end -->
