### PR TITLE
test: increase runtest.ps1 performace

### DIFF
--- a/src/test/RUNTESTS.ps1
+++ b/src/test/RUNTESTS.ps1
@@ -241,13 +241,32 @@ function runtest {
         }
 
         read_global_test_configuration
-        $test_fs = get-content $runscript | select-string -pattern "require_fs_type *" | select -last 1
+        if ($testtype -ne "all") {
+            $type = get-content $runscript | select-string -pattern "require_test_type *" | select -last 1
+            if ($type -ne $null) {
+                $type = $type.ToString().split(" ")[1];
+                if ($testtype -eq "check" -and $type -eq "long") {
+                    continue
+                }
+                if ($testtype -ne "check" -and $testtype -ne $type) {
+                    continue
+                }
+            }
+        }
+
+        $test_fss = get-content $runscript | select-string -pattern "require_fs_type *" | select -last 1
 
         Foreach ($fs in $fss.split(" ").trim()) {
-            if ($test_fs -ne $null) {
-                $res =  $test_fs | select-string -pattern $fs
-                if ($res-eq $null) {
-                    continue;
+            if ($test_fss -ne $null) {
+                $found = 0
+                Foreach ($test_fs in $test_fss.ToString().Split(" ") | select -skip 1) {
+                    if ($test_fs -eq $fs) {
+                        $found = 1
+                        break
+                    }
+                }
+                if ($found -eq 0) {
+                    continue
                 }
             }
             # don't bother trying when fs-type isn't available...


### PR DESCRIPTION
This has been done by reducing amount of process spawned by runtest.ps1.
Insted of it Runtest now parses test script to detect in which
configurations should run that test(old way was run test in every
posible configuration<spawn process there> and test in new process
decides if he want to be run in this configuration or not), although
this model isn't a problem on linux as spawning a new process is
very fast<fork> on windows this is very very slow and we should
reduce amount of new processes if it is only posible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1746)
<!-- Reviewable:end -->
