### PR TITLE
test: fix sync timeout calculation

### DIFF
--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -266,7 +266,7 @@ timed_check_worker(void *arg)
 		clock_gettime(CLOCK_REALTIME, &t1);
 		abs_time = t1;
 		abs_time.tv_nsec += TIMEOUT;
-		if (abs_time.tv_nsec > NANO_PER_ONE) {
+		if (abs_time.tv_nsec >= NANO_PER_ONE) {
 			abs_time.tv_sec += abs_time.tv_nsec / NANO_PER_ONE;
 			abs_time.tv_nsec %= NANO_PER_ONE;
 		}


### PR DESCRIPTION
 On the odd case the tv_nsec=10e9, the timedlock fails with EINVAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1660)
<!-- Reviewable:end -->
