### PR TITLE
pmempool: fix mapping type in pool_params_parse

### DIFF
--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -349,7 +349,7 @@ pool_params_parse(const PMEMpoolcheck *ppc, struct pool_params *params,
 		}
 		params->size = (size_t)s;
 		addr = mmap(NULL, (uint64_t)params->size, PROT_READ,
-			MAP_PRIVATE, fd, 0);
+			MAP_SHARED, fd, 0);
 		if (addr == MAP_FAILED) {
 			ret = -1;
 			goto out_close;


### PR DESCRIPTION
This change is required on account of DAX devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1531)
<!-- Reviewable:end -->
