### PR TITLE
test: fix require_fs_type any and RUNTESTS -f

### DIFF
--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -416,7 +416,11 @@ do
 		shift 2
 		case "$fstype"
 		in
-		none|pmem|non-pmem|any|all)
+		none|pmem|non-pmem|any)
+			# necessary to treat "any" as either pmem or non-pmem with "-f"
+			export FORCE_FS=1
+			;;
+		all)
 			;;
 		*)
 			usage "bad fs-type: $fstype"

--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -185,6 +185,16 @@ function runtest {
     }
 
     #
+    # FS type was forced by user, necessary to treat "any" as either pmem or
+    # non-pmem with "-f"
+    #
+    if($fstype -ne "all") {
+        $Env:FORCE_FS= 1
+    } else {
+        $Env:FORCE_FS= 0
+    }
+
+    #
     # make list of fs-types and build-types to test
     #
     sv -Name fss $fstype

--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -972,7 +972,9 @@ function require_non_pmem {
 function require_fs_type {
     sv -Name req_fs_type 1 -Scope Global
     for ($i=0;$i -lt $args.count;$i++) {
-        if ($args[$i] -eq $Env:FS) {
+        # treat any as either pmem or non-pmem
+        if ($Env:FORCE_FS -eq 1 -and $args[$i] -eq "any" -and $Env:FS -ne "none" -or`
+            $args[$i] -eq $Env:FS) {
             switch ($REAL_FS) {
                 'pmem' { if (require_pmem) { return } }
                 'non-pmem' { if (require_non_pmem) { return } }

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -894,7 +894,10 @@ function require_fs_type() {
 	req_fs_type=1
 	for type in $*
 	do
-		[ "$type" = "$FS" ] &&
+		# treat any as either pmem or non-pmem
+		[ "$type" = "$FS" ] ||
+			([ -n "${FORCE_FS:+x}" ] && [ "$type" = "any" ] &&
+			[ "$FS" != "none" ]) &&
 		case "$REAL_FS"
 		in
 		pmem)


### PR DESCRIPTION
Fix running tests requiring fs type to be any and forcing a specific fs
through RUNTESTS.

Ref: pmem/issues#468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1712)
<!-- Reviewable:end -->
