### PR TITLE
blk: Fix some format strings

### DIFF
--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -34,6 +34,7 @@
  * blk.c -- block memory pool entry points for libpmem
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -92,11 +93,11 @@ nsread(void *ns, unsigned lane, void *buf, size_t count, uint64_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(13, "pbp %p lane %u count %zu off %ju", pbp, lane, count, off);
+	LOG(13, "pbp %p lane %u count %zu off %" PRIu64, pbp, lane, count, off);
 
 	if (off + count > pbp->datasize) {
 		ERR("offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize);
+				(size_t)off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}
@@ -118,11 +119,11 @@ nswrite(void *ns, unsigned lane, const void *buf, size_t count,
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(13, "pbp %p lane %u count %zu off %ju", pbp, lane, count, off);
+	LOG(13, "pbp %p lane %u count %zu off %" PRIu64, pbp, lane, count, off);
 
 	if (off + count > pbp->datasize) {
 		ERR("offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize);
+				(size_t)off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}
@@ -173,13 +174,13 @@ nsmap(void *ns, unsigned lane, void **addrp, size_t len, uint64_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(12, "pbp %p lane %u len %zu off %ju", pbp, lane, len, off);
+	LOG(12, "pbp %p lane %u len %zu off %" PRIu64, pbp, lane, len, off);
 
 	ASSERT(((ssize_t)len) >= 0);
 
 	if (off + len >= pbp->datasize) {
 		ERR("offset + len (%zu) past end of data area (%zu)",
-				off + len, pbp->datasize - 1);
+				(size_t)off + len, pbp->datasize - 1);
 		errno = EINVAL;
 		return -1;
 	}
@@ -230,11 +231,11 @@ nszero(void *ns, unsigned lane, size_t count, uint64_t off)
 {
 	struct pmemblk *pbp = (struct pmemblk *)ns;
 
-	LOG(13, "pbp %p lane %u count %zu off %ju", pbp, lane, count, off);
+	LOG(13, "pbp %p lane %u count %zu off %" PRIu64, pbp, lane, count, off);
 
 	if (off + count > pbp->datasize) {
 		ERR("offset + count (%zu) past end of data area (%zu)",
-				off + count, pbp->datasize);
+				(size_t)off + count, pbp->datasize);
 		errno = EINVAL;
 		return -1;
 	}

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -121,6 +121,7 @@
  *	build_map_locks	data structures used during I/O.
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <sys/param.h>
 #include <unistd.h>
@@ -280,10 +281,10 @@ static const unsigned Nseq[] = { 0, 2, 3, 1 };
 static int
 invalid_lba(struct btt *bttp, uint64_t lba)
 {
-	LOG(3, "bttp %p lba %ju", bttp, lba);
+	LOG(3, "bttp %p lba %" PRIu64, bttp, lba);
 
 	if (lba >= bttp->nlba) {
-		ERR("lba out of range (nlba %ju)", bttp->nlba);
+		ERR("lba out of range (nlba %" PRIu64 ")", bttp->nlba);
 		errno = EINVAL;
 		return 1;
 	}
@@ -424,7 +425,7 @@ static int
 read_flog_pair(struct btt *bttp, unsigned lane, struct arena *arenap,
 	uint64_t flog_off, struct flog_runtime *flog_runtimep, uint32_t flognum)
 {
-	LOG(5, "bttp %p lane %u arenap %p flog_off %ju runtimep %p "
+	LOG(5, "bttp %p lane %u arenap %p flog_off %" PRIu64 " runtimep %p "
 		"flognum %u", bttp, lane, arenap, flog_off, flog_runtimep,
 		flognum);
 
@@ -438,7 +439,7 @@ read_flog_pair(struct btt *bttp, unsigned lane, struct arena *arenap,
 	}
 
 	if (flog_off == 0) {
-		ERR("invalid flog offset %ju", flog_off);
+		ERR("invalid flog offset %" PRIu64, flog_off);
 		errno = EINVAL;
 		return -1;
 	}
@@ -456,7 +457,7 @@ read_flog_pair(struct btt *bttp, unsigned lane, struct arena *arenap,
 	if (invalid_lba(bttp, flog_pair[1].lba))
 		return -1;
 
-	LOG(6, "flog_pair[0] flog_off %ju old_map %u new_map %u seq %u",
+	LOG(6, "flog_pair[0] flog_off %" PRIu64 " old_map %u new_map %u seq %u",
 			flog_off, flog_pair[0].old_map,
 			flog_pair[0].new_map, flog_pair[0].seq);
 	LOG(6, "flog_pair[1] old_map %u new_map %u seq %u",
@@ -764,7 +765,7 @@ static int
 read_arena(struct btt *bttp, unsigned lane, uint64_t arena_off,
 		struct arena *arenap)
 {
-	LOG(3, "bttp %p lane %u arena_off %ju arenap %p",
+	LOG(3, "bttp %p lane %u arena_off %" PRIu64 " arenap %p",
 			bttp, lane, arena_off, arenap);
 
 	struct btt_info info;
@@ -991,7 +992,8 @@ btt_info_set_params(struct btt_info *info, uint32_t external_lbasize,
 	/* ensure the number of blocks is at least 2*nfree */
 	if (internal_nlba < 2 * nfree) {
 		errno = EINVAL;
-		ERR("!number of internal blocks: %ju expected at least %u",
+		ERR("!number of internal blocks: %" PRIu64
+			" expected at least %u",
 			internal_nlba, 2 * nfree);
 		return -1;
 	}
@@ -1147,11 +1149,11 @@ write_layout(struct btt *bttp, unsigned lane, int write)
 
 		btt_info_set_offs(&info, arena_rawsize, rawsize);
 
-		LOG(4, "nextoff 0x%016jx", info.nextoff);
-		LOG(4, "dataoff 0x%016jx", info.dataoff);
-		LOG(4, "mapoff  0x%016jx", info.mapoff);
-		LOG(4, "flogoff 0x%016jx", info.flogoff);
-		LOG(4, "infooff 0x%016jx", info.infooff);
+		LOG(4, "nextoff 0x%016" PRIx64, info.nextoff);
+		LOG(4, "dataoff 0x%016" PRIx64, info.dataoff);
+		LOG(4, "mapoff  0x%016" PRIx64, info.mapoff);
+		LOG(4, "flogoff 0x%016" PRIx64, info.flogoff);
+		LOG(4, "infooff 0x%016" PRIx64, info.infooff);
 
 		/* zero map if ns is not zero-initialized */
 		if (!bttp->ns_cbp->ns_is_zeroed) {
@@ -1175,7 +1177,8 @@ write_layout(struct btt *bttp, unsigned lane, int write)
 			 * Write both btt_flog structs in the pair, writing
 			 * the second one as all zeros.
 			 */
-			LOG(6, "flog[%u] entry off %ju initial %u + zero = %u",
+			LOG(6, "flog[%u] entry off %" PRIu64
+					" initial %u + zero = %u",
 					i, flog_entry_off,
 					next_free_lba,
 					next_free_lba | BTT_MAP_ENTRY_ZERO);
@@ -1184,7 +1187,7 @@ write_layout(struct btt *bttp, unsigned lane, int write)
 				return -1;
 			flog_entry_off += sizeof(flog);
 
-			LOG(6, "flog[%u] entry off %ju zeros",
+			LOG(6, "flog[%u] entry off %" PRIu64 " zeros",
 					i, flog_entry_off);
 			if ((*bttp->ns_cbp->nswrite)(bttp->ns, lane, &Zflog,
 					sizeof(Zflog), flog_entry_off) < 0)
@@ -1374,7 +1377,7 @@ static int
 lba_to_arena_lba(struct btt *bttp, uint64_t lba,
 		struct arena **arenapp, uint32_t *premap_lbap)
 {
-	LOG(3, "bttp %p lba %ju", bttp, lba);
+	LOG(3, "bttp %p lba %" PRIu64, bttp, lba);
 
 	ASSERT(bttp->laidout);
 
@@ -1410,7 +1413,7 @@ struct btt *
 btt_init(uint64_t rawsize, uint32_t lbasize, uint8_t parent_uuid[],
 		unsigned maxlane, void *ns, const struct ns_callback *ns_cbp)
 {
-	LOG(3, "rawsize %ju lbasize %u", rawsize, lbasize);
+	LOG(3, "rawsize %" PRIu64 " lbasize %u", rawsize, lbasize);
 
 	if (rawsize < BTT_MIN_SIZE) {
 		ERR("rawsize smaller than BTT_MIN_SIZE %u", BTT_MIN_SIZE);
@@ -1494,7 +1497,7 @@ btt_nlba(struct btt *bttp)
 int
 btt_read(struct btt *bttp, unsigned lane, uint64_t lba, void *buf)
 {
-	LOG(3, "bttp %p lane %u lba %ju", bttp, lane, lba);
+	LOG(3, "bttp %p lane %u lba %" PRIu64, bttp, lane, lba);
 
 	if (invalid_lba(bttp, lba))
 		return -1;
@@ -1692,7 +1695,7 @@ map_unlock(struct btt *bttp, unsigned lane, struct arena *arenap,
 int
 btt_write(struct btt *bttp, unsigned lane, uint64_t lba, const void *buf)
 {
-	LOG(3, "bttp %p lane %u lba %ju", bttp, lane, lba);
+	LOG(3, "bttp %p lane %u lba %" PRIu64, bttp, lane, lba);
 
 	if (invalid_lba(bttp, lba))
 		return -1;
@@ -1793,7 +1796,8 @@ btt_write(struct btt *bttp, unsigned lane, uint64_t lba, const void *buf)
 static int
 map_entry_setf(struct btt *bttp, unsigned lane, uint64_t lba, uint32_t setf)
 {
-	LOG(3, "bttp %p lane %u lba %ju setf 0x%x", bttp, lane, lba, setf);
+	LOG(3, "bttp %p lane %u lba %" PRIu64 " setf 0x%x",
+	    bttp, lane, lba, setf);
 
 	if (invalid_lba(bttp, lba))
 		return -1;
@@ -1872,7 +1876,7 @@ map_entry_setf(struct btt *bttp, unsigned lane, uint64_t lba, uint32_t setf)
 int
 btt_set_zero(struct btt *bttp, unsigned lane, uint64_t lba)
 {
-	LOG(3, "bttp %p lane %u lba %ju", bttp, lane, lba);
+	LOG(3, "bttp %p lane %u lba %" PRIu64, bttp, lane, lba);
 
 	return map_entry_setf(bttp, lane, lba, BTT_MAP_ENTRY_ZERO);
 }
@@ -1885,7 +1889,7 @@ btt_set_zero(struct btt *bttp, unsigned lane, uint64_t lba)
 int
 btt_set_error(struct btt *bttp, unsigned lane, uint64_t lba)
 {
-	LOG(3, "bttp %p lane %u lba %ju", bttp, lane, lba);
+	LOG(3, "bttp %p lane %u lba %" PRIu64, bttp, lane, lba);
 
 	return map_entry_setf(bttp, lane, lba, BTT_MAP_ENTRY_ERROR);
 }


### PR DESCRIPTION
For the case where clang issues a warning about
'long long' vs. 'long'.
Both are 64 bit in System V ABI, but still, clang warns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1649)
<!-- Reviewable:end -->
