### PR TITLE
test: limit number of arenas in vmem_stats

### DIFF
--- a/src/test/vmem_stats/TEST0
+++ b/src/test/vmem_stats/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 0
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST1
+++ b/src/test/vmem_stats/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 g
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST2
+++ b/src/test/vmem_stats/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gbl
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST3
+++ b/src/test/vmem_stats/TEST3
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gbla
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST4
+++ b/src/test/vmem_stats/TEST4
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 0 gblma
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST5
+++ b/src/test/vmem_stats/TEST5
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 1
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST6
+++ b/src/test/vmem_stats/TEST6
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 g
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST7
+++ b/src/test/vmem_stats/TEST7
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gbl
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST8
+++ b/src/test/vmem_stats/TEST8
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gbla
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log

--- a/src/test/vmem_stats/TEST9
+++ b/src/test/vmem_stats/TEST9
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,9 @@ require_build_type debug
 configure_valgrind memcheck force-disable
 
 setup
+
+# limit the number of arenas to fit into the minimal VMEM pool size
+export JE_VMEM_MALLOC_CONF="narenas:64"
 
 expect_normal_exit ./vmem_stats$EXESUFFIX 1 gblma
 grep -v '<libvmem>:'  vmem$UNITTEST_NUM.log > grep$UNITTEST_NUM.log


### PR DESCRIPTION
By default, jemalloc allocates 4 * num_of_cpu arenas. If statistics
are enabled, it also allocates the corresponding per-arena stat
structures for all the arenas, even if only one arena is actually used
(single-threaded program).  If this test is run on a machine with
the number of cores >=64, the amount of memory required to keep all
the statistics is larger than the usable space of the pool.

The easiest workaround is to limit the number of arenas for this test
by setting JE_VMEM_MALLOC_CONF environment variable.  Thus, the test can
be run on any machine and we don't need to calculate the pool size
based on number of available CPU cores.

Backported from master (ccbf4cb).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1745)
<!-- Reviewable:end -->
