### PR TITLE
test: tools: make pmemdetect recognize DAX device

### DIFF
--- a/src/test/tools/pmemdetect/pmemdetect.c
+++ b/src/test/tools/pmemdetect/pmemdetect.c
@@ -70,7 +70,7 @@ is_pmem(const char *path)
 }
 
 /*
- * is_dev_Dax -- checks if given path points to device dax
+ * is_dev_dax -- checks if given path points to device dax
  */
 static int
 is_dev_dax(const char *path)
@@ -85,7 +85,7 @@ is_dev_dax(const char *path)
 		return -1;
 	}
 
-	return 0;
+	return 1;
 }
 
 int


### PR DESCRIPTION
Pmemdetect has not recognized DAX device so far.
Correct return value of is_dev_dax() to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1524)
<!-- Reviewable:end -->
