### PR TITLE
cpp: fix sync primitives' constructors

### DIFF
--- a/src/include/libpmemobj++/condition_variable.hpp
+++ b/src/include/libpmemobj++/condition_variable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,9 +67,22 @@ public:
 	typedef PMEMcond *native_handle_type;
 
 	/**
-	 * Defaulted constructor.
+	 * Default constructor.
+	 *
+	 * @throw lock_error when the condition_variable is not from persistent
+	 * memory.
 	 */
-	condition_variable() noexcept = default;
+	condition_variable()
+	{
+		PMEMobjpool *pop;
+		if ((pop = pmemobj_pool_by_ptr(&pcond)) == nullptr)
+			throw lock_error(
+				1, std::generic_category(),
+				"Persistent condition variable not from"
+				" persistent memory.");
+
+		pmemobj_cond_zero(pop, &pcond);
+	}
 
 	/**
 	 * Defaulted destructor.

--- a/src/include/libpmemobj++/mutex.hpp
+++ b/src/include/libpmemobj++/mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,9 +63,20 @@ public:
 	typedef PMEMmutex *native_handle_type;
 
 	/**
-	 * Defaulted constructor.
+	 * Default constructor.
+	 *
+	 * @throw lock_error when the mutex is not from persistent memory.
 	 */
-	mutex() noexcept = default;
+	mutex()
+	{
+		PMEMobjpool *pop;
+		if ((pop = pmemobj_pool_by_ptr(&plock)) == nullptr)
+			throw lock_error(1, std::generic_category(),
+					 "Persistent mutex not from persistent"
+					 "memory.");
+
+		pmemobj_mutex_zero(pop, &plock);
+	}
 
 	/**
 	 * Defaulted destructor.

--- a/src/include/libpmemobj++/shared_mutex.hpp
+++ b/src/include/libpmemobj++/shared_mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,9 +62,21 @@ public:
 	typedef PMEMrwlock *native_handle_type;
 
 	/**
-	 * Defaulted constructor.
+	 * Default constructor.
+	 *
+	 * @throw lock_error when the shared_mutex is not from persistent
+	 * memory.
 	 */
-	shared_mutex() noexcept = default;
+	shared_mutex()
+	{
+		PMEMobjpool *pop;
+		if ((pop = pmemobj_pool_by_ptr(&plock)) == nullptr)
+			throw lock_error(1, std::generic_category(),
+					 "Persistent shared mutex not from "
+					 "persistent memory.");
+
+		pmemobj_rwlock_zero(pop, &plock);
+	}
 
 	/**
 	 * Defaulted destructor.

--- a/src/include/libpmemobj++/timed_mutex.hpp
+++ b/src/include/libpmemobj++/timed_mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,9 +66,20 @@ public:
 	typedef PMEMmutex *native_handle_type;
 
 	/**
-	 * Defaulted constructor.
+	 * Default constructor.
+	 *
+	 * @throw lock_error when the timed_mutex is not from persistent memory.
 	 */
-	timed_mutex() noexcept = default;
+	timed_mutex()
+	{
+		PMEMobjpool *pop;
+		if ((pop = pmemobj_pool_by_ptr(&plock)) == nullptr)
+			throw lock_error(1, std::generic_category(),
+					 "Persistent mutex not from persistent"
+					 "memory.");
+
+		pmemobj_mutex_zero(pop, &plock);
+	}
 
 	/**
 	 * Defaulted destructor.

--- a/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
+++ b/src/test/obj_cpp_cond_var/obj_cpp_cond_var.cpp
@@ -357,6 +357,28 @@ reader_lock_for_pred(nvobj::persistent_ptr<struct root> proot)
 }
 
 /*
+ * cond_zero_test -- (internal) test the zeroing constructor
+ */
+void
+cond_zero_test(nvobj::pool<struct root> &pop)
+{
+	PMEMoid raw_cnd;
+
+	pmemobj_alloc(pop.get_handle(), &raw_cnd, sizeof(PMEMcond), 1,
+		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
+			      PMEMcond *mtx = static_cast<PMEMcond *>(ptr);
+			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
+			      return 0;
+		      },
+		      NULL);
+
+	nvobj::condition_variable *placed_mtx =
+		new (pmemobj_direct(raw_cnd)) nvobj::condition_variable;
+	std::unique_lock<nvobj::mutex> lock(pop.get_root()->pmutex);
+	placed_mtx->wait_for(lock, wait_time, []() { return false; });
+}
+
+/*
  * mutex_test -- (internal) launch worker threads to test the pshared_mutex
  */
 template <typename Reader, typename Writer>
