### PR TITLE
rpmem: limit the message size to maximum

### DIFF
--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -1290,11 +1290,22 @@ rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
 		return 0;
 	}
 
-	int ret = fip->ops->persist(fip, offset, len, lane);
-	if (ret) {
-		RPMEM_LOG(ERR, "persist operation failed");
-	}
 
+	int ret = 0;
+	while (len > 0) {
+		size_t tmp_len = len < fip->fi->ep_attr->max_msg_size ?
+			len : fip->fi->ep_attr->max_msg_size;
+
+		ret = fip->ops->persist(fip, offset, tmp_len, lane);
+		if (ret) {
+			RPMEM_LOG(ERR, "persist operation failed");
+			goto err;
+		}
+
+		offset += tmp_len;
+		len -= tmp_len;
+	}
+err:
 	return ret;
 }
 


### PR DESCRIPTION
Read the maximum message size from endpoint's attributes and respect
this in rpmem_persist function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1592)
<!-- Reviewable:end -->
