### PR TITLE
obj: fix range cache segfaulting on last snapshot

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1498,8 +1498,9 @@ pmemobj_tx_get_range_cache(PMEMobjpool *pop,
 
 	struct lane_tx_runtime *runtime = tx.section->runtime;
 
-	/* verify if the cache exists and has at least one free slot */
-	if (cache == NULL || runtime->cache_offset == cache_size) {
+	/* verify if the cache exists and has at least 8 bytes of free space */
+	if (cache == NULL || runtime->cache_offset +
+		sizeof(struct tx_range) >= cache_size) {
 		/* no existing cache, allocate a new one */
 		uint64_t *entry = pvector_push_back(undo);
 		if (entry == NULL) {
@@ -1558,6 +1559,7 @@ pmemobj_tx_add_small(struct tx_add_range_args *args)
 		sizeof(struct tx_range);
 
 	if (remaining_space < range_size) {
+		ASSERT(remaining_space > sizeof(struct tx_range));
 		range_size = remaining_space;
 		data_size = remaining_space - sizeof(struct tx_range);
 

--- a/src/test/obj_tx_add_range_direct/TEST0.PS1
+++ b/src/test/obj_tx_add_range_direct/TEST0.PS1
@@ -48,6 +48,8 @@ $ENV:UNITTEST_NUM = "0"
 
 require_test_type medium
 
+require_fs_type pmem
+
 setup
 
 expect_normal_exit $ENV:EXE_DIR\obj_tx_add_range_direct$Env:EXESUFFIX $DIR\testfile1

--- a/src/test/obj_tx_add_range_direct/TEST1.PS1
+++ b/src/test/obj_tx_add_range_direct/TEST1.PS1
@@ -47,7 +47,7 @@ $ENV:UNITTEST_NUM = "1w"
 
 require_test_type medium
 
-require_fs_type pmem non-pmem
+require_fs_type pmem
 
 # XXX: we don't have valgrind in Windows yet
 # configure_valgrind pmemcheck force-enable

--- a/src/test/obj_tx_add_range_direct/pmemcheck1.log.match
+++ b/src/test/obj_tx_add_range_direct/pmemcheck1.log.match
@@ -43,6 +43,9 @@
 ==$(*)== Number of stores not made persistent: 0
 ==$(*)== ERROR SUMMARY: 0 errors
 ==$(*)== 
+==$(*)== Number of stores not made persistent: 0
+==$(*)== ERROR SUMMARY: 0 errors
+==$(*)== 
 ==$(*)== 
 ==$(*)== Number of stores not made persistent: 1
 ==$(*)== Stores not made persistent properly:


### PR DESCRIPTION
The calculations that decided whether or not creating a new
transaction range cache now take the size of the range header into
account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1774)
<!-- Reviewable:end -->
