### PR TITLE
common: check-headers.sh -- path arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -114,7 +114,10 @@ format:
 
 check-license:
 	$(MAKE) -C utils $@
-	@utils/check_license/check-headers.sh
+	@utils/check_license/check-headers.sh \
+		$(TOP) \
+		utils/check_license/check-license \
+		LICENSE
 	@echo Done.
 
 source:

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,16 +33,26 @@
 
 # check-headers.sh - check copyright and license in source files
 
-SH_FILE="utils\/check_license\/check-headers\.sh"
-BIN_FILE="utils\/check_license\/check-license"
-LIC_FILE="LICENSE"
-
-PWD=`pwd -P`
 SELF=$0
-SELF_FULL=`echo "$PWD/$0" | sed "s/\/\.\//\//g" `
-NVML=`echo $SELF_FULL | sed "s/$SH_FILE//g" `
-LICENSE=`echo $SELF_FULL | sed "s/$SH_FILE/$LIC_FILE/g" `
-CHECK_LICENSE=`echo $SELF_FULL | sed "s/$SH_FILE/$BIN_FILE/g" `
+
+function usage() {
+	echo "Usage: $SELF path_source_root path_check_license_bin path_license [-h|-v|-a]"
+	echo "   -h, --help      this help message"
+	echo "   -v, --verbose   verbose mode"
+	echo "   -a, --all       check all files (only modified files are checked by default)"
+}
+
+if [ "$#" -lt 3 ]; then
+	usage >&2
+	exit 2
+fi
+
+SOURCE_ROOT=$1
+shift
+CHECK_LICENSE=$1
+shift
+LICENSE=$1
+shift
 
 PATTERN=`mktemp`
 TMP=`mktemp`
@@ -51,16 +61,13 @@ rm -f $PATTERN $TMP
 function exit_if_not_exist()
 {
 	if [ ! -f $1 ]; then
-		echo "Error: file $1 does not exist. Exiting..."
+		echo "Error: file $1 does not exist. Exiting..." >&2
 		exit 1
 	fi
 }
 
 if [ "$1" == "-h" -o "$1" == "--help" ]; then
-	echo "Usage: $0 [-h|-v|-a]"
-	echo "   -h, --help      this help message"
-	echo "   -v, --verbose   verbose mode"
-	echo "   -a, --all       check all files (only modified files are checked by default)"
+	usage
 	exit 0
 fi
 
@@ -69,7 +76,7 @@ exit_if_not_exist $CHECK_LICENSE
 
 git rev-parse || exit 1
 
-if [ -f $NVML/.git/shallow ]; then
+if [ -f $SOURCE_ROOT/.git/shallow ]; then
 	SHALLOW_CLONE=1
 	echo
 	echo "Warning: This is a shallow clone. Checking dates in copyright headers"
@@ -104,28 +111,28 @@ fi
 
 if [ $CHECK_ALL -eq 1 ]; then
 	echo "Checking copyright headers of all files..."
-	GIT_COMMAND="ls-tree -r --name-only HEAD"
+	GIT_COMMAND="ls-tree -r --name-only HEAD $SOURCE_ROOT"
 else
 	echo
 	echo "Warning: will check copyright headers of modified files only,"
 	echo "         in order to check all files issue the following command:"
-	echo "         $ $SELF -a"
+	echo "         $ $SELF srcroot checklicensebin license -a"
 	echo
 	echo "Checking copyright headers of modified files only..."
-	GIT_COMMAND="diff --name-only $MERGE_BASE $CURRENT_COMMIT"
+	GIT_COMMAND="diff --name-only $MERGE_BASE $CURRENT_COMMIT $SOURCE_ROOT"
 fi
 
 FILES=$(git $GIT_COMMAND | \
 	grep -v -E -e 'src/jemalloc/' -e 'src/windows/jemalloc_gen/' -e '/queue.h$' -e '/ListEntry.h$' \
 		   -e '/getopt.h$' -e '/getopt.c$' | \
-	grep    -E -e '*\.[ch]$' -e '*\.[ch]pp$' -e '*\.sh$' \
+	grep    -E -e '*\.[chs]$' -e '*\.[ch]pp$' -e '*\.sh$' \
 		   -e '*\.py$' -e '*\.map$' -e 'Makefile*' -e 'TEST*' \
 		   -e '/common.inc$' -e '/match$' -e '/check_whitespace$' \
 		   -e 'LICENSE$' | \
 	xargs)
 
 # jemalloc.mk has to be checked always, because of the grep rules above
-FILES="$FILES $NVML/src/jemalloc/jemalloc.mk"
+FILES="$FILES $SOURCE_ROOT/src/jemalloc/jemalloc.mk"
 
 # create a license pattern file
 $CHECK_LICENSE create $LICENSE $PATTERN
@@ -169,11 +176,11 @@ for file in $FILES ; do
 				else
 					NEW=$COMMIT_FIRST-$COMMIT_LAST
 				fi
-				echo "error: wrong copyright date in file: $file (is: $YEARS, should be: $NEW)"
+				echo "error: wrong copyright date in file: $file (is: $YEARS, should be: $NEW)" >&2
 				RV=1
 			fi
 		else
-			echo "error: unknown commit dates in file: $file"
+			echo "error: unknown commit dates in file: $file" >&2
 			RV=1
 		fi
 	fi
@@ -184,6 +191,6 @@ rm -f $TMP
 if [ $RV -eq 0 ]; then
 	echo "Copyright headers are OK."
 else
-	echo "Error(s) in copyright headers found!"
+	echo "Error(s) in copyright headers found!" >&2
 fi
 exit $RV


### PR DESCRIPTION
This is useful for the case of using this script while
doing out of source builds.
Also, print errors to stderr.