@@ -397,6 +419,8 @@ main(int argc, char *argv[])
 	} catch (nvml::pool_error &pe) {
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
+
+	cond_zero_test(pop);
 
 	std::vector<reader_type> notify_functions(
 		{reader_mutex, reader_mutex_pred, reader_lock, reader_lock_pred,

--- a/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
+++ b/src/test/obj_cpp_mutex_posix/obj_cpp_mutex_posix.cpp
@@ -113,6 +113,26 @@ trylock_test(void *arg)
 }
 
 /*
+ * mutex_zero_test -- (internal) test the zeroing constructor
+ */
+void
+mutex_zero_test(nvobj::pool<struct root> &pop)
+{
+	PMEMoid raw_mutex;
+
+	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
+			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
+			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
+			      return 0;
+		      },
+		      NULL);
+
+	nvobj::mutex *placed_mtx = new (pmemobj_direct(raw_mutex)) nvobj::mutex;
+	std::unique_lock<nvobj::mutex> lck(*placed_mtx);
+}
+
+/*
  * mutex_test -- (internal) launch worker threads to test the pmutex
  */
 template <typename Worker>
@@ -149,6 +169,8 @@ main(int argc, char *argv[])
 	} catch (nvml::pool_error &pe) {
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
+
+	mutex_zero_test(pop);
 
 	mutex_test(pop, increment_pint);
 	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);

--- a/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
+++ b/src/test/obj_cpp_shared_mutex/obj_cpp_shared_mutex.cpp
@@ -120,6 +120,27 @@ reader_trylock(nvobj::persistent_ptr<root> proot)
 }
 
 /*
+ * mutex_zero_test -- (internal) test the zeroing constructor
+ */
+void
+mutex_zero_test(nvobj::pool<struct root> &pop)
+{
+	PMEMoid raw_mutex;
+
+	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMrwlock), 1,
+		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
+			      PMEMrwlock *mtx = static_cast<PMEMrwlock *>(ptr);
+			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
+			      return 0;
+		      },
+		      NULL);
+
+	nvobj::shared_mutex *placed_mtx =
+		new (pmemobj_direct(raw_mutex)) nvobj::shared_mutex;
+	std::unique_lock<nvobj::shared_mutex> lck(*placed_mtx);
+}
+
+/*
  * mutex_test -- (internal) launch worker threads to test the pshared_mutex
  */
 template <typename Worker>
@@ -159,6 +180,8 @@ main(int argc, char *argv[])
 	} catch (nvml::pool_error &pe) {
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
+
+	mutex_zero_test(pop);
 
 	int expected = num_threads * num_ops * 2;
 	mutex_test(pop, writer, reader);

--- a/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
+++ b/src/test/obj_cpp_timed_mtx/obj_cpp_timed_mtx.cpp
@@ -165,6 +165,27 @@ trylock_until_test(nvobj::persistent_ptr<root> proot)
 }
 
 /*
+ * mutex_zero_test -- (internal) test the zeroing constructor
+ */
+void
+mutex_zero_test(nvobj::pool<struct root> &pop)
+{
+	PMEMoid raw_mutex;
+
+	pmemobj_alloc(pop.get_handle(), &raw_mutex, sizeof(PMEMmutex), 1,
+		      [](PMEMobjpool *pop, void *ptr, void *arg) -> int {
+			      PMEMmutex *mtx = static_cast<PMEMmutex *>(ptr);
+			      pmemobj_memset_persist(pop, mtx, 1, sizeof(*mtx));
+			      return 0;
+		      },
+		      NULL);
+
+	nvobj::timed_mutex *placed_mtx =
+		new (pmemobj_direct(raw_mutex)) nvobj::timed_mutex;
+	std::unique_lock<nvobj::timed_mutex> lck(*placed_mtx);
+}
+
+/*
  * mutex_test -- (internal) launch worker threads to test the pmutex
  */
 template <typename Worker>
@@ -201,6 +222,8 @@ main(int argc, char *argv[])
 	} catch (nvml::pool_error &pe) {
 		UT_FATAL("!pool::create: %s %s", pe.what(), path);
 	}
+
+	mutex_zero_test(pop);
 
 	timed_mtx_test(pop, increment_pint);
 	UT_ASSERTeq(pop.get_root()->counter, num_threads * num_ops);


### PR DESCRIPTION
In fringe, highly unlikely cases mutex/shared_mutex locking could
block indefinitely due to improper underlying C type initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1775)
<!-- Reviewable:end -->
