### PR TITLE
common: actually remove Valgrind and libfabric sources

### DIFF
--- a/utils/docker/images/install-libfabric.sh
+++ b/utils/docker/images/install-libfabric.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,6 +45,6 @@ cd $libfabric_dir \
 	&& ./configure --prefix=/usr --enable-sockets \
 	&& make -j2 \
 	&& make install
+cd ..
 rm -f ${libfabric_tarball}
 rm -rf ${libfabric_dir}
-

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -40,4 +40,5 @@ cd valgrind
 ./configure
 make
 make install
+cd ..
 rm -rf valgrind


### PR DESCRIPTION
That's 500MB in uncompressed image...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1699)
<!-- Reviewable:end -->
