### PR TITLE
travis: fix path issues in script

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-23
+++ b/utils/docker/images/Dockerfile.fedora-23
@@ -42,7 +42,7 @@ MAINTAINER wojciech.uss@intel.com
 RUN dnf install -y git gcc clang openssh-server autoconf automake make \
 	wget tar lbzip2 passwd sudo pkgconfig findutils man libunwind-devel \
 	file rpm-build rpm-build-libs which fuse fuse-devel ncurses-devel \
-	libuv-devel glib2-devel libtool pandoc doxygen
+	libuv-devel glib2-devel libtool pandoc doxygen cmake
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -43,7 +43,7 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common libunwind8-dev autoconf \
 	devscripts pkg-config ssh git gcc clang debhelper sudo whois \
 	libc6-dbg libncurses5-dev libuv1-dev libfuse-dev libglib2.0-dev \
-	libtool pandoc doxygen graphviz clang-format-3.8
+	libtool pandoc doxygen graphviz clang-format-3.8 cmake
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/install-libcxx.sh
+++ b/utils/docker/images/install-libcxx.sh
@@ -37,24 +37,25 @@
 llvm_url=https://github.com/llvm-mirror/llvm.git
 libcxxabi_url=https://github.com/llvm-mirror/libcxxabi.git
 libcxx_url=https://github.com/pmem/libcxx.git
-install_path=$HOME/install
-top=$(pwd)
+top=/tmp
+install_path=/usr/local/libcxx
 
 export CC=clang
 export CXX=clang++
 
+cd $top
 git clone $llvm_url
-cd llvm
+cd $top/llvm
 git checkout origin/release_39
-cd projects
+cd $top/llvm/projects
 git clone $libcxxabi_url
 git clone $libcxx_url
-cd libcxxabi
+cd $top/llvm/projects/libcxxabi
 git checkout origin/release_39
 cd $top
 mkdir -p build/abi
 mkdir -p build/lib
-cd build/abi
+cd $top/build/abi
 cmake -DLLVM_PATH=$top/llvm -DCMAKE_INSTALL_PREFIX=$install_path $top/llvm/projects/libcxxabi/
 make install
 cd $top/build/lib


### PR DESCRIPTION
 Our docker images build and install packages as root and run tests
 as nvmluser. Change install dir to /var/install to enable all users
 to use the custom libcxx.
    
 Add cmake to docker images to build libcxx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1571)
<!-- Reviewable:end -->
