### PR TITLE
common: remove dead code found by clang static analyzer

### DIFF
--- a/src/benchmarks/pmem_flush.cpp
+++ b/src/benchmarks/pmem_flush.cpp
@@ -244,7 +244,7 @@ static int
 flush_msync_0(struct pmem_bench *pmb, void *addr, size_t len)
 {
 	void *ptr = align_addr(addr, PAGE_4K);
-	len = align_len(len, addr, PAGE_4K);
+	(void)len;
 
 	msync(ptr, 0, MS_SYNC);
 	return 0;

--- a/src/benchmarks/pmemobj_tx.cpp
+++ b/src/benchmarks/pmemobj_tx.cpp
@@ -414,8 +414,8 @@ add_range_nested_tx(struct obj_tx_bench *obj_bench, struct worker_info *worker,
 			size_t n_oid = obj_bench->n_oid(obj_worker->tx_level);
 			struct offset offset = obj_bench->fn_off(
 				obj_bench, obj_worker->tx_level);
-			ret = pmemobj_tx_add_range(obj_worker->oids[n_oid].oid,
-						   offset.off, offset.size);
+			pmemobj_tx_add_range(obj_worker->oids[n_oid].oid,
+					     offset.off, offset.size);
 			obj_worker->tx_level++;
 			ret = add_range_nested_tx(obj_bench, worker, idx);
 		}

--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -683,7 +683,6 @@ rpmem_remove(const char *target, const char *pool_set, int flags)
 	ret = rpmem_ssh_monitor(ssh, 0);
 	if (ret) {
 		ERR("!waiting for remote command failed");
-		ret = -1;
 		goto err_ssh_monitor;
 	}
 

--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1330,6 +1330,12 @@ rpmem_fip_read(struct rpmem_fip *fip, void *buff, size_t len, size_t off)
 
 		ret = rpmem_fip_readmsg(fip->ep, &fip->rd_lane.read,
 				fip->rd_buff, rd_len, raddr);
+		if (ret) {
+			RPMEM_FI_ERR(ret, "RMA read");
+			errno = ret;
+			return -1;
+		}
+
 		VALGRIND_DO_MAKE_MEM_DEFINED(fip->rd_buff, rd_len);
 
 		ret = rpmem_fip_lane_wait(&fip->rd_lane.lane, FI_READ);

--- a/src/rpmem_common/rpmem_fip_common.c
+++ b/src/rpmem_common/rpmem_fip_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -310,7 +310,7 @@ rpmem_fip_print_info(struct fi_info *fi)
 
 	RPMEMC_LOG(INFO, "libfabric interface info:");
 
-	char *nl = buff;
+	char *nl;
 	char *last = buff;
 	while (last != NULL) {
 		nl = strchr(last, '\n');

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -614,7 +614,8 @@ rpmemd_req_close(struct rpmemd_obc *obc, void *arg)
 	}
 
 	int remove = rpmemd->created && status;
-	ret = rpmemd_close_pool(rpmemd, remove);
+	if (rpmemd_close_pool(rpmemd, remove))
+		RPMEMD_LOG(ERR, "closing pool failed");
 
 	RPMEMD_LOG(NOTICE, "close request response (status = %u)", status);
 	ret = rpmemd_obc_close_resp(rpmemd->obc, status);

--- a/src/tools/rpmemd/rpmemd_fip_worker.c
+++ b/src/tools/rpmemd/rpmemd_fip_worker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,8 +165,7 @@ rpmemd_fip_worker_fini(struct rpmemd_fip_worker *worker)
 
 	errno = pthread_cond_signal(&worker->cond);
 	if (errno) {
-		RPMEMD_LOG(ERR, "!sending signal to worker");
-		ret = -1;
+		RPMEMD_FATAL("!sending signal to worker");
 	}
 
 	util_mutex_unlock(&worker->lock);

--- a/src/tools/rpmemd/rpmemd_log.c
+++ b/src/tools/rpmemd/rpmemd_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -229,8 +229,6 @@ rpmemd_log(enum rpmemd_log_level level, const char *fname, int lineno,
 			"%s%s%s", prefix, errorstr, suffix);
 	if (ret < 0)
 		RPMEMD_FATAL("snprintf failed");
-
-	cnt += (size_t)ret;
 
 	if (rpmemd_use_syslog) {
 		int prio = rpmemd_level2prio[level];


### PR DESCRIPTION
Remove dead increments and assignments in:

    pmem_flush.cpp
    pmemobj_tx.cpp
    rpmem.c
    rpmem_fip.c
    rpmem_fip_common.c
    rpmemd.c
    rpmemd_fip_worker.c
    rpmemd_log.c
Ref: pmem/issues#413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1618)
<!-- Reviewable:end -->
