### PR TITLE
common: fix pool creation time accuracy on windows

### DIFF
--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1633,7 +1633,13 @@ util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 			POOL_HDR_UUID_LEN);
 	}
 
-	hdrp->crtime = (uint64_t)time(NULL);
+	struct timespec t;
+	/* realtime is used because it has better windows implementation */
+	if (clock_gettime(CLOCK_REALTIME, &t) != 0) {
+		ERR("Retrieving time since epoch failed");
+		return -1;
+	}
+	hdrp->crtime = (uint64_t)t.tv_sec;
 
 	if (!arch_flags) {
 		if (util_get_arch_flags(&hdrp->arch_flags)) {


### PR DESCRIPTION
This hopefully fixes the sporadic failures of `pmempool_check` test. I'm also not sure if this is entirely correct as the reason for the failures is still unclear to me. @wlemkows and @janekmi think the issue comes from different timezones on the build nodes that we are sometimes assigned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1720)
<!-- Reviewable:end -->
