### PR TITLE
obj: add pop debug check in sync.c

### DIFF
--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -143,6 +143,8 @@ pmemobj_mutex_zero(PMEMobjpool *pop, PMEMmutex *mutexp)
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
+
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	mutexip->pmemmutex.runid = 0;
 	pmemops_persist(&pop->p_ops, &mutexip->pmemmutex.runid,
@@ -159,6 +161,8 @@ int
 pmemobj_mutex_lock(PMEMobjpool *pop, PMEMmutex *mutexp)
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
 
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
@@ -180,6 +184,8 @@ int
 pmemobj_mutex_assert_locked(PMEMobjpool *pop, PMEMmutex *mutexp)
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
 
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
@@ -214,6 +220,8 @@ pmemobj_mutex_timedlock(PMEMobjpool *pop, PMEMmutex *__restrict mutexp,
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
+
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
 	if (mutex == NULL)
@@ -235,6 +243,8 @@ pmemobj_mutex_trylock(PMEMobjpool *pop, PMEMmutex *mutexp)
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
+
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_mutex_t *mutex = GET_MUTEX(pop, mutexip);
 	if (mutex == NULL)
@@ -252,6 +262,8 @@ int
 pmemobj_mutex_unlock(PMEMobjpool *pop, PMEMmutex *mutexp)
 {
 	LOG(3, "pop %p mutex %p", pop, mutexp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
 
 	/* XXX potential performance improvement - move GET to debug version */
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
@@ -274,6 +286,8 @@ pmemobj_rwlock_zero(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
+
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	rwlockip->pmemrwlock.runid = 0;
 	pmemops_persist(&pop->p_ops, &rwlockip->pmemrwlock.runid,
@@ -290,6 +304,8 @@ int
 pmemobj_rwlock_rdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
 
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
@@ -311,6 +327,8 @@ int
 pmemobj_rwlock_wrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
 
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
@@ -335,6 +353,8 @@ pmemobj_rwlock_timedrdlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
 	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
 		abs_timeout->tv_sec, abs_timeout->tv_nsec);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
+
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
@@ -358,6 +378,8 @@ pmemobj_rwlock_timedwrlock(PMEMobjpool *pop, PMEMrwlock *__restrict rwlockp,
 	LOG(3, "pop %p rwlock %p timeout sec %ld nsec %ld", pop, rwlockp,
 		abs_timeout->tv_sec, abs_timeout->tv_nsec);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
+
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
@@ -378,6 +400,8 @@ int
 pmemobj_rwlock_tryrdlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
 
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
@@ -400,6 +424,8 @@ pmemobj_rwlock_trywrlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
+
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
 	pthread_rwlock_t *rwlock = GET_RWLOCK(pop, rwlockip);
 	if (rwlock == NULL)
@@ -417,6 +443,8 @@ int
 pmemobj_rwlock_unlock(PMEMobjpool *pop, PMEMrwlock *rwlockp)
 {
 	LOG(3, "pop %p rwlock %p", pop, rwlockp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(rwlockp));
 
 	/* XXX potential performance improvement - move GET to debug version */
 	PMEMrwlock_internal *rwlockip = (PMEMrwlock_internal *)rwlockp;
@@ -439,6 +467,8 @@ pmemobj_cond_zero(PMEMobjpool *pop, PMEMcond *condp)
 {
 	LOG(3, "pop %p cond %p", pop, condp);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(condp));
+
 	PMEMcond_internal *condip = (PMEMcond_internal *)condp;
 	condip->pmemcond.runid = 0;
 	pmemops_persist(&pop->p_ops, &condip->pmemcond.runid,
@@ -455,6 +485,8 @@ int
 pmemobj_cond_broadcast(PMEMobjpool *pop, PMEMcond *condp)
 {
 	LOG(3, "pop %p cond %p", pop, condp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(condp));
 
 	PMEMcond_internal *condip = (PMEMcond_internal *)condp;
 	pthread_cond_t *cond = GET_COND(pop, condip);
@@ -476,6 +508,8 @@ int
 pmemobj_cond_signal(PMEMobjpool *pop, PMEMcond *condp)
 {
 	LOG(3, "pop %p cond %p", pop, condp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(condp));
 
 	PMEMcond_internal *condip = (PMEMcond_internal *)condp;
 	pthread_cond_t *cond = GET_COND(pop, condip);
@@ -501,6 +535,9 @@ pmemobj_cond_timedwait(PMEMobjpool *pop, PMEMcond *__restrict condp,
 	LOG(3, "pop %p cond %p mutex %p abstime sec %ld nsec %ld", pop, condp,
 		mutexp, abs_timeout->tv_sec, abs_timeout->tv_nsec);
 
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
+	ASSERTeq(pop, pmemobj_pool_by_ptr(condp));
+
 	PMEMcond_internal *condip = (PMEMcond_internal *)condp;
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;
 	pthread_cond_t *cond = GET_COND(pop, condip);
@@ -525,6 +562,9 @@ pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *condp,
 			PMEMmutex *__restrict mutexp)
 {
 	LOG(3, "pop %p cond %p mutex %p", pop, condp, mutexp);
+
+	ASSERTeq(pop, pmemobj_pool_by_ptr(mutexp));
+	ASSERTeq(pop, pmemobj_pool_by_ptr(condp));
 
 	PMEMcond_internal *condip = (PMEMcond_internal *)condp;
 	PMEMmutex_internal *mutexip = (PMEMmutex_internal *)mutexp;

--- a/src/test/obj_debug/README
+++ b/src/test/obj_debug/README
@@ -28,3 +28,4 @@ The following characters and operations can be used:
 		- pmemobj_tx_add_common
 	a - tests notice of atomic allocation in tx:
 		- pmemobj_alloc
+	s - tests debug checks in the thread synchronization API

--- a/src/test/obj_debug/TEST5
+++ b/src/test/obj_debug/TEST5
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_debug/TEST5 -- unit test for debug features
+#
+export UNITTEST_NAME=obj_debug/TEST5
+export UNITTEST_NUM=5
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_build_type debug
+
+FUNCS=17
+
+setup
+
+for op_index in $(seq 0 $FUNCS); do
+	expect_abnormal_exit ./obj_debug$EXESUFFIX $DIR/testfile1 s $op_index 2> /dev/null
+done
+
+pass

--- a/src/test/obj_debug/TEST5.PS1
+++ b/src/test/obj_debug/TEST5.PS1
@@ -1,0 +1,59 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_debug/TEST5 -- unit test for debug features
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "obj_debug\TEST5"
+$Env:UNITTEST_NUM = "5"
+
+# standard unit test setup
+. ..\unittest\unittest.ps1
+
+require_test_type medium
+require_build_type debug
+
+setup
+
+FUNCS=18
+
+For ($i=0; $i -lt $FUNCS; $i++) {
+    expect_abnormal_exit $Env:EXE_DIR\obj_debug$Env:EXESUFFIX `
+    $DIR/testfile1 s $i 2>$null
+}
+
+pass

--- a/src/test/obj_list/mocks_windows.h
+++ b/src/test/obj_list/mocks_windows.h
@@ -87,6 +87,7 @@ extern "C" {
 #define pmemobj_close __wrap_pmemobj_close
 #define pmemobj_direct __wrap_pmemobj_direct
 #define pmemobj_pool_by_oid __wrap_pmemobj_pool_by_oid
+#define pmemobj_pool_by_ptr __wrap_pmemobj_pool_by_ptr
 #endif
 
 #if defined(__cplusplus)

--- a/src/test/obj_list/obj_list_mocks.c
+++ b/src/test/obj_list/obj_list_mocks.c
@@ -206,6 +206,13 @@ FUNC_MOCK(pmemobj_close, void, PMEMobjpool *pop)
 FUNC_MOCK_END
 
 /*
+ * pmemobj_pool_by_ptr -- pmemobj_pool_by_ptr mock
+ *
+ * Just return Pop.
+ */
+FUNC_MOCK_RET_ALWAYS(pmemobj_pool_by_ptr, PMEMobjpool *, Pop, const void *ptr);
+
+/*
  * pmemobj_direct -- pmemobj_direct mock
  */
 FUNC_MOCK(pmemobj_direct, void *, PMEMoid oid)

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -96,6 +96,14 @@ FUNC_MOCK(pthread_cond_init, int,
 	}
 FUNC_MOCK_END
 
+
+
+PMEMobjpool *
+pmemobj_pool_by_ptr(const void *arg)
+{
+	return &Mock_pop;
+}
+
 /*
  * mock_open_pool -- (internal) simulate pool opening
  */

--- a/src/test/obj_tx_locks/obj_tx_locks.c
+++ b/src/test/obj_tx_locks/obj_tx_locks.c
@@ -53,14 +53,15 @@
 		&(mutexes)[0], TX_LOCK_MUTEX, &(mutexes)[1], TX_LOCK_RWLOCK,\
 		&(rwlocks)[0], TX_LOCK_RWLOCK, &(rwlocks)[1], TX_LOCK_NONE)
 
-static struct transaction_data {
-	PMEMobjpool *pop;
-	PMEMmutex *mutexes;
-	PMEMrwlock *rwlocks;
+struct transaction_data {
+	PMEMmutex mutexes[NUM_LOCKS];
+	PMEMrwlock rwlocks[NUM_LOCKS];
 	int a;
 	int b;
 	int c;
-} test_obj;
+};
+
+PMEMobjpool *Pop;
 
 /*
  * do_tx -- (internal) thread-friendly transaction
@@ -70,7 +71,7 @@ do_tx(void *arg)
 {
 	struct transaction_data *data = arg;
 
-	BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
+	BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
 		data->a = TEST_VALUE_A;
 	} TX_ONCOMMIT {
 		UT_ASSERT(data->a == TEST_VALUE_A);
@@ -93,7 +94,7 @@ do_tx_old(void *arg)
 {
 	struct transaction_data *data = arg;
 
-	BEGIN_TX_OLD(data->pop, data->mutexes, data->rwlocks) {
+	BEGIN_TX_OLD(Pop, data->mutexes, data->rwlocks) {
 		data->a = TEST_VALUE_A;
 	} TX_ONCOMMIT {
 		UT_ASSERT(data->a == TEST_VALUE_A);
@@ -116,7 +117,7 @@ do_aborted_tx(void *arg)
 {
 	struct transaction_data *data = arg;
 
-	BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
+	BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
 		data->a = TEST_VALUE_A;
 		pmemobj_tx_abort(EINVAL);
 		data->a = TEST_VALUE_B;
@@ -141,8 +142,8 @@ do_nested_tx(void *arg)
 {
 	struct transaction_data *data = arg;
 
-	BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
-		BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
+	BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
+		BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
 			data->a = TEST_VALUE_A;
 		} TX_ONCOMMIT {
 			UT_ASSERT(data->a == TEST_VALUE_A);
@@ -163,9 +164,9 @@ do_aborted_nested_tx(void *arg)
 {
 	struct transaction_data *data = arg;
 
-	BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
+	BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
 		data->a = TEST_VALUE_C;
-		BEGIN_TX(data->pop, data->mutexes, data->rwlocks) {
+		BEGIN_TX(Pop, data->mutexes, data->rwlocks) {
 			data->a = TEST_VALUE_A;
 			pmemobj_tx_abort(EINVAL);
 			data->a = TEST_VALUE_B;
@@ -215,7 +216,7 @@ main(int argc, char *argv[])
 	if (argc > 3)
 		UT_FATAL("usage: %s <file> [m]", argv[0]);
 
-	if ((test_obj.pop = pmemobj_create(argv[1], LAYOUT_NAME,
+	if ((Pop = pmemobj_create(argv[1], LAYOUT_NAME,
 	    PMEMOBJ_MIN_POOL, S_IWUSR | S_IRUSR)) == NULL)
 		UT_FATAL("!pmemobj_create");
 
@@ -226,52 +227,54 @@ main(int argc, char *argv[])
 			UT_FATAL("wrong test type supplied %c", argv[1][0]);
 	}
 
-	test_obj.mutexes = CALLOC(NUM_LOCKS, sizeof(PMEMmutex));
-	test_obj.rwlocks = CALLOC(NUM_LOCKS, sizeof(PMEMrwlock));
+	PMEMoid root = pmemobj_root(Pop, sizeof(struct transaction_data));
+
+	struct transaction_data *test_obj =
+			(struct transaction_data *)pmemobj_direct(root);
 
 	if (multithread) {
-		run_mt_test(do_tx, &test_obj);
+		run_mt_test(do_tx, test_obj);
 	} else {
-		do_tx(&test_obj);
-		do_tx(&test_obj);
+		do_tx(test_obj);
+		do_tx(test_obj);
 	}
 
-	UT_ASSERT(test_obj.a == TEST_VALUE_A);
-	UT_ASSERT(test_obj.b == TEST_VALUE_B);
-	UT_ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj->a == TEST_VALUE_A);
+	UT_ASSERT(test_obj->b == TEST_VALUE_B);
+	UT_ASSERT(test_obj->c == TEST_VALUE_C);
 
 	if (multithread) {
-		run_mt_test(do_aborted_tx, &test_obj);
+		run_mt_test(do_aborted_tx, test_obj);
 	} else {
-		do_aborted_tx(&test_obj);
-		do_aborted_tx(&test_obj);
+		do_aborted_tx(test_obj);
+		do_aborted_tx(test_obj);
 	}
 
-	UT_ASSERT(test_obj.a == TEST_VALUE_A);
-	UT_ASSERT(test_obj.b == TEST_VALUE_B);
-	UT_ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj->a == TEST_VALUE_A);
+	UT_ASSERT(test_obj->b == TEST_VALUE_B);
+	UT_ASSERT(test_obj->c == TEST_VALUE_C);
 
 	if (multithread) {
-		run_mt_test(do_nested_tx, &test_obj);
+		run_mt_test(do_nested_tx, test_obj);
 	} else {
-		do_nested_tx(&test_obj);
-		do_nested_tx(&test_obj);
+		do_nested_tx(test_obj);
+		do_nested_tx(test_obj);
 	}
 
-	UT_ASSERT(test_obj.a == TEST_VALUE_A);
-	UT_ASSERT(test_obj.b == TEST_VALUE_B);
-	UT_ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj->a == TEST_VALUE_A);
+	UT_ASSERT(test_obj->b == TEST_VALUE_B);
+	UT_ASSERT(test_obj->c == TEST_VALUE_C);
 
 	if (multithread) {
-		run_mt_test(do_aborted_nested_tx, &test_obj);
+		run_mt_test(do_aborted_nested_tx, test_obj);
 	} else {
-		do_aborted_nested_tx(&test_obj);
-		do_aborted_nested_tx(&test_obj);
+		do_aborted_nested_tx(test_obj);
+		do_aborted_nested_tx(test_obj);
 	}
 
-	UT_ASSERT(test_obj.a == TEST_VALUE_B);
-	UT_ASSERT(test_obj.b == TEST_VALUE_A);
-	UT_ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj->a == TEST_VALUE_B);
+	UT_ASSERT(test_obj->b == TEST_VALUE_A);
+	UT_ASSERT(test_obj->c == TEST_VALUE_C);
 
 
 	/* test that deprecated macros still work */
@@ -279,17 +282,17 @@ main(int argc, char *argv[])
 	UT_COMPILE_ERROR_ON((int)TX_LOCK_MUTEX != (int)TX_PARAM_MUTEX);
 	UT_COMPILE_ERROR_ON((int)TX_LOCK_RWLOCK != (int)TX_PARAM_RWLOCK);
 	if (multithread) {
-		run_mt_test(do_tx_old, &test_obj);
+		run_mt_test(do_tx_old, test_obj);
 	} else {
-		do_tx_old(&test_obj);
-		do_tx_old(&test_obj);
+		do_tx_old(test_obj);
+		do_tx_old(test_obj);
 	}
 
-	UT_ASSERT(test_obj.a == TEST_VALUE_A);
-	UT_ASSERT(test_obj.b == TEST_VALUE_B);
-	UT_ASSERT(test_obj.c == TEST_VALUE_C);
+	UT_ASSERT(test_obj->a == TEST_VALUE_A);
+	UT_ASSERT(test_obj->b == TEST_VALUE_B);
+	UT_ASSERT(test_obj->c == TEST_VALUE_C);
 
-	pmemobj_close(test_obj.pop);
+	pmemobj_close(Pop);
 
 	DONE(NULL);
 }


### PR DESCRIPTION
Add a debug check to the thread synchronization API to check the
provided pmemobj pool handle against the location of the synchronization
primitive. Since this check is costly, it will be performed only in the
debug version of the library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1783)
<!-- Reviewable:end -->
