### PR TITLE
test: reduce the pool size of oom test to 2GB from 20GB

### DIFF
--- a/src/test/obj_out_of_memory/TEST2
+++ b/src/test/obj_out_of_memory/TEST2
@@ -44,9 +44,9 @@ setup
 export PMEM_IS_PMEM_FORCE=1
 export PMEMOBJ_LOG_LEVEL=1
 
-create_poolset $DIR/testset1 20G:$DIR/testfile1
+create_poolset $DIR/testset1 2G:$DIR/testfile1
 
-# allocate 64 kilobyte blocks so that runs are used
+# allocate 32 kilobyte blocks so that runs are used
 expect_normal_exit\
 	./obj_out_of_memory$EXESUFFIX 32768 $DIR/testset1
 

--- a/src/test/obj_out_of_memory/TEST2.PS1
+++ b/src/test/obj_out_of_memory/TEST2.PS1
@@ -50,9 +50,9 @@ setup
 $Env:PMEM_IS_PMEM_FORCE=1
 $Env:PMEMOBJ_LOG_LEVEL=1
 
-create_poolset $DIR\testset1 20G:$DIR\testfile1
+create_poolset $DIR\testset1 2G:$DIR\testfile1
 
-# allocate 64 kilobyte blocks so that runs are used
+# allocate 32 kilobyte blocks so that runs are used
 expect_normal_exit `
 	$Env:EXE_DIR\obj_out_of_memory$Env:EXESUFFIX 32768 $DIR\testset1
 


### PR DESCRIPTION
The old pool size was unreasonable...

The next largest pool size currently is 2GB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1479)
<!-- Reviewable:end -->
