### PR TITLE
obj: force alignment of pmem lock structures

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -61,6 +61,8 @@ extern unsigned long long Mmap_align;
 
 #define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + lp))
 
+#define util_alignof(t) offsetof(struct {char _util_c; t _util_m; }, _util_m)
+
 /*
  * overridable names for malloc & friends used by this library
  */

--- a/src/include/libpmemobj/base.h
+++ b/src/include/libpmemobj/base.h
@@ -187,7 +187,7 @@ void pmemobj_drain(PMEMobjpool *pop);
  * verify that the version available at run-time is compatible with the version
  * used at compile-time by passing these defines to pmemobj_check_version().
  */
-#define PMEMOBJ_MAJOR_VERSION 1
+#define PMEMOBJ_MAJOR_VERSION 2
 #define PMEMOBJ_MINOR_VERSION 1
 const char *pmemobj_check_version(
 		unsigned major_required,

--- a/src/include/libpmemobj/base.h
+++ b/src/include/libpmemobj/base.h
@@ -188,7 +188,7 @@ void pmemobj_drain(PMEMobjpool *pop);
  * used at compile-time by passing these defines to pmemobj_check_version().
  */
 #define PMEMOBJ_MAJOR_VERSION 2
-#define PMEMOBJ_MINOR_VERSION 1
+#define PMEMOBJ_MINOR_VERSION 0
 const char *pmemobj_check_version(
 		unsigned major_required,
 		unsigned minor_required);

--- a/src/include/libpmemobj/thread.h
+++ b/src/include/libpmemobj/thread.h
@@ -49,15 +49,18 @@ extern "C" {
  */
 #define _POBJ_CL_SIZE 64 /* cache line size */
 
-typedef struct {
+typedef union {
+	long long align;
 	char padding[_POBJ_CL_SIZE];
 } PMEMmutex;
 
-typedef struct {
+typedef union {
+	long long align;
 	char padding[_POBJ_CL_SIZE];
 } PMEMrwlock;
 
-typedef struct {
+typedef union {
+	long long align;
 	char padding[_POBJ_CL_SIZE];
 } PMEMcond;
 

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -51,7 +51,7 @@
 
 /* attributes of the obj memory pool format for the pool header */
 #define OBJ_HDR_SIG "PMEMOBJ"	/* must be 8 bytes including '\0' */
-#define OBJ_FORMAT_MAJOR 2
+#define OBJ_FORMAT_MAJOR 3
 #define OBJ_FORMAT_COMPAT 0x0000
 #define OBJ_FORMAT_INCOMPAT 0x0000
 #define OBJ_FORMAT_RO_COMPAT 0x0000

--- a/src/libpmemobj/redo.h
+++ b/src/libpmemobj/redo.h
@@ -52,7 +52,7 @@ struct redo_log {
 	uint64_t value;
 };
 
-typedef int  (*redo_check_offset_fn)(void *ctx, uint64_t offset);
+typedef int (*redo_check_offset_fn)(void *ctx, uint64_t offset);
 
 struct redo_ctx *redo_log_config_new(void *base,
 		const struct pmem_ops *p_ops,

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -73,6 +73,8 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 	LOG(15, "pop_runid %ju runid %ju lock %p init_lock %p", pop_runid,
 		*runid, lock, init_lock);
 
+	ASSERTeq((uintptr_t)runid % util_alignof(uint64_t), 0);
+
 	COMPILE_ERROR_ON(util_alignof(PMEMmutex)
 		!= util_alignof(pthread_mutex_t));
 	COMPILE_ERROR_ON(util_alignof(PMEMrwlock)
@@ -151,8 +153,11 @@ pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp)
 
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
+
 	if (mutex == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
 
 	return pthread_mutex_lock(mutex);
 }
@@ -171,6 +176,8 @@ pmemobj_mutex_assert_locked(PMEMobjpool *pop, PMEMmutex *mutexp)
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
 	if (mutex == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
 
 	int ret = pthread_mutex_trylock(mutex);
 	if (ret == EBUSY)
@@ -203,6 +210,8 @@ pmemobj_mutex_timedlock(PMEMobjpool *pop, PMEMmutex *__restrict mutexp,
 	if (mutex == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
+
 	return pthread_mutex_timedlock(mutex, abs_timeout);
 }
 
@@ -222,6 +231,8 @@ pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp)
 	if (mutex == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
+
 	return pthread_mutex_trylock(mutex);
 }
 
@@ -238,6 +249,8 @@ pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp)
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
 	if (mutex == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
 
 	return pthread_mutex_unlock(mutex);
 }
@@ -274,6 +287,8 @@ pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 	if (rwlock == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
+
 	return pthread_rwlock_rdlock(rwlock);
 }
 
@@ -292,6 +307,8 @@ pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
 
 	return pthread_rwlock_wrlock(rwlock);
 }
@@ -314,6 +331,8 @@ pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
 	if (rwlock == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
+
 	return pthread_rwlock_timedrdlock(rwlock, abs_timeout);
 }
 
@@ -335,6 +354,8 @@ pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
 	if (rwlock == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
+
 	return pthread_rwlock_timedwrlock(rwlock, abs_timeout);
 }
 
@@ -353,6 +374,8 @@ pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
 
 	return pthread_rwlock_tryrdlock(rwlock);
 }
@@ -373,6 +396,8 @@ pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 	if (rwlock == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
+
 	return pthread_rwlock_trywrlock(rwlock);
 }
 
@@ -389,6 +414,8 @@ pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)rwlock % util_alignof(pthread_rwlock_t), 0);
 
 	return pthread_rwlock_unlock(rwlock);
 }
@@ -425,6 +452,8 @@ pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp)
 	if (cond == NULL)
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)cond % util_alignof(pthread_cond_t), 0);
+
 	return pthread_cond_broadcast(cond);
 }
 
