### PR TITLE
common: suppress errors after ASSERT* macros

### DIFF
--- a/src/common/out.h
+++ b/src/common/out.h
@@ -47,7 +47,7 @@
  * Suppress errors which are after appropriate ASSERT* macro for nondebug
  * builds.
  */
-#if !defined(DEBUG) && defined(__clang_analyzer__)
+#if !defined(DEBUG) && (defined(__clang_analyzer__) || defined(__COVERITY__))
 #define OUT_FATAL_DISCARD_NORETURN __attribute__((noreturn))
 #else
 #define OUT_FATAL_DISCARD_NORETURN


### PR DESCRIPTION
... reported by Coverity for nondebug build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1656)
<!-- Reviewable:end -->
