### PR TITLE
cpp: fix swap implementation

### DIFF
--- a/src/include/libpmemobj++/detail/persistent_ptr_base.hpp
+++ b/src/include/libpmemobj++/detail/persistent_ptr_base.hpp
@@ -208,7 +208,6 @@ public:
 	persistent_ptr_base &
 	operator=(persistent_ptr_base const &r)
 	{
-		detail::conditional_add_to_tx(this);
 		this_type(r).swap(*this);
 
 		return *this;
@@ -245,7 +244,6 @@ public:
 	persistent_ptr_base &
 	operator=(persistent_ptr_base<Y> const &r)
 	{
-		detail::conditional_add_to_tx(this);
 		this_type(r).swap(*this);
 
 		return *this;
@@ -257,8 +255,10 @@ public:
 	 * @param[in,out] other the other persistent_ptr to swap.
 	 */
 	void
-	swap(persistent_ptr_base &other) noexcept
+	swap(persistent_ptr_base &other)
 	{
+		detail::conditional_add_to_tx(this);
+		detail::conditional_add_to_tx(&other);
 		std::swap(this->oid, other.oid);
 	}
 

--- a/src/include/libpmemobj++/p.hpp
+++ b/src/include/libpmemobj++/p.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,8 +94,6 @@ public:
 	p &
 	operator=(const p &rhs)
 	{
-		detail::conditional_add_to_tx(this);
-
 		this_type(rhs).swap(*this);
 
 		return *this;
@@ -116,8 +114,6 @@ public:
 	p &
 	operator=(const p<Y> &rhs)
 	{
-		detail::conditional_add_to_tx(this);
-
 		this_type(rhs).swap(*this);
 
 		return *this;
@@ -164,10 +160,15 @@ public:
 
 	/**
 	 * Swaps two p objects of the same type.
+	 *
+	 * @throw nvml::transaction_error when adding the object to the
+	 *	transaction failed.
 	 */
 	void
-	swap(p &other) noexcept
+	swap(p &other)
 	{
+		detail::conditional_add_to_tx(this);
+		detail::conditional_add_to_tx(&other);
 		std::swap(this->val, other.val);
 	}
 
@@ -183,7 +184,7 @@ private:
  */
 template <class T>
 inline void
-swap(p<T> &a, p<T> &b) noexcept
+swap(p<T> &a, p<T> &b)
 {
 	a.swap(b);
 }

--- a/src/include/libpmemobj++/persistent_ptr.hpp
+++ b/src/include/libpmemobj++/persistent_ptr.hpp
@@ -369,7 +369,7 @@ public:
  */
 template <class T>
 inline void
-swap(persistent_ptr<T> &a, persistent_ptr<T> &b) noexcept
+swap(persistent_ptr<T> &a, persistent_ptr<T> &b)
 {
 	a.swap(b);
 }

--- a/src/test/obj_cpp_p_ext/TEST1
+++ b/src/test/obj_cpp_p_ext/TEST1
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_p_ext/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_cxx11
+configure_valgrind pmemcheck force-enable
+
+setup
+
+expect_normal_exit\
+    ./obj_cpp_p_ext$EXESUFFIX $DIR/testfile1
+
+pass

--- a/src/test/obj_cpp_ptr/TEST1
+++ b/src/test/obj_cpp_ptr/TEST1
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_cpp_ptr/TEST1
+export UNITTEST_NUM=1
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_cxx11
+configure_valgrind pmemcheck force-enable
+
+setup
+
+expect_normal_exit\
+    ./obj_cpp_ptr$EXESUFFIX $DIR/testfile1
+
+pass


### PR DESCRIPTION
The swap implementation for both p<> and persistent_ptr<> was incorrect
in terms of powerfail safety. After these changes swap for both classes
may throw an exception. The C++ [swappable.requirements] does not specify
that a user defined swap be noexcept.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1595)
<!-- Reviewable:end -->