@@ -443,6 +472,8 @@ pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp)
 	pthread_cond_t *cond = GET_COND(pop, condip);
 	if (cond == NULL)
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)cond % util_alignof(pthread_cond_t), 0);
 
 	return pthread_cond_signal(cond);
 }
@@ -468,6 +499,9 @@ pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *__restrict condp,
 	if ((cond == NULL) || (mutex == NULL))
 		return EINVAL;
 
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
+	ASSERTeq((uintptr_t)cond % util_alignof(pthread_cond_t), 0);
+
 	return pthread_cond_timedwait(cond, mutex, abs_timeout);
 }
 
@@ -489,6 +523,9 @@ pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
 	if ((cond == NULL) || (mutex == NULL))
 		return EINVAL;
+
+	ASSERTeq((uintptr_t)mutex % util_alignof(pthread_mutex_t), 0);
+	ASSERTeq((uintptr_t)cond % util_alignof(pthread_cond_t), 0);
 
 	return pthread_cond_wait(cond, mutex);
 }

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -73,6 +73,13 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 	LOG(15, "pop_runid %ju runid %ju lock %p init_lock %p", pop_runid,
 		*runid, lock, init_lock);
 
+	COMPILE_ERROR_ON(util_alignof(PMEMmutex)
+		!= util_alignof(pthread_mutex_t));
+	COMPILE_ERROR_ON(util_alignof(PMEMrwlock)
+		!= util_alignof(pthread_rwlock_t));
+	COMPILE_ERROR_ON(util_alignof(PMEMcond)
+		!= util_alignof(pthread_cond_t));
+
 	uint64_t tmp_runid;
 
 	VALGRIND_REMOVE_PMEM_MAPPING(runid, sizeof(*runid));

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -79,6 +79,7 @@ OBJ_TESTS = \
 	obj_heap_state\
 	obj_include\
 	obj_lane\
+	obj_layout\
 	obj_list_insert\
 	obj_list_move\
 	obj_list_recovery\

--- a/src/test/libpmempool_transform/out0.log.match
+++ b/src/test/libpmempool_transform/out0.log.match
@@ -13,7 +13,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -25,7 +25,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -37,7 +37,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -49,7 +49,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -61,7 +61,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/libpmempool_transform/out1.log.match
+++ b/src/test/libpmempool_transform/out1.log.match
@@ -13,7 +13,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -25,7 +25,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -37,7 +37,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -49,7 +49,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -61,7 +61,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -73,7 +73,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -85,7 +85,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/libpmempool_transform/out1w.log.match
+++ b/src/test/libpmempool_transform/out1w.log.match
@@ -44,3 +44,5 @@ Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)
 Root offset              : 0x0
