### PR TITLE
pool: fix mapping device dax

### DIFF
--- a/src/libpmempool/libpmempool.c
+++ b/src/libpmempool/libpmempool.c
@@ -270,7 +270,7 @@ pmempool_check_initU(struct pmempool_check_argsU *args, size_t args_size)
 
 	if (args->backup_path != NULL) {
 		ppc->backup_path = strdup(args->backup_path);
-		if (!ppc->args.backup_path) {
+		if (!ppc->backup_path) {
 			ERR("!strdup");
 			goto error_backup_path_malloc;
 		}

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -62,6 +62,7 @@
 #include "set.h"
 #include "check_util.h"
 #include "util_pmem.h"
+#include "mmap.h"
 
 /* arbitrary size of a maximum file part being read / write at once */
 #define RW_BUFFERING_SIZE (128 * 1024 * 1024)
@@ -350,8 +351,7 @@ pool_params_parse(const PMEMpoolcheck *ppc, struct pool_params *params,
 			goto out_close;
 		}
 		params->size = (size_t)s;
-		addr = mmap(NULL, (uint64_t)params->size, PROT_READ,
-			MAP_SHARED, fd, 0);
+		addr = util_map(fd, params->size, MAP_SHARED, 1, 0);
 		if (addr == MAP_FAILED) {
 			ret = -1;
 			goto out_close;


### PR DESCRIPTION
When calling mmap without a hint address under Valgrind, Valgrind intercepts the call and passes its own hint address which is not properly aligned for device DAX.

Ref: pmem/issues#462

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1764)
<!-- Reviewable:end -->
