### PR TITLE
test: fix require_dev_dax_node()

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -826,7 +826,7 @@ function require_dev_dax_node() {
 			exit 0
 		fi
 		local device_dax_path=${NODE_DEVICE_DAX_PATH[$node]}
-		local cmd="run_command ssh $SSH_OPTS ${NODE[$node]} cd $DIR && LD_LIBRARY_PATH=$REMOTE_LD_LIBRARY_PATH ../pmemdetect -d"
+		local cmd="ssh $SSH_OPTS ${NODE[$node]} cd $DIR && LD_LIBRARY_PATH=$REMOTE_LD_LIBRARY_PATH ../pmemdetect -d"
 	else
 		local prefix="$UNITTEST_NAME: SKIP"
 		if [ ${#DEVICE_DAX_PATH[@]} -lt $min ]; then


### PR DESCRIPTION
Output of pmemdetect is not printed, beacuse of usage
of run_command(). It looks like this:

obj_rpmem_basic_integration/TEST12: SKIP NODE 0:

Remove run_command() so that output of pmemdetect was printed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1523)
<!-- Reviewable:end -->
