### PR TITLE
obj: add ctl var for suppressing expensive checks

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -2252,6 +2252,11 @@ prefault.at_open | rw | global | int | int | boolean
 
 As above, but affects **pmemobj_open()** function.
 
+tx.debug.skip_expensive_checks | rw | - | int | int | boolean
+
+Turns off some expensive checks performed by transaction module in "debug"
+builds. Ignored in "release" builds.
+
 # CTL external configuration #
 
 In addition to direct function call, each write entry point can also be set

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -161,6 +161,10 @@ obj_ctl_init_and_load(PMEMobjpool *pop)
 		return -1;
 	}
 
+	if (pop) {
+		tx_ctl_init(pop);
+	}
+
 	struct ctl_query_provider *p;
 
 	char *env_config = os_getenv(OBJ_CONFIG_ENV_VARIABLE);

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -159,10 +159,11 @@ struct pmemobjpool {
 	persist_remote_fn persist_remote; /* remote persist function */
 
 	int vg_boot;
+	int tx_debug_skip_expensive_checks;
 
 	/* padding to align size of this structure to page boundary */
 	/* sizeof(unused2) == 8192 - offsetof(struct pmemobjpool, unused2) */
-	char unused2[1572];
+	char unused2[1568];
 };
 
 /*

--- a/src/libpmemobj/tx.h
+++ b/src/libpmemobj/tx.h
@@ -79,4 +79,6 @@ struct lane_tx_layout {
  */
 PMEMobjpool *tx_get_pop(void);
 
+void tx_ctl_init(PMEMobjpool *pop);
+
 #endif


### PR DESCRIPTION
~~Currently it's not possible to profile applications using pmemobj.
Release versions of the library don't have debug symbols and
debug versions are very slow because of single check in
pmemobj_tx_commit.~~

~~To allow profiling introduce PMEMOBJ_DEBUG_SUPPRESS_EXPENSIVE_CHECKS
environment variable.~~

The new ctl variable is: tx.debug.skip_expensive_checks=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1797)
<!-- Reviewable:end -->