+
+

--- a/src/test/libpmempool_transform/out1w.log.match
+++ b/src/test/libpmempool_transform/out1w.log.match
@@ -28,7 +28,7 @@ type                     : regular file
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -44,5 +44,3 @@ Number of lanes          : 1024
 Heap offset              : $(nW)
 Heap size                : $(nW)
 Root offset              : 0x0
-
-

--- a/src/test/magic/out0.log.match
+++ b/src/test/magic/out0.log.match
@@ -1,5 +1,5 @@
-$(*): Persistent Memory Pool file, type: BLK, version $(*)
-$(*): Persistent Memory Pool file, type: LOG, version $(*)
-$(*): Persistent Memory Pool file, type: OBJ, version $(*)
+$(*): Persistent Memory Pool file, type: BLK, version 0x1
+$(*): Persistent Memory Pool file, type: LOG, version 0x1
+$(*): Persistent Memory Pool file, type: OBJ, version 0x3
 $(*): Persistent Memory Poolset file
 $(*): Persistent Memory Poolset file with replica

--- a/src/test/magic/out0.log.match
+++ b/src/test/magic/out0.log.match
@@ -1,5 +1,5 @@
-$(*): Persistent Memory Pool file, type: BLK, version 0x1
-$(*): Persistent Memory Pool file, type: LOG, version 0x1
-$(*): Persistent Memory Pool file, type: OBJ, version 0x2
+$(*): Persistent Memory Pool file, type: BLK, version $(*)
+$(*): Persistent Memory Pool file, type: LOG, version $(*)
+$(*): Persistent Memory Pool file, type: OBJ, version $(*)
 $(*): Persistent Memory Poolset file
 $(*): Persistent Memory Poolset file with replica

--- a/src/test/obj_convert/common.sh
+++ b/src/test/obj_convert/common.sh
@@ -40,11 +40,11 @@ export MEMCHECK_DONT_CHECK_LEAKS=1
 
 verify_scenario() {
 	# convert tool always ask for confirmation, so say yes ;)
-	echo -e "y\n" | expect_normal_exit\
+	echo -e "y\ny\n" | expect_normal_exit\
 		$PMEMPOOL$EXESUFFIX convert $DIR/scenario$1a &> /dev/null
 	expect_normal_exit ./obj_convert$EXESUFFIX $DIR/scenario$1a va $1
 
-	echo -e "y\n" | expect_normal_exit\
+	echo -e "y\ny\n" | expect_normal_exit\
 		$PMEMPOOL$EXESUFFIX convert $DIR/scenario$1c &> /dev/null
 	expect_normal_exit ./obj_convert$EXESUFFIX $DIR/scenario$1c vc $1
 }
@@ -77,4 +77,3 @@ run_scenarios() {
 		verify_scenario $i
 	done
 }
-

--- a/src/test/obj_layout/.gitignore
+++ b/src/test/obj_layout/.gitignore
@@ -1,0 +1,1 @@
+obj_layout

--- a/src/test/obj_layout/Makefile
+++ b/src/test/obj_layout/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,12 +31,12 @@
 #
 
 #
-# src/test/obj_pmalloc_basic/Makefile -- build obj_pmalloc_basic unit test
+# src/test/obj_layout/Makefile -- build layout unit test
 #
-TARGET = obj_pmalloc_basic
-OBJS = obj_pmalloc_basic.o
+TARGET = obj_layout
+OBJS = obj_layout.o
 
 LIBPMEM=y
-LIBPMEMOBJ=internal-nondebug
+LIBPMEMOBJ=internal-debug
 
 include ../Makefile.inc

--- a/src/test/obj_layout/TEST0
+++ b/src/test/obj_layout/TEST0
@@ -1,5 +1,6 @@
+#!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2016, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,12 +32,18 @@
 #
 
 #
-# src/test/obj_pmalloc_basic/Makefile -- build obj_pmalloc_basic unit test
+# src/test/obj_layout/TEST0 -- unit test for obj_layout interface
 #
-TARGET = obj_pmalloc_basic
-OBJS = obj_pmalloc_basic.o
+export UNITTEST_NAME=obj_layout/TEST0
+export UNITTEST_NUM=0
 
