### PR TITLE
libpmempool tests: fix crtime test sporadic

### DIFF
--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -53,10 +53,12 @@ rm -rf $LOG && touch $LOG
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 
-FUTURE_TIME=$(date +"%s")
-let "FUTURE_TIME+=60*60"
-
+TIME=$(date +"%s")
+let "FUTURE_TIME=$TIME+60*60"
+let "PAST_TIME=$TIME-60*60"
+PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
 $PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
+touch -mt $PAST_TIME $POOL_P1
 
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
 expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG

--- a/src/test/pmempool_check/TEST16.PS1
+++ b/src/test/pmempool_check/TEST16.PS1
@@ -63,6 +63,11 @@ expect_normal_exit $PMEMPOOL create log $POOLSET
 $FUTURE_TIME+=60*60
 &$PMEMSPOIL -v $POOL_P1 "pool_hdr.crtime=$FUTURE_TIME" >> $LOG
 
+[DateTime]$past=Get-Date
+$past=$past.AddHours(-1)
+$file=Get-Item $POOL_P1
+$file.LastWriteTime=$past
+
 expect_abnormal_exit $PMEMPOOL check -v $POOLSET >> $LOG
 expect_abnormal_exit $PMEMPOOL check -vry $POOLSET >> $LOG
 expect_normal_exit $PMEMPOOL check -vrya $POOLSET >> $LOG

--- a/src/test/pmempool_check/out16.log.match
+++ b/src/test/pmempool_check/out16.log.match
@@ -13,6 +13,8 @@ replica 0 part 0: pool_hdr.crtime is not valid
 replica 0 part 0: setting pool_hdr.crtime to file's modtime: $(*)
 replica 0 part 1: checking pool header
 replica 0 part 1: pool header correct
+replica 0 part 0: invalid pool_hdr.checksum
+replica 0 part 0: setting pool_hdr.checksum to $(nW)
 checking pmemlog header
 pmemlog header correct
 $(nW)pool.set: repaired


### PR DESCRIPTION
Set mtime of pool file to the past to make sure pool header checksum
has to be fixed each time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1480)
<!-- Reviewable:end -->
