### PR TITLE
cpp: replace NULL with nullptr

### DIFF
--- a/src/test/obj_cpp_allocator/obj_cpp_allocator.cpp
+++ b/src/test/obj_cpp_allocator/obj_cpp_allocator.cpp
@@ -183,5 +183,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -434,5 +434,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
+++ b/src/test/obj_cpp_cond_var_posix/obj_cpp_cond_var_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -488,5 +488,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_deque/obj_cpp_deque.cpp
+++ b/src/test/obj_cpp_deque/obj_cpp_deque.cpp
@@ -97,7 +97,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_deque");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -126,5 +126,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_list/obj_cpp_list.cpp
+++ b/src/test/obj_cpp_list/obj_cpp_list.cpp
@@ -96,7 +96,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_list");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -125,5 +125,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
+++ b/src/test/obj_cpp_make_persistent/obj_cpp_make_persistent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -224,5 +224,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
+++ b/src/test/obj_cpp_make_persistent_array/obj_cpp_make_persistent_array.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -244,5 +244,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_array_atomic/obj_cpp_make_persistent_array_atomic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -230,5 +230,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
+++ b/src/test/obj_cpp_make_persistent_atomic/obj_cpp_make_persistent_atomic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -169,5 +169,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_map/obj_cpp_map.cpp
+++ b/src/test/obj_cpp_map/obj_cpp_map.cpp
@@ -112,7 +112,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_map");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -141,5 +141,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_multimap/obj_cpp_multimap.cpp
+++ b/src/test/obj_cpp_multimap/obj_cpp_multimap.cpp
@@ -118,7 +118,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_multimap");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -147,5 +147,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_multiset/obj_cpp_multiset.cpp
+++ b/src/test/obj_cpp_multiset/obj_cpp_multiset.cpp
@@ -106,7 +106,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_multiset");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -135,5 +135,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
+++ b/src/test/obj_cpp_mutex/obj_cpp_mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,5 +155,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
+++ b/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -165,5 +165,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
+++ b/src/test/obj_cpp_p_ext/obj_cpp_p_ext.cpp
@@ -395,5 +395,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_pool/obj_cpp_pool.cpp
+++ b/src/test/obj_cpp_pool/obj_cpp_pool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -173,9 +173,9 @@ main(int argc, char *argv[])
 
 	switch (argv[1][0]) {
 		case 'c':
-			poolsize = strtoul(argv[4], NULL, 0) *
+			poolsize = strtoul(argv[4], nullptr, 0) *
 				MB; /* in megabytes */
-			mode = strtoul(argv[5], NULL, 8);
+			mode = strtoul(argv[5], nullptr, 8);
 
 			pool_create(argv[2], layout, poolsize, mode);
 			break;
@@ -183,9 +183,9 @@ main(int argc, char *argv[])
 			pool_open(argv[2], layout);
 			break;
 		case 'd':
-			poolsize = strtoul(argv[4], NULL, 0) *
+			poolsize = strtoul(argv[4], nullptr, 0) *
 				MB; /* in megabytes */
-			mode = strtoul(argv[5], NULL, 8);
+			mode = strtoul(argv[5], nullptr, 8);
 
 			double_close(argv[2], layout, poolsize, mode);
 			break;
@@ -196,5 +196,5 @@ main(int argc, char *argv[])
 			UT_FATAL("unknown operation");
 	}
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
+++ b/src/test/obj_cpp_pool_primitives/obj_cpp_pool_primitives.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -290,5 +290,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_priority_queue/obj_cpp_priority_queue.cpp
+++ b/src/test/obj_cpp_priority_queue/obj_cpp_priority_queue.cpp
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_priority_queue");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -138,5 +138,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -53,7 +53,8 @@ namespace
 {
 
 /*
- * test_null_ptr -- verifies if the pointer correctly behaves like a NULL-value
+ * test_null_ptr -- verifies if the pointer correctly behaves like a
+ * nullptr-value
  */
 void
 test_null_ptr(nvobj::persistent_ptr<int> &f)
@@ -61,7 +62,7 @@ test_null_ptr(nvobj::persistent_ptr<int> &f)
 	UT_ASSERT(OID_IS_NULL(f.raw()));
 	UT_ASSERT((bool)f == false);
 	UT_ASSERT(!f);
-	UT_ASSERTeq(f.get(), NULL);
+	UT_ASSERTeq(f.get(), nullptr);
 	UT_ASSERT(f == nullptr);
 }
 
