### PR TITLE
common: fix make test and make sync-remote issue

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -357,8 +357,6 @@ SYNC_EXT=synced
 
 all test cstyle format: $(TESTS_BUILD)
 
-test: sync-remotes
-
 clean clobber: $(TESTS_BUILD)
 	$(RM) -r $(DIR_SYNC)
 	$(RM) *.$(SYNC_EXT)
@@ -393,8 +391,10 @@ check: test
 	@./RUNTESTS $(RUNTEST_OPTIONS) $(TESTS)
 	@echo "No failures."
 
-check-remote-quiet: test
+check-remote-quiet: sync-remotes
 	@./RUNTESTS $(RUNTEST_OPTIONS) $(REMOTE_TESTS)
+
+sync-remotes: test
 
 check-remote: check-remote-quiet
 	@echo "No failures."


### PR DESCRIPTION
make test does NOT depend on make sync-remote.
make sync-remote depends on make test.
make check-remote depends on make sync-remote.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1657)
<!-- Reviewable:end -->
