### PR TITLE
obj: export non-inlined pmemobj_direct

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -3,7 +3,7 @@ layout: manual
 Content-Style: 'text/css'
 title: libpmemobj(3)
 header: NVM Library
-date: pmemobj API version 2.0.0
+date: pmemobj API version 2.1.0
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)
@@ -565,14 +565,18 @@ Device DAX is the device-centric analogue of Filesystem DAX. It allows memory
 ranges to be allocated and mapped without need of an intervening file system.
 For more information please see **ndctl-create-namespace**(1).
 
-In case of a remote replica, the *REPLICA* keyword has to be followed by an address of a remote host (in the format recognized by the **ssh**(1) remote login client)
-and a relative path to a remote pool set file (located in the root config directory on the target node - see **librpmem**(3)):
+In case of a remote replica, the *REPLICA* keyword has to be followed by
+an address of a remote host (in the format recognized by the **ssh**(1)
+remote login client) and a relative path to a remote pool set file (located
+in the root config directory on the target node - see **librpmem**(3)):
 
 ```
 REPLICA [<user>@]<hostname> [<relative-path>/]<remote-pool-set-file>
 ```
 
-There are no other lines in the remote replica section – the REPLICA line defines a remote replica entirely. Here is the example of "myobjpool.set" file:
+There are no other lines in the remote replica section - the REPLICA line
+defines a remote replica entirely. Here is the example of "myobjpool.set"
+file:
 
 ```
 PMEMPOOLSET
@@ -758,7 +762,17 @@ linked data structure - it shall never use memory address of an object, but its 
 void *pmemobj_direct(PMEMoid oid);
 ```
 
