### PR TITLE
rpmem: do not call ibv_fork_init directly

### DIFF
--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -342,12 +342,11 @@ using **fork**(2).  The application must take into account this fact when
 using **wait**(2) and **waitpid**(2) functions which may return a PID of
 the **ssh** process executed by **librpmem**.
 
-The **librpmem** library calls the **ibv_fork_init**(3) function in library's
-constructor in order to enable **fork**(2) support in **libibverbs**.
-If an application uses the **libibverbs** before loading the **librpmem**
-library it must call the **ibv_fork_inif**(3) function before allocating
-any resources using **libibverbs**, otherwise **rpmem_open** and
-**rpmem_create** functions will return an error.
+The **librpmem** library requires **fork**(2) support in **libibverbs**,
+otherwise **rpmem_open** and **rpmem_create** functions will return an error.
+By default **libfabric** initializes **libibverbs** with **fork**(2) support
+by calling the **ibv_fork_init**(3) function. See **fi_verbs**(7) for more
+details.
 
 # REMOTE POOL SIZE #
 A remote pool size depends on the configuration of a pool set file on the remote

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -135,8 +135,7 @@ LIBS += -lrpmem
 CONFIGS += pmembench_rpmem
 CXXFLAGS += -DRPMEM_AVAILABLE
 else
-$(info NOTE: Skipping librpmem benchmark because libfabric is missing \
--- see src/librpmem/README for details.)
+$(info NOTE: Skipping librpmem benchmark because $(BUILD_RPMEM_INFO))
 endif
 
 ifeq ($(GLIB),y)

--- a/src/common.inc
+++ b/src/common.inc
@@ -195,21 +195,10 @@ export pkgconfigdir := $(libdir)/pkgconfig
 export bindir := $(exec_prefix)/bin
 export bashcompdir := $(sysconfdir)/bash_completion.d
 