-LIBPMEM=y
-LIBPMEMOBJ=internal-nondebug
+# standard unit test setup
+. ../unittest/unittest.sh
 
-include ../Makefile.inc
+require_test_type short
+
+setup
+
+expect_normal_exit ./obj_layout$EXESUFFIX
+
+pass

--- a/src/test/obj_layout/obj_layout.c
+++ b/src/test/obj_layout/obj_layout.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2016, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_layout.c -- unit test for layout
+ *
+ * This test should be modified after every layout change. It's here to prevent
+ * any accidental layout changes.
+ */
+#include "util.h"
+#include "unittest.h"
+
+#include "sync.h"
+#include "heap_layout.h"
+#include "lane.h"
+#include "pvector.h"
+#include "tx.h"
+#include "redo.h"
+#include "list.h"
+
+#define SIZEOF_CHUNK_HEADER_V3 (8)
+#define MAX_CHUNK_V3 (65535 - 7)
+#define SIZEOF_CHUNK_V3 (1024ULL * 256)
+#define SIZEOF_ZONE_HEADER_V3 (64)
+#define SIZEOF_ZONE_METADATA_V3 (SIZEOF_ZONE_HEADER_V3 +\
+	SIZEOF_CHUNK_HEADER_V3 * MAX_CHUNK_V3)
+#define SIZEOF_HEAP_HDR_V3 (1024)
+#define SIZEOF_ALLOCATION_HEADER_V3 (16)
+#define SIZEOF_LOCK_V3 (64)
+#define SIZEOF_PMEMOID_V3 (16)
+#define SIZEOF_LIST_ENTRY_V3 (SIZEOF_PMEMOID_V3 * 2)
+#define SIZEOF_LIST_HEAD_V3 (SIZEOF_PMEMOID_V3 + SIZEOF_LOCK_V3)
+#define SIZEOF_LANE_SECTION_V3 (1024)
+#define SIZEOF_LANE_V3 (3 * SIZEOF_LANE_SECTION_V3)
+#define SIZEOF_PVECTOR_V3 (224)
+#define SIZEOF_TX_RANGE_META_V3 (16)
+#define SIZEOF_TX_RANGE_CACHE_V3 (8112)
+#define SIZEOF_REDO_LOG_V3 (16)
+#define SIZEOF_LANE_LIST_LAYOUT_V3 (1024 - 8)
+#define SIZEOF_LANE_ALLOC_LAYOUT_V3 (10 * SIZEOF_REDO_LOG_V3)
+#define SIZEOF_LANE_TX_LAYOUT_V3 (8 + (4 * SIZEOF_PVECTOR_V3))
+
+POBJ_LAYOUT_BEGIN(layout);
+POBJ_LAYOUT_ROOT(layout, struct foo);
+POBJ_LAYOUT_END(layout);
+
+struct foo {
+	POBJ_LIST_ENTRY(struct foo) f;
+};
+
+POBJ_LIST_HEAD(foo_head, struct foo);
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_layout");
+
+	UT_COMPILE_ERROR_ON(CHUNKSIZE != SIZEOF_CHUNK_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct chunk);
+	ASSERT_ALIGNED_FIELD(struct chunk, data);
+	ASSERT_ALIGNED_CHECK(struct chunk);
+	UT_COMPILE_ERROR_ON(sizeof(struct chunk_run) != SIZEOF_CHUNK_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct chunk_run);
+	ASSERT_ALIGNED_FIELD(struct chunk_run, block_size);
+	ASSERT_ALIGNED_FIELD(struct chunk_run, bucket_vptr);
+	ASSERT_ALIGNED_FIELD(struct chunk_run, bitmap);
+	ASSERT_ALIGNED_FIELD(struct chunk_run, data);
+	ASSERT_ALIGNED_CHECK(struct chunk_run);
+	UT_COMPILE_ERROR_ON(sizeof(struct chunk_run) != SIZEOF_CHUNK_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct chunk_header);
+	ASSERT_ALIGNED_FIELD(struct chunk_header, type);
+	ASSERT_ALIGNED_FIELD(struct chunk_header, flags);
+	ASSERT_ALIGNED_FIELD(struct chunk_header, size_idx);
+	ASSERT_ALIGNED_CHECK(struct chunk_header);
+	UT_COMPILE_ERROR_ON(sizeof(struct chunk_header) !=
+		SIZEOF_CHUNK_HEADER_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct zone_header);
+	ASSERT_ALIGNED_FIELD(struct zone_header, magic);
+	ASSERT_ALIGNED_FIELD(struct zone_header, size_idx);
+	ASSERT_ALIGNED_FIELD(struct zone_header, reserved);
+	ASSERT_ALIGNED_CHECK(struct zone_header);
+	UT_COMPILE_ERROR_ON(sizeof(struct zone_header) !=
+		SIZEOF_ZONE_HEADER_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct zone);
+	ASSERT_ALIGNED_FIELD(struct zone, header);
+	ASSERT_ALIGNED_FIELD(struct zone, chunk_headers);
+	ASSERT_ALIGNED_CHECK(struct zone);
+	UT_COMPILE_ERROR_ON(sizeof(struct zone) !=
+		SIZEOF_ZONE_METADATA_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct heap_header);
+	ASSERT_ALIGNED_FIELD(struct heap_header, signature);
+	ASSERT_ALIGNED_FIELD(struct heap_header, major);
+	ASSERT_ALIGNED_FIELD(struct heap_header, minor);
+	ASSERT_ALIGNED_FIELD(struct heap_header, size);
+	ASSERT_ALIGNED_FIELD(struct heap_header, chunksize);
+	ASSERT_ALIGNED_FIELD(struct heap_header, chunks_per_zone);
+	ASSERT_ALIGNED_FIELD(struct heap_header, reserved);
+	ASSERT_ALIGNED_FIELD(struct heap_header, checksum);
+	ASSERT_ALIGNED_CHECK(struct heap_header);
+	UT_COMPILE_ERROR_ON(sizeof(struct heap_header) !=
+		SIZEOF_HEAP_HDR_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct allocation_header);
+	ASSERT_ALIGNED_FIELD(struct allocation_header, zone_id);
+	ASSERT_ALIGNED_FIELD(struct allocation_header, chunk_id);
+	ASSERT_ALIGNED_FIELD(struct allocation_header, size);
+	ASSERT_ALIGNED_CHECK(struct allocation_header);
+	UT_COMPILE_ERROR_ON(sizeof(struct allocation_header) !=
+		SIZEOF_ALLOCATION_HEADER_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct redo_log);
+	ASSERT_ALIGNED_FIELD(struct redo_log, offset);
+	ASSERT_ALIGNED_FIELD(struct redo_log, value);
+	ASSERT_ALIGNED_CHECK(struct redo_log);
+	UT_COMPILE_ERROR_ON(sizeof(struct redo_log) !=
+		SIZEOF_REDO_LOG_V3);
+
+	ASSERT_ALIGNED_BEGIN(PMEMoid);
+	ASSERT_ALIGNED_FIELD(PMEMoid, pool_uuid_lo);
+	ASSERT_ALIGNED_FIELD(PMEMoid, off);
+	ASSERT_ALIGNED_CHECK(PMEMoid);
+	UT_COMPILE_ERROR_ON(sizeof(PMEMoid) !=
+		SIZEOF_PMEMOID_V3);
+
+	UT_COMPILE_ERROR_ON(sizeof(PMEMmutex) != SIZEOF_LOCK_V3);
+	UT_COMPILE_ERROR_ON(sizeof(PMEMmutex) != sizeof(PMEMmutex_internal));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMmutex) !=
+		util_alignof(PMEMmutex_internal));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMmutex) !=
+		util_alignof(pthread_mutex_t));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMmutex) !=
+		util_alignof(uint64_t));
+
+	UT_COMPILE_ERROR_ON(sizeof(PMEMrwlock) != SIZEOF_LOCK_V3);
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMrwlock) !=
+		util_alignof(PMEMrwlock_internal));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMrwlock) !=
+		util_alignof(pthread_rwlock_t));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMrwlock) !=
+		util_alignof(uint64_t));
+
+	UT_COMPILE_ERROR_ON(sizeof(PMEMcond) != SIZEOF_LOCK_V3);
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMcond) !=
+		util_alignof(PMEMcond_internal));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMcond) !=
+		util_alignof(pthread_cond_t));
+	UT_COMPILE_ERROR_ON(util_alignof(PMEMcond) !=
+		util_alignof(uint64_t));
+
+	UT_COMPILE_ERROR_ON(sizeof(struct foo) != SIZEOF_LIST_ENTRY_V3);
+	UT_COMPILE_ERROR_ON(sizeof(struct list_entry) != SIZEOF_LIST_ENTRY_V3);
+	UT_COMPILE_ERROR_ON(sizeof(struct foo_head) != SIZEOF_LIST_HEAD_V3);
+	UT_COMPILE_ERROR_ON(sizeof(struct list_head) != SIZEOF_LIST_HEAD_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct lane_list_layout);
+	ASSERT_ALIGNED_FIELD(struct lane_list_layout, obj_offset);
+	ASSERT_ALIGNED_FIELD(struct lane_list_layout, redo);
+	ASSERT_ALIGNED_CHECK(struct lane_list_layout);
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_list_layout) >
+		sizeof(struct lane_section_layout));
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_list_layout) !=
+		SIZEOF_LANE_LIST_LAYOUT_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct lane_alloc_layout);
+	ASSERT_ALIGNED_FIELD(struct lane_alloc_layout, redo);
+	ASSERT_ALIGNED_CHECK(struct lane_alloc_layout);
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_alloc_layout) >
+		sizeof(struct lane_section_layout));
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_alloc_layout) !=
+		SIZEOF_LANE_ALLOC_LAYOUT_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct lane_tx_layout);
+	ASSERT_ALIGNED_FIELD(struct lane_tx_layout, state);
+	ASSERT_ALIGNED_FIELD(struct lane_tx_layout, undo_log);
+	ASSERT_ALIGNED_CHECK(struct lane_tx_layout);
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_tx_layout) >
+		sizeof(struct lane_section_layout));
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_tx_layout) !=
+		SIZEOF_LANE_TX_LAYOUT_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct lane_layout);
+	ASSERT_ALIGNED_FIELD(struct lane_layout, sections);
+	ASSERT_ALIGNED_CHECK(struct lane_layout);
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_layout) !=
+		SIZEOF_LANE_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct lane_section_layout);
+	ASSERT_ALIGNED_FIELD(struct lane_section_layout, data);
+	ASSERT_ALIGNED_CHECK(struct lane_section_layout);
+	UT_COMPILE_ERROR_ON(sizeof(struct lane_section_layout) !=
+		SIZEOF_LANE_SECTION_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct pvector);
+	ASSERT_ALIGNED_FIELD(struct pvector, arrays);
+	ASSERT_ALIGNED_FIELD(struct pvector, embedded);
+	ASSERT_ALIGNED_CHECK(struct pvector);
+	UT_COMPILE_ERROR_ON(sizeof(struct pvector) !=
+		SIZEOF_PVECTOR_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct tx_range);
+	ASSERT_ALIGNED_FIELD(struct tx_range, offset);
+	ASSERT_ALIGNED_FIELD(struct tx_range, size);
+	ASSERT_ALIGNED_CHECK(struct tx_range);
+	UT_COMPILE_ERROR_ON(sizeof(struct tx_range) !=
+		SIZEOF_TX_RANGE_META_V3);
+
+	ASSERT_ALIGNED_BEGIN(struct tx_range_cache);
+	ASSERT_ALIGNED_FIELD(struct tx_range_cache, range);
+	ASSERT_ALIGNED_CHECK(struct tx_range_cache);
+	UT_COMPILE_ERROR_ON(sizeof(struct tx_range_cache) !=
+		SIZEOF_TX_RANGE_CACHE_V3);
+
+	DONE(NULL);
+}

