### PR TITLE
common: extend test timeout for AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test_script:
         echo "`$Env:PMEM_FS_DIR = `"\temp`"" >> testconfig.ps1
         echo "`$Env:PMEM_FS_DIR_FORCE_PMEM = `"1`"" >> testconfig.ps1
         echo "`$Env:TM = `"1`"" >> testconfig.ps1
-        ./RUNTESTS.ps1 -b debug -o 3m
+        ./RUNTESTS.ps1 -b debug -o 4m
     }
 
 artifacts:


### PR DESCRIPTION
This is a temporary workaround for timeouts in vmem_multiple_pools
test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1789)
<!-- Reviewable:end -->