-check_ibv_fork_init = $(shell echo "\#include <infiniband/verbs.h> int main(void) { return ibv_fork_init(); }" |\
-	$(CC) -c $(CFLAGS) -x c -o /dev/null -libverbs - 2>/dev/null && echo y || echo n)
-
-export HAS_LIBFABRIC := $(call check_package, libfabric)
-
-ifeq ($(HAS_LIBFABRIC),y)
-ifeq ($(RPMEM_DISABLE_LIBIBVERBS),y)
-export HAS_LIBIBVERBS := n
-export BUILD_RPMEM := y
-else
-export HAS_LIBIBVERBS := $(call check_ibv_fork_init)
-export BUILD_RPMEM := $(HAS_LIBIBVERBS)
-endif
-else
-export BUILD_RPMEM := n
+export BUILD_RPMEM := $(call check_package, libfabric --atleast-version=1.4)
+ifneq ($(BUILD_RPMEM),y)
+	export BUILD_RPMEM_INFO := libfabric (version >= 1.4) is missing -- \
+see src/librpmem/README for details.
 endif
 
 sparse-c = $(shell for c in *.c; do sparse -Wsparse-all -Wno-declaration-after-statement $(CFLAGS) $(INCS) $$c || true; done)

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1435,13 +1435,15 @@ util_poolset_remote_replica_open(struct pool_set *set, unsigned repidx,
 #ifndef _WIN32
 	/*
 	 * This is a workaround for an issue with using device dax with
-	 * libibverbs. The problem is that we use ibv_fork_init(3) which
-	 * makes all registered memory being madvised with MADV_DONTFORK
-	 * flag. In libpmemobj the remote replication is performed without
-	 * pool header (first 4k). In such case the address passed to
-	 * madvise(2) is aligned to 4k, but device dax can require different
-	 * alignment (default is 2MB). This workaround madvises the entire
-	 * memory region before registering it by ibv_reg_mr(3).
+	 * libibverbs. To handle fork() function calls correctly libfabric use
+	 * ibv_fork_init(3) which makes all registered memory being madvised
+	 * with MADV_DONTFORK flag. In libpmemobj the remote replication is
+	 * performed without pool header (first 4k). In such case the address
+	 * passed to madvise(2) is aligned to 4k, but device dax can require
+	 * different alignment (default is 2MB). This workaround madvises the
+	 * entire memory region before registering it by fi_mr_reg(3).
+	 *
+	 * The librpmem client requires fork() support to work correctly.
 	 */
 	if (set->replica[0]->part[0].is_dev_dax) {
 		int ret = madvise(set->replica[0]->part[0].addr,

--- a/src/examples/librpmem/Makefile
+++ b/src/examples/librpmem/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,13 +43,7 @@ LIBS = -lrpmem -pthread $(shell $(PKG_CONFIG) --libs libfabric)
 
 CFLAGS = $(shell $(PKG_CONFIG) --cflags libfabric)
 else
-ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
-Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
-else
-$(info NOTE: Skipping librpmem because libfabric is missing \
--- see src/librpmem/README for details.)
-endif
+$(info NOTE: Skipping librpmem because $(BUILD_RPMEM_INFO))
 endif
 
 include ../Makefile.inc

--- a/src/librpmem/Makefile
+++ b/src/librpmem/Makefile
@@ -54,26 +54,14 @@ SOURCE = $(COMMON)/util.c\
 	rpmem_fip.c
 
 else
-ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
-Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
-else
-$(info NOTE: Skipping librpmem because libfabric is missing \
--- see src/librpmem/README for details.)
-endif
+$(info NOTE: Skipping librpmem because $(BUILD_RPMEM_INFO))
 endif
 
 include ../Makefile.inc
 
 ifeq ($(BUILD_RPMEM),y)
-
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 CFLAGS += -I. -I../rpmem_common
 CFLAGS += -DRPMEMC_LOG_RPMEM
-
-ifeq ($(HAS_LIBIBVERBS),y)
-LIBS += -libverbs
-CFLAGS += -DHAS_IBVERBS
-endif
 endif

--- a/src/librpmem/README
+++ b/src/librpmem/README
@@ -2,6 +2,6 @@ This directory contains a librpmem library which provides
 remote access to persistent memory over RDMA.
 
 ** DEPENDENCIES: **
-The librpmem library depends on libfabric library:
+The librpmem library depends on libfabric (version >= 1.4) library:
 
 https://github.com/ofiwg/libfabric

--- a/src/librpmem/librpmem.c
+++ b/src/librpmem/librpmem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,14 +42,11 @@
 #include "rpmem.h"
 #include "rpmem_common.h"
 #include "rpmem_util.h"
+#include "rpmem_fip.h"
 #include "util.h"
 #include "out.h"
 
-#ifdef HAS_IBVERBS
-#include <infiniband/verbs.h>
-#endif
-
-extern int Rpmem_fork_fail;
+extern int Rpmem_fork_unsafe;
 
 /*
  * librpmem_init -- load-time initialization for librpmem
@@ -65,12 +62,10 @@ librpmem_init(void)
 			RPMEM_MAJOR_VERSION, RPMEM_MINOR_VERSION);
 	LOG(3, NULL);
 	rpmem_util_cmds_init();
-#ifdef HAS_IBVERBS
-	Rpmem_fork_fail = ibv_fork_init();
-	if (Rpmem_fork_fail)
-		RPMEM_LOG(ERR, "Initialization libibverbs to support "
-			"fork() failed. See librpmem(3) for details.");
-#endif
+
+	rpmem_fip_probe_fork_safety(&Rpmem_fork_unsafe);
+	RPMEM_LOG(NOTICE, "Libfabric is %sfork safe",
+		Rpmem_fork_unsafe ? "not " : "");
 }
 
 /*

--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -57,17 +57,17 @@
 	RPMEM_REMOVE_POOL_SET	\
 )
 
-extern int Rpmem_fork_fail;
+extern int Rpmem_fork_unsafe;
 
 /*
- * If set, indicates the ibv_fork_init() failed and consecutive calls to
+ * If set, indicates libfabric does not support fork() and consecutive calls to
  * rpmem_create/rpmem_open must fail.
  */
-int Rpmem_fork_fail;
+int Rpmem_fork_unsafe;
 
 #define RPMEM_CHECK_FORK() do {\
-if (Rpmem_fork_fail) {\
-	ERR("initialization libibverbs to support fork() failed");\
+if (Rpmem_fork_unsafe) {\
+	ERR("libfabric is initialized without fork() support");\
 	return NULL;\
 }\
 } while (0)

--- a/src/librpmem/rpmem_fip.h
+++ b/src/librpmem/rpmem_fip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,3 +66,5 @@ int rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
 
 int rpmem_fip_read(struct rpmem_fip *fip, void *buff,
 		size_t len, size_t off);
+
+void rpmem_fip_probe_fork_safety(int *fork_unsafe);

--- a/src/test/rpmem_basic/Makefile
+++ b/src/test/rpmem_basic/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -58,8 +58,4 @@ LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 INCS += -I../../common
 INCS += -I../../rpmem_common
-ifeq ($(HAS_LIBIBVERBS),y)
-LIBS += -libverbs
-CFLAGS += -DHAS_IBVERBS
-endif
 endif

--- a/src/test/rpmemd_db/Makefile
+++ b/src/test/rpmemd_db/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ vpath %.c $(TOP)/src/librpmem
 vpath %.c $(TOP)/src/tools/rpmemd
 
 TARGET = rpmemd_db
-OBJS = rpmemd_db_test.o rpmemd_log.o rpmemd_db.o rpmem_util.o librpmem.o
+OBJS = rpmemd_db_test.o rpmemd_log.o rpmemd_db.o
 
 LIBPMEM=y
 LIBPMEMCOMMON=y

--- a/src/test/rpmemd_db/rpmem1.log.match
+++ b/src/test/rpmemd_db/rpmem1.log.match
@@ -1,3 +1,3 @@
-<librpmem>: <1> [$(*)] flock $(nW): Resource temporarily unavailable
-<librpmem>: <1> [$(*)] Non-empty file detected
-<librpmem>: <1> [$(*)] Non-empty file detected
+<rpmemd_db>: <1> [$(*)] flock $(nW): Resource temporarily unavailable
+<rpmemd_db>: <1> [$(*)] Non-empty file detected
+<rpmemd_db>: <1> [$(*)] Non-empty file detected

--- a/src/test/rpmemd_db/rpmemd_db_test.c
+++ b/src/test/rpmemd_db/rpmemd_db_test.c
@@ -41,6 +41,7 @@
 #include "rpmemd_db.h"
 #include "rpmemd_log.h"
 #include "set.h"
+#include "out.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -634,6 +635,9 @@ main(int argc, char *argv[])
 
 	START(argc, argv, "rpmemd_db");
 
+	util_init();
+	out_init("rpmemd_db", "RPMEM_LOG_LEVEL", "RPMEM_LOG_FILE", 0, 0);
+
 	if (argc != 5)
 		UT_FATAL("usage: %s <log-file> <root_dir> <pool_desc_1>"
 				" <pool_desc_2>", argv[0]);
@@ -660,5 +664,6 @@ main(int argc, char *argv[])
 
 	rpmemd_log_close();
 
+	out_fini();
 	DONE(NULL);
 }

--- a/src/test/tools/fip/Makefile
+++ b/src/test/tools/fip/Makefile
@@ -44,8 +44,7 @@ TARGET = fip
 OBJS = fip.o rpmem_fip_common.o rpmem_common.o util.o os_linux.o
 
 else
-$(info NOTE: Skipping fip because libfabric is missing \
--- see src/test/tools/fip/README for details.)
+$(info NOTE: Skipping fip because $(BUILD_RPMEM_INFO))
 endif
 
 include $(TOP)/src/tools/Makefile.inc
@@ -56,4 +55,3 @@ CFLAGS += -I$(TOP)/src/common
 CFLAGS += $(shell $(PKG_CONFIG) --cflags libfabric)
 LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 endif
-

--- a/src/tools/rpmemd/Makefile
+++ b/src/tools/rpmemd/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,13 +65,7 @@ LIBS += $(shell $(PKG_CONFIG) --libs libfabric)
 INSTALL_TARGET=$(EXPERIMENTAL)
 
 else
-ifeq ($(HAS_LIBIBVERBS),n)
-$(info NOTE: Skipping librpmem because libibverbs headers are missing. \
-Set RPMEM_DISABLE_LIBIBVERBS=y to build librpmem anyway.)
-else
-$(info NOTE: Skipping rpmemd because libfabric is missing \
--- see src/tools/rpmemd/README for details.)
-endif
+$(info NOTE: Skipping rpmemd because $(BUILD_RPMEM_INFO))
 endif
 
 include ../Makefile.inc


### PR DESCRIPTION
Libfabric by default initialize libibverbs to handle fork properly.
Requires libfabric version >= 1.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1722)
<!-- Reviewable:end -->
