### PR TITLE
common: link with '-lrt' when necessary

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -85,6 +85,13 @@ ifneq ($(NORPATH),1)
 LDFLAGS += -Wl,-rpath=$(libdir)$(LIB_SUBDIR)
 endif
 
+# XXX: required by clock_gettime(), if glibc version < 2.17
+# The os_clock_gettime() function is now in OS abstraction layer,
+# linked to all the librariess, unit tests and benchmarks.
+ifeq ($(call check_librt), n)
+LIBS += -lrt
+endif
+
 define arch32_error_msg
 
 ##################################################

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -66,6 +66,13 @@ endif
 LIBS += -L$(LIBS_DIR)/debug
 LIBS += -pthread
 
+# XXX: required by clock_gettime(), if glibc version < 2.17
+# The os_clock_gettime() function is now in OS abstraction layer,
+# linked to all the librariess, unit tests and benchmarks.
+ifeq ($(call check_librt), n)
+LIBS += -lrt
+endif
+
 ifeq ($(LIBPMEMPOOL), y)
 DYNAMIC_LIBS += -lpmempool
 STATIC_DEBUG_LIBS += $(LIBS_DIR)/debug/libpmempool.a

--- a/src/test/obj_sync/Makefile
+++ b/src/test/obj_sync/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,7 +39,6 @@ vpath %.c $(TOP)/src/libpmemobj
 
 TARGET = obj_sync
 OBJS = obj_sync.o sync.o
-LIBS = -lrt
 
 LIBPMEMCOMMON=y
 LIBPMEM=y

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -1,4 +1,4 @@
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -92,6 +92,13 @@ PMEMOBJ_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemobj/libpmemobj_unscoped.o
 PMEMBLK_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemblk/libpmemblk_unscoped.o
 
 LIBS += -pthread
+
+# XXX: required by clock_gettime(), if glibc version < 2.17
+# The os_clock_gettime() function is now in OS abstraction layer,
+# linked to all the librariess, unit tests and benchmarks.
+ifeq ($(call check_librt), n)
+LIBS += -lrt
+endif
 
 ifeq ($(TOOLS_COMMON), y)
 LIBPMEMCOMMON=y


### PR DESCRIPTION
The librt is needed for clock_gettime(), if glibc version < 2.17.
This patch fixes the NVML build failures on some old Linux distros,
as well as the Coverity build failures on TravisCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1787)
<!-- Reviewable:end -->
