### PR TITLE
obj: fix obj_sync cgroup/pids trigger

### DIFF
--- a/src/test/obj_sync/TEST0
+++ b/src/test/obj_sync/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX m 50 300
+expect_normal_exit ./obj_sync$EXESUFFIX m 50 5
 
 check
 

--- a/src/test/obj_sync/TEST0.PS1
+++ b/src/test/obj_sync/TEST0.PS1
@@ -54,7 +54,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 50 300
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 50 5
 
 check
 

--- a/src/test/obj_sync/TEST1
+++ b/src/test/obj_sync/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ require_valgrind_dev_3_10
 configure_valgrind drd force-enable
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX m 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX m 10 5
 
 check
 

--- a/src/test/obj_sync/TEST1.PS1
+++ b/src/test/obj_sync/TEST1.PS1
@@ -58,7 +58,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 10 5
 
 check
 

--- a/src/test/obj_sync/TEST2
+++ b/src/test/obj_sync/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ configure_valgrind helgrind force-enable
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX m 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX m 10 5
 
 check
 

--- a/src/test/obj_sync/TEST2.PS1
+++ b/src/test/obj_sync/TEST2.PS1
@@ -58,7 +58,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX m 10 5
 
 check
 

--- a/src/test/obj_sync/TEST3
+++ b/src/test/obj_sync/TEST3
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ require_valgrind_dev_3_10
 configure_valgrind drd force-enable
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX r 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX r 10 5
 
 check
 

--- a/src/test/obj_sync/TEST3.PS1
+++ b/src/test/obj_sync/TEST3.PS1
@@ -58,7 +58,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX r 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX r 10 5
 
 check
 

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ require_valgrind_dev_3_10
 configure_valgrind helgrind force-enable
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX r 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX r 10 5
 
 check
 

--- a/src/test/obj_sync/TEST4.PS1
+++ b/src/test/obj_sync/TEST4.PS1
@@ -57,7 +57,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX r 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX r 10 5
 
 check
 

--- a/src/test/obj_sync/TEST5
+++ b/src/test/obj_sync/TEST5
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ require_valgrind_dev_3_10
 configure_valgrind drd force-enable
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX c 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX c 10 5
 
 check
 

--- a/src/test/obj_sync/TEST5.PS1
+++ b/src/test/obj_sync/TEST5.PS1
@@ -57,7 +57,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX c 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX c 10 5
 
 check
 

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ require_valgrind_dev_3_10
 configure_valgrind helgrind force-enable
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX c 10 50
+expect_normal_exit ./obj_sync$EXESUFFIX c 10 5
 
 check
 

--- a/src/test/obj_sync/TEST6.PS1
+++ b/src/test/obj_sync/TEST6.PS1
@@ -57,7 +57,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX c 10 50
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX c 10 5
 
 check
 

--- a/src/test/obj_sync/TEST7
+++ b/src/test/obj_sync/TEST7
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX t 50 300
+expect_normal_exit ./obj_sync$EXESUFFIX t 50 5
 
 check
 

--- a/src/test/obj_sync/TEST7.PS1
+++ b/src/test/obj_sync/TEST7.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -53,7 +53,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 50 300
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 50 5
 
 check
 

--- a/src/test/obj_sync/TEST8
+++ b/src/test/obj_sync/TEST8
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2017-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,6 @@ configure_valgrind drd force-enable
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX t 10 30
+expect_normal_exit ./obj_sync$EXESUFFIX t 10 5
 
 pass

--- a/src/test/obj_sync/TEST8.PS1
+++ b/src/test/obj_sync/TEST8.PS1
@@ -57,6 +57,6 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 10 30
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 10 5
 
 pass

--- a/src/test/obj_sync/TEST9
+++ b/src/test/obj_sync/TEST9
@@ -49,6 +49,6 @@ configure_valgrind helgrind force-enable
 
 setup
 
-expect_normal_exit ./obj_sync$EXESUFFIX t 10 30
+expect_normal_exit ./obj_sync$EXESUFFIX t 10 5
 
 pass

--- a/src/test/obj_sync/TEST9.PS1
+++ b/src/test/obj_sync/TEST9.PS1
@@ -57,6 +57,6 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 10 30
+expect_normal_exit $Env:EXE_DIR\obj_sync$Env:EXESUFFIX t 10 5
 
 pass


### PR DESCRIPTION
The test sporadically triggered the cgroup/pids.max limit which caused the
pthread_create to fail. This change limits the number of threads spawned in
succesion and makes them run longer. This way the test does not behave like
a fork bomb and should not trigger the cgroup limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1630)
<!-- Reviewable:end -->
