### PR TITLE
benchmark: use C++ includes

### DIFF
--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,11 +56,11 @@
 #ifndef _BENCHMARK_H
 #define _BENCHMARK_H
 
-#include <limits.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <climits>
+#include <cstdbool>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 #include <util.h>
 

--- a/src/benchmarks/benchmark_time.cpp
+++ b/src/benchmarks/benchmark_time.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,10 +34,10 @@
  * benchmark_time.cpp -- benchmark_time module definitions
  */
 #include "benchmark_time.hpp"
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #define NSECPSEC 1000000000
 

--- a/src/benchmarks/benchmark_time.hpp
+++ b/src/benchmarks/benchmark_time.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@
 /*
  * benchmark_time.hpp -- declarations of benchmark_time module
  */
-#include <time.h>
+#include <ctime>
 
 typedef struct timespec benchmark_time_t;
 

--- a/src/benchmarks/benchmark_worker.cpp
+++ b/src/benchmarks/benchmark_worker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
  * benchmark_worker.cpp -- benchmark_worker module definitions
  */
 
-#include <assert.h>
+#include <cassert>
 #include <err.h>
 
 #include "benchmark_worker.hpp"

--- a/src/benchmarks/blk.cpp
+++ b/src/benchmarks/blk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,14 +36,14 @@
 
 #include "benchmark.hpp"
 #include "libpmemblk.h"
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
 #include <pthread.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 struct blk_bench;

--- a/src/benchmarks/clo.cpp
+++ b/src/benchmarks/clo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,12 +32,12 @@
 /*
  * clo.cpp -- command line options module definitions
  */
-#include <assert.h>
+#include <cassert>
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
 #include <err.h>
-#include <errno.h>
 #include <getopt.h>
-#include <inttypes.h>
-#include <string.h>
 
 #include "benchmark.hpp"
 #include "clo.hpp"

--- a/src/benchmarks/clo_vec.cpp
+++ b/src/benchmarks/clo_vec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,9 +32,9 @@
 /*
  * clo_vec.cpp -- command line options vector definitions
  */
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 
 #include "clo_vec.hpp"
 

--- a/src/benchmarks/clo_vec.hpp
+++ b/src/benchmarks/clo_vec.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
  * clo_vec.hpp -- command line options vector declarations
  */
 #include "queue.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 struct clo_vec_args {
 	TAILQ_ENTRY(clo_vec_args) next;

--- a/src/benchmarks/config_reader.cpp
+++ b/src/benchmarks/config_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,11 +32,11 @@
 /*
  * config_reader.cpp -- config reader module definitions
  */
-#include <assert.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <glib.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/queue.h>
 
 #include "config_reader.hpp"

--- a/src/benchmarks/config_reader_win.cpp
+++ b/src/benchmarks/config_reader_win.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,10 +32,10 @@
 /*
  * config_reader_win.cpp -- config reader module definitions
  */
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <tchar.h>
 
 #include "config_reader.hpp"

--- a/src/benchmarks/log.cpp
+++ b/src/benchmarks/log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,10 +33,10 @@
  * log.cpp -- pmemlog benchmarks definitions
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstring>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
 #include <unistd.h>

--- a/src/benchmarks/map_bench.cpp
+++ b/src/benchmarks/map_bench.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
  * map_bench.cpp -- benchmarks for: ctree, btree, rtree, rbtree, hashmap_atomic
  * and hashmap_tx from examples.
  */
-#include <assert.h>
+#include <cassert>
 #include <pthread.h>
 
 #include "benchmark.hpp"

--- a/src/benchmarks/obj_lanes.cpp
+++ b/src/benchmarks/obj_lanes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,8 @@
  * obj_lanes.cpp -- lane benchmark definition
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include <unistd.h>
 
 #include "benchmark.hpp"

--- a/src/benchmarks/obj_locks.cpp
+++ b/src/benchmarks/obj_locks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,8 +34,8 @@
  * obj_locks.cpp -- main source file for PMEM locks benchmark
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include <pthread.h>
 
 #include "benchmark.hpp"

--- a/src/benchmarks/obj_pmalloc.cpp
+++ b/src/benchmarks/obj_pmalloc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,13 +34,13 @@
  * obj_pmalloc.cpp -- pmalloc benchmarks definition
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include "benchmark.hpp"

--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,14 +33,14 @@
 /*
  * pmem_flush.cpp -- benchmark implementation for pmem_persist and pmem_msync
  */
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
 #include <libpmem.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
 

--- a/src/benchmarks/pmem_memcpy.cpp
+++ b/src/benchmarks/pmem_memcpy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,14 +32,14 @@
 /*
  * pmem_memcpy.cpp -- benchmark implementation for pmem_memcpy
  */
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
 #include <libpmem.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
 

--- a/src/benchmarks/pmem_memset.cpp
+++ b/src/benchmarks/pmem_memset.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,11 @@
  * pmem_memset.cpp -- benchmark for pmem_memset function
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstring>
 #include <fcntl.h>
 #include <libpmem.h>
-#include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,17 +34,17 @@
  * pmembench.cpp -- main source file for benchmark framework
  */
 
-#include <assert.h>
+#include <cassert>
+#include <cerrno>
+#include <cfloat>
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <dirent.h>
 #include <err.h>
-#include <errno.h>
-#include <float.h>
 #include <getopt.h>
-#include <inttypes.h>
 #include <linux/limits.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,12 +37,12 @@
 #include "benchmark.hpp"
 #include "libpmemobj.h"
 #include "queue.h"
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #define FACTOR 8

--- a/src/benchmarks/pmemobj_gen.cpp
+++ b/src/benchmarks/pmemobj_gen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,13 +35,13 @@
  * and pmemobj_open() functions.
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
 #include <file.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/src/benchmarks/pmemobj_persist.cpp
+++ b/src/benchmarks/pmemobj_persist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,13 +34,13 @@
  * pmemobj_persist.cpp -- pmemobj persist benchmarks definition
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <unistd.h>

--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,12 +34,12 @@
  * pmemobj_tx.cpp -- pmemobj_tx_alloc(), pmemobj_tx_free(),
  * pmemobj_tx_realloc(), pmemobj_tx_add_range() benchmarks.
  */
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
 #include "benchmark.hpp"

--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,13 +34,13 @@
  * rpmem_persist.cpp -- rpmem persist benchmarks definition
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <unistd.h>

--- a/src/benchmarks/scenario.cpp
+++ b/src/benchmarks/scenario.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,9 +32,9 @@
 /*
  * scenario.cpp -- scenario module definitions
  */
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
 
 #include "queue.h"
 #include "scenario.hpp"

--- a/src/benchmarks/scenario.hpp
+++ b/src/benchmarks/scenario.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
  * scenario.hpp -- scenario module declaration
  */
 
-#include <stdbool.h>
+#include <cstdbool>
 
 struct kv {
 	TAILQ_ENTRY(kv) next;

--- a/src/benchmarks/vmem.cpp
+++ b/src/benchmarks/vmem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
  */
 
 #include "benchmark.hpp"
-#include <assert.h>
+#include <cassert>
 #include <libvmem.h>
 #include <sys/stat.h>
 


### PR DESCRIPTION
Use proper C++ includes since benchmarks are compiled as C++.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1549)
<!-- Reviewable:end -->
