### PR TITLE
pool: add arch_flags check

### DIFF
--- a/src/libpmempool/check_util.h
+++ b/src/libpmempool/check_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ struct check_status;
  *
  * Its size is equal to the size of the biggest state structure it must store.
  */
-#define CHECK_INSTEP_LOCATION_NUM 529
+#define CHECK_INSTEP_LOCATION_NUM 553
 
 struct check_step_data {
 	uint64_t location[CHECK_INSTEP_LOCATION_NUM];

--- a/src/test/pmempool_check/TEST19
+++ b/src/test/pmempool_check/TEST19
@@ -1,0 +1,77 @@
+#!/bin/bash -e
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_check/TEST19 -- test for checking and fixing pool files arch_flags
+#
+export UNITTEST_NAME=pmempool_check/TEST19
+export UNITTEST_NUM=19
+
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type pmem non-pmem
+
+setup
+
+POOLSET=$DIR/pool.set
+POOL_P1=$DIR/pool.p1
+POOL_P2=$DIR/pool.p2
+LOG=out${UNITTEST_NUM}.log
+rm -rf $LOG && touch $LOG
+
+create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
+expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
+
+INVALID_ARCH_FLAGS="FFFFFFFF"
+
+# If valid part exists it can be used to check and fix invalid arch_flags
+$PMEMSPOIL -v $POOL_P1 pool_hdr.arch_flags=$INVALID_ARCH_FLAGS >> $LOG
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG
+# pmempool info schould exit normally
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
+
+# if valid part does not exist it is impossible to check arch_flags
+$PMEMSPOIL -v $POOL_P1 pool_hdr.arch_flags=$INVALID_ARCH_FLAGS >> $LOG
+$PMEMSPOIL -v $POOL_P2 pool_hdr.arch_flags=$INVALID_ARCH_FLAGS >> $LOG
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG
+# pmempool check would fix checksum but pmempool info should fail
+# because arch_flags is still invalid
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -vrya $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX info $POOLSET >> $LOG 2> /dev/null
+
+check
+
+pass

--- a/src/test/pmempool_check/TEST19.PS1
+++ b/src/test/pmempool_check/TEST19.PS1
@@ -1,0 +1,81 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# pmempool_check/TEST16 -- test for checking and fixing pool files arch_flags
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "pmempool_check\TEST19"
+$Env:UNITTEST_NUM = "19"
+
+. ..\unittest\unittest.ps1
+
+require_test_type medium
+
+require_fs_type any
+
+setup
+
+$POOLSET="$DIR\pool.set"
+$POOL_P1="$DIR\pool.p1"
+$POOL_P2="$DIR\pool.p2"
+$LOG="out$Env:UNITTEST_NUM.log"
+rm $LOG -Force -ea si
+
+create_poolset $POOLSET 20M:$POOL_P1 20M:$POOL_P2
+expect_normal_exit $PMEMPOOL create log $POOLSET
+
+$INVALID_ARCH_FLAGS="FFFFFFFF"
+
+# If valid part exists it can be used to check and fix invalid arch_flags
+&$PMEMSPOIL -v $POOL_P1 "pool_hdr.arch_flags=$INVALID_ARCH_FLAGS" >> $LOG
+expect_abnormal_exit $PMEMPOOL check -v $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL check -vry $POOLSET >> $LOG
+# pmempool info schould exit normally
+expect_normal_exit $PMEMPOOL info $POOLSET >> $null
+
+# if valid part does not exist it is impossible to check arch_flags
+&$PMEMSPOIL -v $POOL_P1 "pool_hdr.arch_flags=$INVALID_ARCH_FLAGS" >> $LOG
+&$PMEMSPOIL -v $POOL_P2 "pool_hdr.arch_flags=$INVALID_ARCH_FLAGS" >> $LOG
+expect_abnormal_exit $PMEMPOOL check -v $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL check -vry $POOLSET >> $LOG
+# pmempool check would fix checksum but pmempool info should fail
+# because arch_flags is still invalid
+expect_normal_exit $PMEMPOOL check -vrya $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL info $POOLSET >> $LOG 2> $null
+
+check
+
+pass

--- a/src/test/pmempool_check/out19.log.match
+++ b/src/test/pmempool_check/out19.log.match
@@ -1,0 +1,36 @@
+$(nW)pool.p1: spoil: pool_hdr.arch_flags=$(nW)
+replica 0 part 0: checking pool header
+replica 0 part 0: incorrect pool header
+$(nW)pool.set: not consistent
+replica 0 part 0: checking pool header
+replica 0 part 0: incorrect pool header
+replica 0 part 0: pool_hdr.arch_flags is not valid
+replica 0 part 0: setting pool_hdr.arch_flags to $(nW)
+replica 0 part 1: checking pool header
+replica 0 part 1: pool header correct
+checking pmemlog header
+pmemlog header correct
+$(nW)pool.set: repaired
+$(nW)pool.p1: spoil: pool_hdr.arch_flags=$(nW)
+$(nW)pool.p2: spoil: pool_hdr.arch_flags=$(nW)
+replica 0 part 0: checking pool header
+replica 0 part 0: incorrect pool header
+$(nW)pool.set: not consistent
+replica 0 part 0: checking pool header
+replica 0 part 0: incorrect pool header
+replica 0 part 1: checking pool header
+replica 0 part 1: incorrect pool header
+replica 0 part 0: the following error can be fixed using PMEMPOOL_CHECK_ADVANCED flag
+replica 0 part 0: invalid pool_hdr.checksum
+$(nW)pool.set: cannot repair
+replica 0 part 0: checking pool header
+replica 0 part 0: incorrect pool header
+replica 0 part 1: checking pool header
+replica 0 part 1: incorrect pool header
+replica 0 part 0: invalid pool_hdr.checksum
+replica 0 part 0: setting pool_hdr.checksum to $(nW)
+replica 0 part 1: invalid pool_hdr.checksum
+replica 0 part 1: setting pool_hdr.checksum to $(nW)
+checking pmemlog header
+pmemlog header correct
+$(nW)pool.set: repaired


### PR DESCRIPTION
If other part in replica has valid pool header it is possible to use it to
validate arch_flags. arch_flags in all parts of the replica should be equal.

Ref: pmem/issues#387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1659)
<!-- Reviewable:end -->
