### PR TITLE
common: change mmap list mutex to RWlock

### DIFF
--- a/src/libpmem/pmem_windows.c
+++ b/src/libpmem/pmem_windows.c
@@ -107,7 +107,7 @@ is_pmem_proc(const void *addr, size_t len)
 	const void *begin = addr;
 	const void *end = (const void *)((char *)addr + len);
 
-	WaitForSingleObject(FileMappingQMutex, INFINITE);
+	AcquireSRWLockShared(&FileMappingQLock);
 
 	PFILE_MAPPING_TRACKER mt;
 	SORTEDQ_FOREACH(mt, &FileMappingQHead, ListEntry) {
@@ -154,7 +154,7 @@ is_pmem_proc(const void *addr, size_t len)
 		retval = 0;
 	}
 
-	ReleaseMutex(FileMappingQMutex);
+	ReleaseSRWLockShared(&FileMappingQLock);
 
 	LOG(3, "returning %d", retval);
 	return retval;

--- a/src/test/pmem_is_pmem_windows/pmem_is_pmem_windows.c
+++ b/src/test/pmem_is_pmem_windows/pmem_is_pmem_windows.c
@@ -104,7 +104,7 @@ worker(void *arg)
 	return NULL;
 }
 
-extern HANDLE FileMappingQMutex;
+extern SRWLOCK FileMappingQLock;
 extern struct FMLHead FileMappingQHead;
 
 int
@@ -204,11 +204,11 @@ main(int argc, char *argv[])
 		mt->Access = FILE_MAP_READ;
 		mt->Offset = offset;
 
-		WaitForSingleObject(FileMappingQMutex, INFINITE);
+		AcquireSRWLockExclusive(&FileMappingQLock);
 		SORTEDQ_INSERT(&FileMappingQHead, mt, ListEntry,
 			FILE_MAPPING_TRACKER,
 			mmap_file_mapping_comparer);
-		ReleaseMutex(FileMappingQMutex);
+		ReleaseSRWLockExclusive(&FileMappingQLock);
 	}
 
 	CloseHandle(file_map);

--- a/src/windows/include/win_mmap.h
+++ b/src/windows/include/win_mmap.h
@@ -71,7 +71,7 @@ typedef struct FILE_MAPPING_TRACKER {
 	FILE_MAPPING_TRACKER_FLAGS Flags;
 } FILE_MAPPING_TRACKER, *PFILE_MAPPING_TRACKER;
 
-extern HANDLE FileMappingQMutex;
+extern SRWLOCK FileMappingQLock;
 extern SORTEDQ_HEAD(FMLHead, FILE_MAPPING_TRACKER) FileMappingQHead;
 
 #endif /* WIN_MMAP_H */

--- a/src/windows/win_mmap.c
+++ b/src/windows/win_mmap.c
@@ -79,54 +79,9 @@ unsigned long long Pagesize;
  * XXX Unify the Linux and Windows code and replace this structure with
  * the map tracking list defined in mmap.h.
  */
-HANDLE FileMappingQMutex = INVALID_HANDLE_VALUE;
+SRWLOCK FileMappingQLock = SRWLOCK_INIT;
 struct FMLHead FileMappingQHead =
 	SORTEDQ_HEAD_INITIALIZER(FileMappingQHead);
-
-/*
- * LockFileMappingQ -- (internal) acquires the mapping list mutex
- *
- * Note that this logic dove-tails with mmap_fini() to also detect
- * race conditions around acquire while delete.
- *
- * Case 1: mmap_fini() fully called first - FileMappingQMutex will
- *     be INVALID_HANDLE_VALUE and the WaitForSingleObject will fail.
- * Case 2: mmap_fini() runs while this thread is blocked
- *     in WaitForSingleObject - We will detect
- *     FileMappingQMutex == INVALID_HANDLE_VALUE
- *     E.g., Lock() by Thrd1, Thrd2 Lock by mmap_fini (blocked),
- *     Thrd3 Lock (blocked); eventually map_fini runs before Thrd3.
- * Case 3: Call to acquire is made before call to mmap_init or after map_fini.
- *
- * Note: WAIT_ABANDONED is treated as fatal, as no assumptions can be made
- *     about the consistency of FileMappingQHead or its link list elements.
- */
-static BOOL
-LockFileMappingQ(void)
-{
-	HANDLE Mutex = FileMappingQMutex;
-
-	DWORD ret = WaitForSingleObject(FileMappingQMutex, INFINITE);
-	if (ret != WAIT_OBJECT_0)
-		FATAL("WaitForSingleObject failed");
-
-	if (FileMappingQMutex == INVALID_HANDLE_VALUE) {
-		ERR("acquire-while-delete race error");
-		ReleaseMutex(Mutex);
-		return FALSE; /* XXX - FATAL() */
-	}
-
-	return TRUE;
-}
-
-/*
- * UnlockFileMappingQ -- (internal) releases the mapping list mutex
- */
-static BOOL
-UnlockFileMappingQ(void)
-{
-	return ReleaseMutex(FileMappingQMutex);
-}
 
 /*
  * mmap_file_mapping_comparer -- (internal) compares the two file mapping
@@ -147,7 +102,7 @@ mmap_info(void)
 {
 	LOG(4, NULL);
 
-	WaitForSingleObject(FileMappingQMutex, INFINITE);
+	AcquireSRWLockShared(&FileMappingQLock);
 
 	PFILE_MAPPING_TRACKER mt;
 	for (mt = SORTEDQ_FIRST(&FileMappingQHead);
@@ -167,7 +122,7 @@ mmap_info(void)
 			mt->Flags);
 	}
 
-	ReleaseMutex(FileMappingQMutex);
+	ReleaseSRWLockShared(&FileMappingQLock);
 }
 #endif
 
@@ -250,23 +205,7 @@ mmap_unreserve(void *addr, size_t len)
 static void
 mmap_init(void)
 {
-
-	HANDLE Mutex = CreateMutex(NULL, TRUE, NULL);
-	if (Mutex == INVALID_HANDLE_VALUE || Mutex == NULL)
-		FATAL("CreateMutex failed");
-
-#ifdef C_ASSERT
-	C_ASSERT(sizeof(HANDLE) == sizeof(LONG64));
-#endif
-
-	LONG64 ret = InterlockedCompareExchange64(
-			(PLONG64)&FileMappingQMutex,
-			(LONG64)Mutex, (LONG64)INVALID_HANDLE_VALUE);
-	if (ret != (LONG64)INVALID_HANDLE_VALUE) {
-		CloseHandle(Mutex);
-		FATAL("multiple calls to mmap_init()");
-	}
-
+	AcquireSRWLockExclusive(&FileMappingQLock);
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);
 	Mmap_align = si.dwAllocationGranularity;
@@ -274,7 +213,7 @@ mmap_init(void)
 
 	SORTEDQ_INIT(&FileMappingQHead);
 
-	UnlockFileMappingQ();
+	ReleaseSRWLockExclusive(&FileMappingQLock);
 }
 
 /*
@@ -285,15 +224,11 @@ mmap_init(void)
 static void
 mmap_fini(void)
 {
-	ASSERTne(FileMappingQMutex, INVALID_HANDLE_VALUE);
-
 	/*
 	 * Let's make sure that no one is in the middle of updating the
 	 * list by grabbing the lock.
 	 */
