### PR TITLE
test: limit number of arenas in vmem_stats

### DIFF
--- a/src/test/vmem_stats/TEST0
+++ b/src/test/vmem_stats/TEST0
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 0
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST0.PS1
+++ b/src/test/vmem_stats/TEST0.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit  $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 0
 

--- a/src/test/vmem_stats/TEST1
+++ b/src/test/vmem_stats/TEST1
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 g
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST1.PS1
+++ b/src/test/vmem_stats/TEST1.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 0 g
 

--- a/src/test/vmem_stats/TEST2
+++ b/src/test/vmem_stats/TEST2
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gbl
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST2.PS1
+++ b/src/test/vmem_stats/TEST2.PS1
@@ -49,6 +49,9 @@ require_build_type debug
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 0 gbl
 
 Get-Content vmem$Env:UNITTEST_NUM.log | Where-Object `

--- a/src/test/vmem_stats/TEST3
+++ b/src/test/vmem_stats/TEST3
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gbla
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST3.PS1
+++ b/src/test/vmem_stats/TEST3.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 0 gbla
 

--- a/src/test/vmem_stats/TEST4
+++ b/src/test/vmem_stats/TEST4
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gblma
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST4.PS1
+++ b/src/test/vmem_stats/TEST4.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 0 gblma
 

--- a/src/test/vmem_stats/TEST5
+++ b/src/test/vmem_stats/TEST5
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 1
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST5.PS1
+++ b/src/test/vmem_stats/TEST5.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 1
 

--- a/src/test/vmem_stats/TEST6
+++ b/src/test/vmem_stats/TEST6
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 g
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST6.PS1
+++ b/src/test/vmem_stats/TEST6.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 1 g
 

--- a/src/test/vmem_stats/TEST7
+++ b/src/test/vmem_stats/TEST7
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gbl
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST7.PS1
+++ b/src/test/vmem_stats/TEST7.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 1 gbl
 

--- a/src/test/vmem_stats/TEST8
+++ b/src/test/vmem_stats/TEST8
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gbla
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST8.PS1
+++ b/src/test/vmem_stats/TEST8.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 1 gbla
 

--- a/src/test/vmem_stats/TEST9
+++ b/src/test/vmem_stats/TEST9
@@ -50,6 +50,9 @@ configure_valgrind force-disable
 
 setup
 
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
+
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gblma
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 

--- a/src/test/vmem_stats/TEST9.PS1
+++ b/src/test/vmem_stats/TEST9.PS1
@@ -1,4 +1,4 @@
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@ require_fs_type none
 require_build_type debug
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+$Env:JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit $Env:EXE_DIR\vmem_stats$Env:EXESUFFIX 1 gblma
 


### PR DESCRIPTION
By default, jemalloc allocates 4 * num_of_cpu arenas. If statistics
are enabled, it also allocates the corresponding per-arena stat
structures for all the arenas, even if only one arena is actually used
(single-threaded program).  If this test is run on a machine with
the number of cores >=64, the amount of memory required to keep all
the statistics is larger than the usable space of the pool.

The easiest workaround is to limit the number of arenas for this test
by setting JE_VMEM_MALLOC_CONF environment variable.  Thus, the test can
be run on any machine and we don't need to calculate the pool size
based on number of available CPU cores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1740)
<!-- Reviewable:end -->