--- a/src/test/obj_pmalloc_basic/Makefile
+++ b/src/test/obj_pmalloc_basic/Makefile
@@ -37,6 +37,6 @@ TARGET = obj_pmalloc_basic
 OBJS = obj_pmalloc_basic.o
 
 LIBPMEM=y
-LIBPMEMOBJ=internal-nondebug
+LIBPMEMOBJ=internal-debug
 
 include ../Makefile.inc

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -249,8 +249,6 @@ test_spec_compliance()
 		sizeof(struct oob_header);
 
 	UT_ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
-	UT_COMPILE_ERROR_ON(sizeof(struct allocation_header) != 16);
-	UT_COMPILE_ERROR_ON(sizeof(struct chunk_header) != 8);
 	UT_COMPILE_ERROR_ON(offsetof(struct chunk_run, data) <
 		MAX_CACHELINE_ALIGNMENT);
 }

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -249,6 +249,10 @@ test_spec_compliance()
 		sizeof(struct oob_header);
 
 	UT_ASSERTeq(max_alloc, PMEMOBJ_MAX_ALLOC_SIZE);
+	UT_COMPILE_ERROR_ON(sizeof(struct allocation_header) != 16);
+	UT_COMPILE_ERROR_ON(sizeof(struct chunk_header) != 8);
+	UT_COMPILE_ERROR_ON(offsetof(struct chunk_run, data) <
+		MAX_CACHELINE_ALIGNMENT);
 }
 
 int

