### PR TITLE
tools: use byte value for memset fill argument in rpmemd

### DIFF
--- a/src/tools/rpmemd/rpmemd_config.c
+++ b/src/tools/rpmemd/rpmemd_config.c
@@ -381,7 +381,7 @@ parse_config_file(const char *filename, struct rpmemd_config *config,
 	struct rpmemd_special_chars_pos pos;
 
 	do {
-		memset(&pos, INT32_MAX, sizeof(pos));
+		memset(&pos, 0xff, sizeof(pos));
 		if (get_config_line(file, &line, &line_max,
 			&line_max_increased, &pos) != 0)
 			goto error;


### PR DESCRIPTION
It shouldn't have any visible effect, because memset internally
truncates higher 24-bits.

Reported by Coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1655)
<!-- Reviewable:end -->
