### PR TITLE
common: queue.h clang static analyzer fix

### DIFF
--- a/src/common/queue.h
+++ b/src/common/queue.h
@@ -81,6 +81,16 @@
  * For details on the use of these macros, see the queue(3) manual page.
  */
 
+#ifdef __clang_analyzer__
+static void custom_assert(int) __attribute__((analyzer_noreturn))
+{
+}
+
+#define CLANG_ASSERT(x) custom_assert(x)
+#else
+#define CLANG_ASSERT(x) do {} while (0)
+#endif
+
 /*
  * List definitions.
  */
@@ -433,6 +443,7 @@ struct {								\
 } while (/*CONSTCOND*/0)
 
 #define	TAILQ_REMOVE(head, elm, field) do {				\
+	CLANG_ASSERT(elm);						\
 	if (((elm)->field.tqe_next) != NULL)				\
 		(elm)->field.tqe_next->field.tqe_prev = 		\
 		    (elm)->field.tqe_prev;				\


### PR DESCRIPTION
This is a workaround for reported clang static analyzer false
positives from queue.h.

Ref: pmem/issues#309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1547)
<!-- Reviewable:end -->