--- a/src/test/pmempool_info/out12.log.match
+++ b/src/test/pmempool_info/out12.log.match
@@ -5,7 +5,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(*)
 Mandatory features       : $(*)
 Not mandatory features   : $(*)
 Forced RO                : $(*)

--- a/src/test/pmempool_info/out18.log.match
+++ b/src/test/pmempool_info/out18.log.match
@@ -8,7 +8,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -40,7 +40,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out10.log.match
+++ b/src/test/pmempool_sync/out10.log.match
@@ -25,7 +25,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out10w.log.match
+++ b/src/test/pmempool_sync/out10w.log.match
@@ -23,7 +23,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out2.log.match
+++ b/src/test/pmempool_sync/out2.log.match
@@ -26,7 +26,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -47,7 +47,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -59,7 +59,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -71,7 +71,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -83,7 +83,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out2w.log.match
+++ b/src/test/pmempool_sync/out2w.log.match
@@ -26,7 +26,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -47,7 +47,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -59,7 +59,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -71,7 +71,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -83,7 +83,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out3.log.match
+++ b/src/test/pmempool_sync/out3.log.match
@@ -8,7 +8,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -20,7 +20,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -32,7 +32,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out4.log.match
+++ b/src/test/pmempool_sync/out4.log.match
@@ -24,7 +24,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -45,7 +45,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -57,7 +57,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -69,7 +69,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -81,7 +81,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out4w.log.match
+++ b/src/test/pmempool_sync/out4w.log.match
@@ -24,7 +24,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -45,7 +45,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -57,7 +57,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -69,7 +69,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -81,7 +81,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out6.log.match
+++ b/src/test/pmempool_sync/out6.log.match
@@ -16,7 +16,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -37,7 +37,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -49,7 +49,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_sync/out7.log.match
+++ b/src/test/pmempool_sync/out7.log.match
@@ -22,7 +22,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -43,7 +43,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -55,7 +55,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -67,7 +67,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out0.log.match
+++ b/src/test/pmempool_transform/out0.log.match
@@ -10,7 +10,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -22,7 +22,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -34,7 +34,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -46,7 +46,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -58,7 +58,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out1.log.match
+++ b/src/test/pmempool_transform/out1.log.match
@@ -10,7 +10,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -22,7 +22,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -34,7 +34,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -46,7 +46,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -58,7 +58,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -70,7 +70,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -82,7 +82,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out10.log.match
+++ b/src/test/pmempool_transform/out10.log.match
@@ -27,7 +27,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out10w.log.match
+++ b/src/test/pmempool_transform/out10w.log.match
@@ -25,7 +25,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out2.log.match
+++ b/src/test/pmempool_transform/out2.log.match
@@ -17,7 +17,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -38,7 +38,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -50,7 +50,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out2w.log.match
+++ b/src/test/pmempool_transform/out2w.log.match
@@ -17,7 +17,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -38,7 +38,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -50,7 +50,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out3.log.match
+++ b/src/test/pmempool_transform/out3.log.match
@@ -24,7 +24,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -45,7 +45,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out3w.log.match
+++ b/src/test/pmempool_transform/out3w.log.match
@@ -22,7 +22,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -43,7 +43,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out4.log.match
+++ b/src/test/pmempool_transform/out4.log.match
@@ -54,7 +54,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -75,7 +75,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -87,7 +87,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -99,7 +99,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -111,7 +111,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -123,7 +123,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out4w.log.match
+++ b/src/test/pmempool_transform/out4w.log.match
@@ -54,7 +54,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -75,7 +75,7 @@ size                     : 20971520
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -87,7 +87,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -99,7 +99,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -111,7 +111,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -123,7 +123,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out5.log.match
+++ b/src/test/pmempool_transform/out5.log.match
@@ -46,7 +46,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -67,7 +67,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -79,7 +79,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -91,7 +91,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -103,7 +103,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out5w.log.match
+++ b/src/test/pmempool_transform/out5w.log.match
@@ -44,7 +44,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -65,7 +65,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -77,7 +77,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -89,7 +89,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -101,7 +101,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out6.log.match
+++ b/src/test/pmempool_transform/out6.log.match
@@ -44,7 +44,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out6w.log.match
+++ b/src/test/pmempool_transform/out6w.log.match
@@ -42,7 +42,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out7.log.match
+++ b/src/test/pmempool_transform/out7.log.match
@@ -26,7 +26,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -47,7 +47,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -59,7 +59,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ [part file]
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out8.log.match
+++ b/src/test/pmempool_transform/out8.log.match
@@ -21,7 +21,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -42,7 +42,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/pmempool_transform/out9.log.match
+++ b/src/test/pmempool_transform/out9.log.match
@@ -21,7 +21,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0
@@ -42,7 +42,7 @@ size                     : $(nW)
 
 POOL Header:
 Signature                : PMEMOBJ
