### PR TITLE
common: fix pkg-config files

### DIFF
--- a/utils/make-pkg-config.sh
+++ b/utils/make-pkg-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -69,7 +69,7 @@ Name: libpmemobj
 Description: libpmemobj library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires: libpmem
+Requires.private: libpmem
 Libs: -L\${libdir} -lpmemobj
 Libs.private: -ldl
 Cflags: -I\${includedir}
@@ -85,7 +85,7 @@ Name: libpmempool
 Description: libpmempool library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires: libpmem
+Requires.private: libpmem
 Libs: -L\${libdir} -lpmempool
 Libs.private: -ldl
 Cflags: -I\${includedir}
@@ -101,7 +101,7 @@ Name: libpmemblk
 Description: libpmemblk library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires: libpmem
+Requires.private: libpmem
 Libs: -L\${libdir} -lpmemblk
 Cflags: -I\${includedir}
 EOF
@@ -116,7 +116,7 @@ Name: libpmemlog
 Description: libpmemlog library from NVML project
 Version: \${version}
 URL: http://pmem.io/nvml
-Requires: libpmem
+Requires.private: libpmem
 Libs: -L\${libdir} -lpmemlog
 Cflags: -I\${includedir}
 EOF


### PR DESCRIPTION
From pkg-config documentation:
"Requires and Requires.private define other modules needed by the
 library. It is usually preferred to use the private variant of Requires
 to avoid exposing unnecessary libraries to the program that is linking
 with your library. If the program will not be using the symbols of the
 required library, it should not be linking directly to that library.
 (...)
 Since pkg-config always exposes the link flags of the Requires
 libraries, these modules will become direct dependencies of the
 program. On the other hand, libraries from Requires.private will only
 be included when static linking. For this reason, it is usually only
 appropriate to add modules from the same package in Requires."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1673)
<!-- Reviewable:end -->
