### PR TITLE
benchmark: do not use '-std=c++11'

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -116,7 +116,8 @@ endif
 
 CXXFLAGS = -Wall
 CXXFLAGS += -Werror
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=c++0x
+CXXFLAGS += -Wno-invalid-offsetof
 CXXFLAGS += -Wpointer-arith
 CXXFLAGS += -Wunused-macros
 CXXFLAGS += -pthread

--- a/src/benchmarks/pmemobj_atomic_lists.cpp
+++ b/src/benchmarks/pmemobj_atomic_lists.cpp
@@ -213,7 +213,7 @@ enum type_mode {
 static struct element
 position_head(struct obj_worker *obj_worker, size_t op_idx)
 {
-	struct element head = {0};
+	struct element head = {0, OID_NULL, false};
 	head.before = true;
 	if (!obj_bench.args->queue)
 		head.itemp = POBJ_LIST_FIRST(&obj_worker->head);
@@ -228,7 +228,7 @@ position_head(struct obj_worker *obj_worker, size_t op_idx)
 static struct element
 position_tail(struct obj_worker *obj_worker, size_t op_idx)
 {
-	struct element tail = {0};
+	struct element tail = {0, OID_NULL, false};
 	tail.before = false;
 	if (!obj_bench.args->queue)
 		tail.itemp = POBJ_LIST_LAST(&obj_worker->head, field);
@@ -285,7 +285,7 @@ static TOID(struct item) obj_get_item(struct obj_worker *obj_worker, size_t idx)
 static struct element
 position_rand(struct obj_worker *obj_worker, size_t op_idx)
 {
-	struct element elm = {0};
+	struct element elm = {0, OID_NULL, false};
 	elm.before = true;
 	if (!obj_bench.args->queue)
 		elm.itemp =


### PR DESCRIPTION
There is nothing in benchmark code that requires C++11.
Also, it appears like '-std=c++11' is not supported by the current
version of Coverity Scan Analysis Tool that is integrated with TravisCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1561)
<!-- Reviewable:end -->
