### PR TITLE
obj: fix obj_lane memcheck bug

### DIFF
--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -240,6 +240,7 @@ test_lane_hold_release(void)
 
 	pop->p.lanes_desc.lane_locks = CALLOC(OBJ_NLANES, sizeof(uint64_t));
 	pop->p.lanes_offset = (uint64_t)&pop->l - (uint64_t)&pop->p;
+	pop->p.uuid_lo = 123456;
 	base_ptr = &pop->p;
 
 	struct lane_section *sec;


### PR DESCRIPTION
Ref: pmem/issues#509

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1782)
<!-- Reviewable:end -->