-Major                    : 2
+Major                    : $(nW)
 Mandatory features       : 0x0
 Not mandatory features   : 0x0
 Forced RO                : 0x0

--- a/src/test/rpmem_proto/rpmem_proto.c
+++ b/src/test/rpmem_proto/rpmem_proto.c
@@ -42,32 +42,6 @@
 #include "librpmem.h"
 #include "rpmem_proto.h"
 
-#define STR(x)	#x
-
-#define ASSERT_ALIGNED_BEGIN(type) do {\
-size_t off = 0;\
-const char *last = "(none)";\
-type t;\
-
-#define ASSERT_ALIGNED_FIELD(type, field) do {\
-if (0)\
-	UT_OUT("%s.%s\t\t: offset %lu real offset %lu",\
-		STR(type), STR(field), off, offsetof(type, field));\
-if (offsetof(type, field) != off)\
-	UT_FATAL("%s: padding, missing field or fields not in order between "\
-		"'%s' and '%s' -- offset %lu, real offset %lu",\
-		STR(type), last, STR(field), off, offsetof(type, field));\
-off += sizeof(t.field);\
-last = STR(field);\
-} while (0)
-
-#define ASSERT_ALIGNED_CHECK(type)\
-if (off != sizeof(type))\
-	UT_FATAL("%s: missing field or padding after '%s': "\
-		"sizeof(%s) = %lu, fields size = %lu",\
-		STR(type), last, STR(type), sizeof(type), off);\
-} while (0)
-
 int
 main(int argc, char *argv[])
 {

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -732,6 +732,28 @@ _name(const struct test_case *tc, int argc, char *argv[])
 	.func = _name,\
 }
 
+#define STR(x) #x
+
+#define ASSERT_ALIGNED_BEGIN(type) do {\
+size_t off = 0;\
+const char *last = "(none)";\
+type t;
+
+#define ASSERT_ALIGNED_FIELD(type, field) do {\
+if (offsetof(type, field) != off)\
+	UT_FATAL("%s: padding, missing field or fields not in order between "\
+		"'%s' and '%s' -- offset %lu, real offset %lu",\
+		STR(type), last, STR(field), off, offsetof(type, field));\
+off += sizeof(t.field);\
+last = STR(field);\
+} while (0)
+
+#define ASSERT_ALIGNED_CHECK(type)\
+if (off != sizeof(type))\
+	UT_FATAL("%s: missing field or padding after '%s': "\
+		"sizeof(%s) = %lu, fields size = %lu",\
+		STR(type), last, STR(type), sizeof(type), off);\
+} while (0)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This patch restores the proper alignment of the structures containing
pthread locks, it's a regression introduced in 672fc89. This is an ABI
change, and thus all of the pools created prior to it are incompatible
without an upgrade path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1489)
<!-- Reviewable:end -->
