### PR TITLE
test: fix skipping tests under Valgrind tools

### DIFF
--- a/src/test/magic/TEST0
+++ b/src/test/magic/TEST0
@@ -44,7 +44,7 @@ require_build_type nondebug
 
 # There is no point in testing the file command using memcheck
 # because even if it does report any problems we can't fix it
-configure_valgrind memcheck force-disable
+configure_valgrind force-disable
 
 setup
 

--- a/src/test/obj_list_recovery/TEST0
+++ b/src/test/obj_list_recovery/TEST0
@@ -43,7 +43,7 @@ export UNITTEST_NUM=0
 require_test_type medium
 
 # the test delibretly fails at various stages of redo logging
-configure_valgrind pmemcheck force-disable
+configure_valgrind pmemcheck force-disable ../obj_list/obj_list$EXESUFFIX
 
 setup
 

--- a/src/test/obj_list_recovery/TEST1
+++ b/src/test/obj_list_recovery/TEST1
@@ -43,7 +43,7 @@ export UNITTEST_NUM=1
 require_test_type medium
 
 # the test delibretly fails at various stages of redo logging
-configure_valgrind pmemcheck force-disable
+configure_valgrind pmemcheck force-disable ../obj_list/obj_list$EXESUFFIX
 
 setup
 

--- a/src/test/obj_list_recovery/TEST2
+++ b/src/test/obj_list_recovery/TEST2
@@ -43,7 +43,7 @@ export UNITTEST_NUM=2
 require_test_type medium
 
 # the test delibretly fails at various stages of redo logging
-configure_valgrind pmemcheck force-disable
+configure_valgrind pmemcheck force-disable ../obj_list/obj_list$EXESUFFIX
 
 setup
 

--- a/src/test/pmempool_check/TEST11
+++ b/src/test/pmempool_check/TEST11
@@ -43,7 +43,7 @@ require_test_type medium
 require_dax_devices 1
 require_fs_type any
 # covered by TEST20
-configure_valgrind memcheck force-disable
+configure_valgrind memcheck force-disable $PMEMPOOL$EXESUFFIX
 
 setup
 

--- a/src/test/pmempool_check/TEST12
+++ b/src/test/pmempool_check/TEST12
@@ -43,7 +43,7 @@ require_test_type medium
 require_dax_devices 1
 require_fs_type any
 # covered by TEST21
-configure_valgrind memcheck force-disable
+configure_valgrind memcheck force-disable $PMEMPOOL$EXESUFFIX
 
 setup
 

--- a/src/test/pmempool_check/TEST13
+++ b/src/test/pmempool_check/TEST13
@@ -43,7 +43,7 @@ require_test_type medium
 require_dax_devices 1
 require_fs_type any
 # covered by TEST22
-configure_valgrind memcheck force-disable
+configure_valgrind memcheck force-disable $PMEMPOOL$EXESUFFIX
 
 setup
 

--- a/src/test/pmempool_check/TEST14
+++ b/src/test/pmempool_check/TEST14
@@ -42,8 +42,8 @@ require_test_type medium
 
 require_dax_devices 1
 require_fs_type any
-# covered by TEST23
-configure_valgrind memcheck force-disable
+# memcheck covered by TEST23, pmemcheck takes too long
+configure_valgrind force-disable $PMEMPOOL$EXESUFFIX
 
 setup
 

--- a/src/test/pmempool_check/TEST5
+++ b/src/test/pmempool_check/TEST5
@@ -43,7 +43,7 @@ require_test_type medium
 require_fs_type pmem non-pmem
 
 # Valgrind cannot trace more than 32G which is required for this test
-configure_valgrind memcheck force-disable
+configure_valgrind force-disable
 
 setup
 

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1065,6 +1065,10 @@ function require_valgrind_tool() {
 	[ -d "$2" ] && dir="$2" && binary=
 	pushd "$dir" > /dev/null
 	[ -n "$binary" ] || binary=$(get_executables)
+	if [ -z "$binary" ]; then
+		echo "require_valgrind_tool: error: no binary found" >&2
+		exit 1
+	fi
 	strings ${binary} 2>&1 | \
 	grep -q "compiled with support for Valgrind $tool" && true
 	if [ $? -ne 0 ]; then

--- a/src/test/vmmalloc_init/TEST16
+++ b/src/test/vmmalloc_init/TEST16
@@ -49,7 +49,7 @@ require_no_asan
 
 # Valgrind does not call vmmalloc's malloc implementation from library
 # loaded with RTLD_DEEPBIND.
-configure_valgrind memcheck force-disable
+configure_valgrind memcheck force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 
 setup
 

--- a/src/test/vmmalloc_init/TEST6
+++ b/src/test/vmmalloc_init/TEST6
@@ -49,7 +49,7 @@ require_no_asan
 
 # Valgrind does not call vmmalloc's malloc implementation from library
 # loaded with RTLD_DEEPBIND.
-configure_valgrind memcheck force-disable
+configure_valgrind memcheck force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 
 setup
 


### PR DESCRIPTION
Some tests require to specify binary explicitly in order to properly
detect if valgrind support was enabled.

Ref: pmem/issues#488

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1724)
<!-- Reviewable:end -->
