### PR TITLE
examples/benchmarks: properly end the transaction on abort

### DIFF
--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -484,7 +484,7 @@ static int
 obj_op_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 	  size_t idx)
 {
-	int ret = 0;
+	volatile int ret = 0;
 	struct obj_tx_worker *obj_worker = (struct obj_tx_worker *)worker->priv;
 	TX_BEGIN(obj_bench->pop)
 	{
@@ -506,7 +506,7 @@ obj_op_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 		if (obj_bench->op_mode != OP_MODE_ABORT &&
 		    obj_bench->op_mode != OP_MODE_ABORT_NESTED) {
 			fprintf(stderr, "transaction failed\n");
-			return -1;
+			ret = -1;
 		}
 	}
 	TX_END

--- a/src/examples/libpmemobj/hashmap/hashmap_tx.c
+++ b/src/examples/libpmemobj/hashmap/hashmap_tx.c
@@ -251,6 +251,7 @@ hm_tx_remove(PMEMobjpool *pop, TOID(struct hashmap_tx) hashmap, uint64_t key)
 
 	if (TOID_IS_NULL(var))
 		return OID_NULL;
+	int ret = 0;
 
 	TX_BEGIN(pop) {
 		if (TOID_IS_NULL(prev))
@@ -268,8 +269,11 @@ hm_tx_remove(PMEMobjpool *pop, TOID(struct hashmap_tx) hashmap, uint64_t key)
 	} TX_ONABORT {
 		fprintf(stderr, "transaction aborted: %s\n",
 			pmemobj_errormsg());
-		return OID_NULL;
+		ret = -1;
 	} TX_END
+
+	if (ret)
+		return OID_NULL;
 
 	if (D_RO(hashmap)->count < D_RO(buckets)->nbuckets)
 		hm_tx_rebuild(pop, hashmap, D_RO(buckets)->nbuckets / 2);


### PR DESCRIPTION
Returning from ONABORT section does not close the surrounding transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1576)
<!-- Reviewable:end -->
