### PR TITLE
common: allow coverity scans on Travis without a cron

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -35,17 +35,22 @@
 #            prepared for building NVML project.
 #
 
-if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan job if build is not triggered by 'cron'"
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
+	&& "$COVERITY" -eq 1 ]]; then
+	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
+		"'cron' nor by a push to 'coverity_scan' branch"
 	exit 0
 fi
 
-if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$COVERITY" -ne 1 ]]; then
-	echo "INFO: Skip regular jobs if build is triggered by 'cron'"
+if [[ ( "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" )\
+	&& "$COVERITY" -ne 1 ]]; then
+	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
+		" or by a push to 'coverity_scan' branch"
 	exit 0
 fi
 
-if [[ "$TRAVIS_EVENT_TYPE" == "cron" && "$COVERITY" -eq 1 ]]; then
+if [[ ( "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" )\
+	&& "$COVERITY" -eq 1 ]]; then
 	./run-coverity.sh
 	exit $?
 fi

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -47,12 +47,15 @@
 # the Docker Hub.
 #
 
-if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$COVERITY" -eq 1 ]]; then
-	echo "INFO: Skip Coverity scan job if build is not triggered by 'cron'"
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
+	&& "$COVERITY" -eq 1 ]]; then
+	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
+		"'cron' nor by a push to 'coverity_scan' branch"
 	exit 0
 fi
 
-if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" ]]
+then
 	echo "INFO: Skip Docker image preparation for Coverity scan job"
 	exit 0
 fi

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -43,7 +43,9 @@ echo -n | openssl s_client -connect scan.coverity.com:443 | \
 export CC=gcc
 
 export COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
-export COVERITY_SCAN_BRANCH_PATTERN="master"
+[[ "$TRAVIS_EVENT_TYPE" == "cron" ]] \
+	&& export COVERITY_SCAN_BRANCH_PATTERN="master" \
+	|| export COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
 export COVERITY_SCAN_BUILD_COMMAND="make -j all"
 
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
This allows users to run Coverity scans on their own forks just by pushing to 'coverity_scan' branch.
Users have to define COVERITY_SCAN_NOTIFICATION_EMAIL and COVERITY_SCAN_TOKEN in their project's settings on Travis. For details see https://scan.coverity.com/travis_ci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1607)
<!-- Reviewable:end -->
