### PR TITLE
obj: Add a few more compiler time assertions

### DIFF
--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -77,6 +77,13 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 
 	ASSERTeq((uintptr_t)runid % util_alignof(uint64_t), 0);
 
+	COMPILE_ERROR_ON(sizeof(PMEMmutex)
+		!= sizeof(PMEMmutex_internal));
+	COMPILE_ERROR_ON(sizeof(PMEMrwlock)
+		!= sizeof(PMEMrwlock_internal));
+	COMPILE_ERROR_ON(sizeof(PMEMcond)
+		!= sizeof(PMEMcond_internal));
+
 	COMPILE_ERROR_ON(util_alignof(PMEMmutex)
 		!= util_alignof(pthread_mutex_t));
 	COMPILE_ERROR_ON(util_alignof(PMEMrwlock)


### PR DESCRIPTION
Managed to build libpmemobj with incosistent PMEMmutex
and PMEMrwlock types. This basic error should definitely be
caught compile time, not just in obj_layout tests.

Ref: pmem/issues#427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1653)
<!-- Reviewable:end -->
