### PR TITLE
common: run Coverity scan builds via 'cron'

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -35,17 +35,17 @@
 #            prepared for building NVML project.
 #
 
-if [[ "$TRAVIS_BRANCH" != "coverity_scan" && "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan build if not on 'coverity_scan' branch"
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$COVERITY" -eq 1 ]]; then
+	echo "INFO: Skip Coverity scan job if build is not triggered by 'cron'"
 	exit 0
 fi
 
-if [[ "$TRAVIS_BRANCH" == "coverity_scan" && "$COVERITY" -ne 1 ]]; then
-	echo "INFO: Skip regular builds on 'coverity_scan' branch"
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$COVERITY" -ne 1 ]]; then
+	echo "INFO: Skip regular jobs if build is triggered by 'cron'"
 	exit 0
 fi
 
-if [[ "$TRAVIS_BRANCH" == "coverity_scan" && "$COVERITY" -eq 1 ]]; then
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$COVERITY" -eq 1 ]]; then
 	./run-coverity.sh
 	exit $?
 fi

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -47,13 +47,13 @@
 # the Docker Hub.
 #
 
-if [[ "$TRAVIS_BRANCH" != "coverity_scan" && "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan build if not on 'coverity_scan' branch"
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$COVERITY" -eq 1 ]]; then
+	echo "INFO: Skip Coverity scan job if build is not triggered by 'cron'"
 	exit 0
 fi
 
-if [[ "$TRAVIS_BRANCH" == "coverity_scan" ]]; then
-	echo "INFO: Skip Docker image preparation for Coverity scan build"
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+	echo "INFO: Skip Docker image preparation for Coverity scan job"
 	exit 0
 fi
 

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -43,7 +43,7 @@ echo -n | openssl s_client -connect scan.coverity.com:443 | \
 export CC=gcc
 
 export COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
-export COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
+export COVERITY_SCAN_BRANCH_PATTERN="master"
 export COVERITY_SCAN_BUILD_COMMAND="make -j all"
 
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Make use of new Travis feature and trigger daily Coverity scans
on 'master' branch using 'cron' builds.
The 'coverity_scan' branch is not needed anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1572)
<!-- Reviewable:end -->
