### PR TITLE
utils: formatting style errors like compiler ones

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -182,7 +182,7 @@ for file in $FILES ; do
 				else
 					NEW=$COMMIT_FIRST-$COMMIT_LAST
 				fi
-				echo "error: wrong copyright date in file: $file (is: $YEARS, should be: $NEW)" >&2
+				echo "$file:1: error: wrong copyright date: (is: $YEARS, should be: $NEW)" >&2
 				RV=1
 			fi
 		else

--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -63,6 +63,7 @@
 #define STR_MODE_LICENSE	"check-license"
 
 #define ERROR(fmt, ...)	fprintf(stderr, "error: " fmt "\n", __VA_ARGS__)
+#define ERROR2(fmt, ...)	fprintf(stderr, fmt "\n", __VA_ARGS__)
 
 /*
  * help_str -- string for the help message
@@ -231,11 +232,11 @@ analyze_license(const char *path_to_check,
 	if (strstr2(buffer, LICENSE_BEG, LICENSE_END,
 				&beg_str, &end_str)) {
 		if (!beg_str)
-			ERROR("incorrect license in the file: %s"
+			ERROR2("%s:1: error: incorrect license"
 				" (license should start with the string '%s')",
 				path_to_check, LICENSE_BEG);
 		else
-			ERROR("incorrect license in the file: %s"
+			ERROR2("%s:1: error: incorrect license"
 				" (license should end with the string '%s')",
 				path_to_check, LICENSE_END);
 		return -1;
@@ -405,12 +406,12 @@ verify_license(const char *path_to_check, char *pattern)
 
 	if (err_str)
 		/* found an error in the copyright notice */
-		ERROR("incorrect copyright notice in the file: %s (%s)",
+		ERROR2("%s:1: error: incorrect copyright notice: %s",
 			path_to_check, err_str);
 
 	/* now check the license */
 	if (memcmp(license, pattern, strlen(pattern)) != 0) {
-		ERROR("incorrect license in the file: %s", path_to_check);
+		ERROR2("%s:1: error: incorrect license", path_to_check);
 		print_diff(license, pattern, strlen(pattern));
 		return -1;
 	}

--- a/utils/check_whitespace
+++ b/utils/check_whitespace
@@ -57,7 +57,7 @@ my $Errcount = 0;
 # err -- emit error, keep total error count
 #
 sub err {
-	warn "$Me: ERROR: ", @_, "\n";
+	warn @_, "\n";
 	$Errcount++;
 }
 
@@ -77,14 +77,14 @@ sub check_whitespace {
 		$line++;
 		$eol = /\n/s;
 		if (/^\.nf$/) {
-			err("$full: $line: nested .nf") if $nf;
+			err("$full:$line: ERROR: nested .nf") if $nf;
 			$nf = 1;
 		} elsif (/^\.fi$/) {
 			$nf = 0;
 		} elsif ($nf == 0) {
 			chomp;
-			err("$full: $line: trailing whitespace") if /\s$/;
-			err("$full: $line: spaces before tabs") if / \t/;
+			err("$full:$line: ERROR: trailing whitespace") if /\s$/;
+			err("$full:$line: ERROR: spaces before tabs") if / \t/;
 		}
 	}
 


### PR DESCRIPTION
It allows vim and other IDE to jump from error message to corresponding
place in code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1686)
<!-- Reviewable:end -->
