### PR TITLE
vmem: Format string fix in vmem.c

### DIFF
--- a/src/libvmem/vmem.c
+++ b/src/libvmem/vmem.c
@@ -258,7 +258,7 @@ vmem_delete(VMEM *vmp)
 
 	int ret = je_vmem_pool_delete((pool_t *)((uintptr_t)vmp + Header_size));
 	if (ret != 0) {
-		ERR("invalid pool handle: 0x%" PRIx64, (uintptr_t)vmp);
+		ERR("invalid pool handle: 0x%" PRIxPTR, (uintptr_t)vmp);
 		errno = EINVAL;
 		return;
 	}


### PR DESCRIPTION
Some picky toolchains don't like printing uintptr_t as PRIx64
 - e.g. when uintptr_t is ul, while uint64_t is ull.
Using %p instead of % PRIx64 format specifier.
Another option is to use the PRIxPTR format specifier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1598)
<!-- Reviewable:end -->
