### PR TITLE
test: suppress helgrind issues /w adjacent blocks

### DIFF
--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -37,6 +37,8 @@
 export UNITTEST_NAME=obj_pmalloc_mt/TEST0
 export UNITTEST_NUM=0
 
+export VALGRIND_OPTS="--suppressions=helgrind_adjacent_block.supp"
+
 # standard unit test setup
 . ../unittest/unittest.sh
 

--- a/src/test/obj_pmalloc_mt/helgrind_adjacent_block.supp
+++ b/src/test/obj_pmalloc_mt/helgrind_adjacent_block.supp
@@ -1,0 +1,6 @@
+{
+  <intentional layout race, protected by transient state>
+  Helgrind:Race
+  ...
+  fun:heap_get_adjacent_free_block
+}


### PR DESCRIPTION
This is an on-purpose race that has no negative effects. In happens during
a free of a huge block, when the algorithm tries to coalesce the block with
its free neighbours. The blocks are first identified in the persistent
layout without grabing a lock and then they are retrieved from a protected
container - this ensures that the block is correct. Even if the data that
was read is stale or invalid, nothing bad can happen - the chunk that is
being freed simply won't get coalesced.

This is a temporary solution to pmem/issues#342

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1485)
<!-- Reviewable:end -->
