### PR TITLE
common: use rpath when linking libraries

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -81,6 +81,10 @@ CFLAGS += $(EXTRA_CFLAGS)
 
 LDFLAGS += -Wl,-z,relro -Wl,--fatal-warnings -Wl,--warn-common $(EXTRA_LDFLAGS)
 
+ifneq ($(NORPATH),1)
+LDFLAGS += -Wl,-rpath=$(libdir)$(LIB_SUBDIR)
+endif
+
 define arch32_error_msg
 
 ##################################################

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -347,7 +347,7 @@ override_dh_strip:
 	dh_strip --dbg-package=$PACKAGE_NAME-dbg
 
 override_dh_auto_install:
-	dh_auto_install -- EXPERIMENTAL=${EXPERIMENTAL} CPP_DOC_DIR="${OBJ_CPP_DOC_DIR}" prefix=/$PREFIX libdir=/$LIB_DIR includedir=/$INC_DIR docdir=/$DOC_DIR man1dir=/$MAN1_DIR man3dir=/$MAN3_DIR sysconfdir=/etc
+	dh_auto_install -- EXPERIMENTAL=${EXPERIMENTAL} CPP_DOC_DIR="${OBJ_CPP_DOC_DIR}" prefix=/$PREFIX libdir=/$LIB_DIR includedir=/$INC_DIR docdir=/$DOC_DIR man1dir=/$MAN1_DIR man3dir=/$MAN3_DIR sysconfdir=/etc NORPATH=1
 
 override_dh_install:
 	mkdir -p debian/tmp/usr/share/nvml/

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -456,7 +456,8 @@ make install DESTDIR=%{buildroot}\
 	sysconfdir=%{_sysconfdir}\
 	docdir=%{_docdir}\
 	EXPERIMENTAL=${EXPERIMENTAL}\
-	CPP_DOC_DIR=${OBJ_CPP_DOC_DIR}
+	CPP_DOC_DIR=${OBJ_CPP_DOC_DIR}\
+	NORPATH=1
 mkdir -p %{buildroot}%{_datadir}/nvml
 cp utils/nvml.magic %{buildroot}%{_datadir}/nvml/
 


### PR DESCRIPTION
If user installs NVML to $HOME and try to build his application using
pmemobj the linking phase fails, because of missing path to libpmem.
Solve it by setting runtime path of the directory with libpmem for all
libraries.
In general use of rpath is discouraged for distro packages, so disable
it for both Debian and Fedora packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1706)
<!-- Reviewable:end -->