-	HANDLE Mutex = FileMappingQMutex;
-	if (!LockFileMappingQ())
-		return; /* XXX - FATAL() */
+	AcquireSRWLockExclusive(&FileMappingQLock);
 
 	while (!SORTEDQ_EMPTY(&FileMappingQHead)) {
 		PFILE_MAPPING_TRACKER mt;
@@ -317,10 +252,7 @@ mmap_fini(void)
 
 		free(mt);
 	}
-
-	FileMappingQMutex = INVALID_HANDLE_VALUE;
-	ReleaseMutex(Mutex);
-	CloseHandle(Mutex);
+	ReleaseSRWLockExclusive(&FileMappingQLock);
 }
 
 #define PROT_ALL (PROT_READ|PROT_WRITE|PROT_EXEC)
@@ -609,16 +541,12 @@ mmap(void *addr, size_t len, int prot, int flags, int fd, off_t offset)
 			GetLastError());
 	}
 
-	if (!LockFileMappingQ()) {
-		ERR("cannot lock mapping list");
-		errno = EBUSY;
-		return MAP_FAILED; /* XXX - clean up */
-	}
+	AcquireSRWLockExclusive(&FileMappingQLock);
 
 	SORTEDQ_INSERT(&FileMappingQHead, mt, ListEntry,
 			FILE_MAPPING_TRACKER, mmap_file_mapping_comparer);
 
-	UnlockFileMappingQ();
+	ReleaseSRWLockExclusive(&FileMappingQLock);
 
 #ifdef MMAP_DEBUG_INFO
 	mmap_info();
@@ -887,11 +815,7 @@ munmap(void *addr, size_t len)
 	void *begin = addr;
 	void *end = (void *)((char *)addr + len);
 
-	if (!LockFileMappingQ()) {
-		ERR("cannot lock mapping list");
-		errno = EBUSY;
-		return -1;
-	}
+	AcquireSRWLockExclusive(&FileMappingQLock);
 
 	PFILE_MAPPING_TRACKER mt;
 	PFILE_MAPPING_TRACKER next;
@@ -949,7 +873,7 @@ munmap(void *addr, size_t len)
 	retval = 0;
 
 err:
-	UnlockFileMappingQ();
+	ReleaseSRWLockExclusive(&FileMappingQLock);
 
 	if (retval == -1)
 		errno = EINVAL;
@@ -1010,11 +934,7 @@ msync(void *addr, size_t len, int flags)
 	void *begin = addr;
 	void *end = (void *)((char *)addr + len);
 
-	if (!LockFileMappingQ()) {
-		ERR("cannot lock mapping list");
-		errno = EBUSY;
-		return -1;
-	}
+	AcquireSRWLockShared(&FileMappingQLock);
 
 	PFILE_MAPPING_TRACKER mt;
 	SORTEDQ_FOREACH(mt, &FileMappingQHead, ListEntry) {
@@ -1067,7 +987,7 @@ msync(void *addr, size_t len, int flags)
 	}
 
 err:
-	UnlockFileMappingQ();
+	ReleaseSRWLockShared(&FileMappingQLock);
 	return retval;
 }
 
@@ -1122,11 +1042,7 @@ mprotect(void *addr, size_t len, int prot)
 	void *begin = addr;
 	void *end = (void *)((char *)addr + len);
 
-	if (!LockFileMappingQ()) {
-		ERR("cannot lock mapping list");
-		errno = EBUSY;
-		return -1;
-	}
+	AcquireSRWLockShared(&FileMappingQLock);
 
 	PFILE_MAPPING_TRACKER mt;
 	SORTEDQ_FOREACH(mt, &FileMappingQHead, ListEntry) {
@@ -1198,7 +1114,7 @@ mprotect(void *addr, size_t len, int prot)
 	}
 
 err:
-	UnlockFileMappingQ();
+	ReleaseSRWLockShared(&FileMappingQLock);
 	return retval;
 }
 


### PR DESCRIPTION
this change will improve performance of msync and mprotect
functions in multithreaded environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1752)
<!-- Reviewable:end -->