@@ -77,7 +78,7 @@ get_temp()
 }
 
 /*
- * test_ptr_operators_null -- verifies various operations on NULL pointers
+ * test_ptr_operators_null -- verifies various operations on nullptr pointers
  */
 void
 test_ptr_operators_null()
@@ -139,7 +140,7 @@ test_ptr_atomic(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTne(pfoo.get(), NULL);
+	UT_ASSERTne(pfoo.get(), nullptr);
 
 	(*pfoo).bar = TEST_INT;
 	pop.persist(pfoo);
@@ -156,7 +157,7 @@ test_ptr_atomic(nvobj::pool<root> &pop)
 		UT_ASSERT(0);
 	}
 
-	UT_ASSERTeq(pfoo.get(), NULL);
+	UT_ASSERTeq(pfoo.get(), nullptr);
 }
 
 /*
@@ -341,5 +342,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
+++ b/src/test/obj_cpp_ptr_arith/obj_cpp_ptr_arith.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ prepare_array(nvobj::pool_base &pop)
 
 	nvobj::persistent_ptr<T> parr_vsize;
 	ret = pmemobj_alloc(pop.get_handle(), parr_vsize.raw_ptr(),
-			    sizeof(T) * TEST_ARR_SIZE, 0, NULL, NULL);
+			    sizeof(T) * TEST_ARR_SIZE, 0, nullptr, nullptr);
 
 	UT_ASSERTeq(ret, 0);
 
@@ -231,5 +231,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_queue/obj_cpp_queue.cpp
+++ b/src/test/obj_cpp_queue/obj_cpp_queue.cpp
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_queue");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -138,5 +138,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_set/obj_cpp_set.cpp
+++ b/src/test/obj_cpp_set/obj_cpp_set.cpp
@@ -106,7 +106,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_set");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -135,5 +135,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -175,5 +175,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
+++ b/src/test/obj_cpp_shared_mutex_posix/obj_cpp_shared_mutex_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -184,5 +184,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_stack/obj_cpp_stack.cpp
+++ b/src/test/obj_cpp_stack/obj_cpp_stack.cpp
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_stack");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -138,5 +138,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -238,5 +238,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
+++ b/src/test/obj_cpp_timed_mtx_posix/obj_cpp_timed_mtx_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -239,5 +239,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_transaction/obj_cpp_transaction.cpp
+++ b/src/test/obj_cpp_transaction/obj_cpp_transaction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -614,5 +614,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_unordered_map/obj_cpp_unordered_map.cpp
+++ b/src/test/obj_cpp_unordered_map/obj_cpp_unordered_map.cpp
@@ -125,7 +125,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_unordered_map");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -154,5 +154,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_unordered_multimap/obj_cpp_unordered_multimap.cpp
+++ b/src/test/obj_cpp_unordered_multimap/obj_cpp_unordered_multimap.cpp
@@ -128,7 +128,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_unordered_multimap");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -157,5 +157,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_unordered_multiset/obj_cpp_unordered_multiset.cpp
+++ b/src/test/obj_cpp_unordered_multiset/obj_cpp_unordered_multiset.cpp
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_unordered_multiset");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -146,5 +146,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_unordered_set/obj_cpp_unordered_set.cpp
+++ b/src/test/obj_cpp_unordered_set/obj_cpp_unordered_set.cpp
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_unordered_set");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -144,5 +144,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }

--- a/src/test/obj_cpp_vector/obj_cpp_vector.cpp
+++ b/src/test/obj_cpp_vector/obj_cpp_vector.cpp
@@ -95,7 +95,7 @@ main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_cpp_vector");
 
-	if (argc != 3 || strchr("co", argv[1][0]) == NULL)
+	if (argc != 3 || strchr("co", argv[1][0]) == nullptr)
 		UT_FATAL("usage: %s <c,o> file-name", argv[0]);
 
 	const char *path = argv[2];
@@ -124,5 +124,5 @@ main(int argc, char *argv[])
 
 	pop.close();
 
-	DONE(NULL);
+	DONE(nullptr);
 }


### PR DESCRIPTION
As is the convention since c++11, the C NULL should be replaced by nullptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1622)
<!-- Reviewable:end -->
