### PR TITLE
docker: fix valgrind tests under docker

### DIFF
--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@ cat << EOF > $WORKDIR/src/test/testconfig.sh
 NON_PMEM_FS_DIR=/tmp
 PMEM_FS_DIR=/tmp
 PMEM_FS_DIR_FORCE_PMEM=1
+TEST_BUILD="debug nondebug"
 EOF
 
 # Configure remote tests

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,8 +45,8 @@ export RPMEM_DISABLE_LIBIBVERBS=y
 cd $WORKDIR
 make check-license \
 	&& make cstyle \
-	&& make -j2 USE_LIBUNWIND=1 BUILD_STATIC=n \
-	&& make -j2 test USE_LIBUNWIND=1 BUILD_STATIC=n \
-	&& make -j2 pcheck BUILD_STATIC=n \
+	&& make -j2 USE_LIBUNWIND=1 \
+	&& make -j2 test USE_LIBUNWIND=1 \
+	&& make -j2 pcheck \
 	&& make DESTDIR=/tmp source
 


### PR DESCRIPTION
The test for valgrind support compiled into our libraries needs
statically linkied binaries. Enable build and disable running tests
to save time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1577)
<!-- Reviewable:end -->
