### PR TITLE
common: check-license remove named variadic macro

### DIFF
--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -62,7 +62,7 @@
 #define STR_MODE_PATTERN	"check-pattern"
 #define STR_MODE_LICENSE	"check-license"
 
-#define ERROR(fmt, args...)	fprintf(stderr, "error: " fmt "\n", ## args)
+#define ERROR(fmt, ...)	fprintf(stderr, "error: " fmt "\n", __VA_ARGS__)
 
 /*
  * help_str -- string for the help message


### PR DESCRIPTION
Using a GNU extension is not necessery for the ERROR
macro in check-license.c

error: named variadic macros are a GNU extension
error: token pasting of ',' and __VA_ARGS__ is a GNU extension

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1636)
<!-- Reviewable:end -->
