### PR TITLE
jemalloc: clear LIB_OUTDIR while building jemalloc

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -111,9 +111,11 @@ else
 objdir = ../$(OBJDIR)/$(DIRNAME)
 endif
 
-LIB_OUTDIR = $(objdir)/..
+LIB_OUTDIR ?= $(objdir)/..
 
+ifneq ($(LIB_OUTDIR),)
 LDFLAGS += -L$(LIB_OUTDIR)
+endif
 
 ifneq ($(SOURCE),)
 _OBJS = $(SOURCE:.c=.o)

--- a/src/jemalloc/Makefile.nvml
+++ b/src/jemalloc/Makefile.nvml
@@ -1,4 +1,4 @@
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,5 +42,7 @@ include ./jemalloc.mk
 ifeq ($(DEBUG),1)
 JEMALLOC_CONFIG += --enable-debug
 endif
+
+LIB_OUTDIR =
 
 include ../Makefile.inc


### PR DESCRIPTION
The path used in LIB_OUTDIR is not valid while building jemalloc.
The linker in some toolchains issues a warning for this, and
since fatal warnings are enabled among the linker flags, it can
beak the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1597)
<!-- Reviewable:end -->