-The **pmemobj_direct**() function returns a pointer to an object represented by *oid*. If **OID_NULL** is passed as an argument, function returns NULL.
+The **pmemobj_direct**() function returns a pointer to an object represented by *oid*.
+If **OID_NULL** is passed as an argument, function returns NULL.
+
+>NOTE:
+For preformance reasons, on Linux this function is inlined by default.
+You may decide to compile your programs using the non-inlined variant
+of **pmemobj_direct**() by defining **PMEMOBJ_DIRECT_NON_INLINE** macro.
+You should define this macro by using *\#define* preprocessor directive,
+which must come before *\#include* of **\<libpmemobj.h\>**.
+You could also use *\-D* option to gcc.
+On Windows **PMEMOBJ_DIRECT_NON_INLINE** macro has no effect.
 
 ```c
 PMEMoid pmemobj_oid(const void *addr); (EXPERIMENTAL)

--- a/src/include/libpmemobj/base.h
+++ b/src/include/libpmemobj/base.h
@@ -102,7 +102,7 @@ extern __thread struct _pobj_pcache {
  * Returns the direct pointer of an object.
  */
 static inline void *
-pmemobj_direct(PMEMoid oid)
+pmemobj_direct_inline(PMEMoid oid)
 {
 	if (oid.off == 0 || oid.pool_uuid_lo == 0)
 		return NULL;
@@ -122,16 +122,17 @@ pmemobj_direct(PMEMoid oid)
 	return (void *)((uintptr_t)_pobj_cached_pool.pop + oid.off);
 }
 
-#else /* _WIN32 */
-
-/* XXX - this is temporary (see obj.c for details) */
+#endif /* _WIN32 */
 
 /*
  * Returns the direct pointer of an object.
  */
+#if defined(_WIN32) || defined(_PMEMOBJ_INTRNL) ||\
+	defined(PMEMOBJ_DIRECT_NON_INLINE)
 void *pmemobj_direct(PMEMoid oid);
-
-#endif /* _WIN32 */
+#else
+#define pmemobj_direct pmemobj_direct_inline
+#endif
 
 /*
  * Returns the OID of the object pointed to by addr.
@@ -197,7 +198,7 @@ void pmemobj_drain(PMEMobjpool *pop);
  * used at compile-time by passing these defines to pmemobj_check_version().
  */
 #define PMEMOBJ_MAJOR_VERSION 2
-#define PMEMOBJ_MINOR_VERSION 0
+#define PMEMOBJ_MINOR_VERSION 1
 
 #ifndef _WIN32
 const char *pmemobj_check_version(unsigned major_required,

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -72,6 +72,6 @@ SOURCE =\
 
 include ../Makefile.inc
 
-CFLAGS += -DUSE_LIBDL
+CFLAGS += -DUSE_LIBDL -D_PMEMOBJ_INTRNL
 
 LIBS += -pthread -lpmem -ldl

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -103,6 +103,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_persist;
 		pmemobj_flush;
 		pmemobj_drain;
+		pmemobj_direct;
 		_pobj_cached_pool;
 		_pobj_cache_invalidate;
 		_pobj_debug_notice;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -59,6 +59,15 @@ int _pobj_cache_invalidate;
 
 __thread struct _pobj_pcache _pobj_cached_pool;
 
+/*
+ * pmemobj_direct -- returns the direct pointer of an object
+ */
+void *
+pmemobj_direct(PMEMoid oid)
+{
+	return pmemobj_direct_inline(oid);
+}
+
 #else /* _WIN32 */
 
 /*

--- a/src/test/obj_direct/Makefile
+++ b/src/test/obj_direct/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ vpath %.c ../../libpmemobj
 vpath %.c ../../common
 
 TARGET = obj_direct
-OBJS = obj_direct.o
+OBJS = obj_direct.o obj_direct_inline.o obj_direct_non_inline.o
 
 LIBPMEM=y
 LIBPMEMOBJ=y

--- a/src/test/obj_direct/obj_direct.h
+++ b/src/test/obj_direct/obj_direct.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_direct.h -- unit test for pmemobj_direct()
+ */
+#ifndef OBJ_DIRECT_H
+#define OBJ_DIRECT_H 1
+
+#include "libpmemobj.h"
+
+void *obj_direct_inline(PMEMoid oid);
+void *obj_direct_non_inline(PMEMoid oid);
+
+#endif /* OBJ_DIRECT_H */

--- a/src/test/obj_direct/obj_direct.vcxproj
+++ b/src/test/obj_direct/obj_direct.vcxproj
@@ -12,6 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="obj_direct.c" />
+    <ClCompile Include="obj_direct_inline.c" />
+    <ClCompile Include="obj_direct_non_inline.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\common\libpmemcommon.vcxproj">
@@ -29,6 +31,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="obj_direct.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{10469175-EEF7-44A0-9961-AC4E45EFD800}</ProjectGuid>

--- a/src/test/obj_direct/obj_direct.vcxproj.filters
+++ b/src/test/obj_direct/obj_direct.vcxproj.filters
@@ -8,9 +8,18 @@
     <Filter Include="Test Scripts">
       <UniqueIdentifier>{af85130b-199d-4610-834d-707504d99266}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{37b70c4b-e0a5-440e-bbcc-cb86abe6f78b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="obj_direct.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="obj_direct_inline.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="obj_direct_non_inline.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -18,5 +27,10 @@
     <None Include="TEST0.PS1">
       <Filter>Test Scripts</Filter>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="obj_direct.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/test/obj_direct/obj_direct_inline.c
+++ b/src/test/obj_direct/obj_direct_inline.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_direct_inline.c -- unit test for direct
+ */
+#include "unittest.h"
+#include "obj_direct.h"
+
+void *
+obj_direct_inline(PMEMoid oid)
+{
+	UT_OUT("pmemobj_direct inlined");
+	return pmemobj_direct(oid);
+}

--- a/src/test/obj_direct/obj_direct_non_inline.c
+++ b/src/test/obj_direct/obj_direct_non_inline.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_direct_inline.c -- unit test for direct
+ */
+#define PMEMOBJ_DIRECT_NON_INLINE
+
+#include "unittest.h"
+#include "obj_direct.h"
+
+void *
+obj_direct_non_inline(PMEMoid oid)
+{
+	UT_OUT("pmemobj_direct non-inlined");
+	return pmemobj_direct(oid);
+}

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -14,6 +14,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -87,6 +88,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -160,6 +162,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first
@@ -233,6 +236,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_direct
 pmemobj_drain
 pmemobj_errormsg
 pmemobj_first


### PR DESCRIPTION
Users may decide at compile-time to use inlined (default) or non-inlined
variant in their programs by defining PMEMOBJ_DIRECT_NON_INLINE macro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1716)
<!-- Reviewable:end -->
