### PR TITLE
obj: remove pmemobj_direct from libpmemobj.map

### DIFF
--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,7 +61,6 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_cond_wait;
 		pmemobj_pool_by_oid;
 		pmemobj_pool_by_ptr;
-		pmemobj_direct;
 		pmemobj_oid;
 		pmemobj_alloc;
 		pmemobj_zalloc;


### PR DESCRIPTION
pmemobj_direct is only declared as static inline in headers,
it is not a public symbol.

See also:

nm src/nondebug/libpmemobj/libpmemobj_unscoped.o | grep direct

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1608)
<!-- Reviewable:end -->
