### PR TITLE
cpp: fix wrong pointer type in the allocator

### DIFF
--- a/src/include/libpmemobj++/allocator.hpp
+++ b/src/include/libpmemobj++/allocator.hpp
@@ -201,6 +201,7 @@ public:
 	 */
 	using value_type = T;
 	using pointer = persistent_ptr<value_type>;
+	using const_void_pointer = persistent_ptr<const void>;
 	using size_type = std::size_t;
 	using bool_type = bool;
 
@@ -248,8 +249,7 @@ public:
 	 * @throw transaction_scope_error if called outside of a transaction.
 	 */
 	pointer
-	allocate(size_type cnt,
-		 typename std::allocator<void>::const_pointer = 0)
+	allocate(size_type cnt, const_void_pointer = 0)
 	{
 		if (pmemobj_tx_stage() != TX_STAGE_WORK)
 			throw transaction_scope_error(
@@ -352,8 +352,7 @@ public:
 	 * @throw transaction_scope_error if called outside of a transaction.
 	 */
 	pointer
-	allocate(size_type cnt,
-		 typename std::allocator<void>::const_pointer = 0)
+	allocate(size_type cnt, const_pointer = 0)
 	{
 		if (pmemobj_tx_stage() != TX_STAGE_WORK)
 			throw transaction_scope_error(


### PR DESCRIPTION
Wrong pointer type in unused parameters of allocate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1581)
<!-- Reviewable:end -->
