### PR TITLE
test: export some host variables to remote nodes

### DIFF
--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -2097,6 +2097,9 @@ function init_rpmem_on_node() {
 		fi
 
 		require_node_log_files $slave rpmemd$UNITTEST_NUM.log
+		if [ -n ${UNITTEST_DO_NOT_CHECK_OPEN_FILES+x} ]; then
+			export_vars_node $slave UNITTEST_DO_NOT_CHECK_OPEN_FILES
+		fi
 	done
 	RPMEM_CMD="\"$RPMEM_CMD\""
 
@@ -2121,6 +2124,10 @@ function init_rpmem_on_node() {
 	export_vars_node $master PMEMOBJ_LOG_FILE
 	export_vars_node $master PMEMPOOL_LOG_FILE
 	export_vars_node $master PMEMPOOL_LOG_LEVEL
+
+	if [ -n ${UNITTEST_DO_NOT_CHECK_OPEN_FILES+x} ]; then
+		export_vars_node $master UNITTEST_DO_NOT_CHECK_OPEN_FILES
+	fi
 
 	require_node_log_files $master rpmem$UNITTEST_NUM.log
 	require_node_log_files $master $PMEMOBJ_LOG_FILE


### PR DESCRIPTION
Export host UNITTEST_DO_NOT_CHECK_OPEN_FILES variable to remote nodes,
which allows to control this behavior over testconfig.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1719)
<!-- Reviewable:end -->
