### PR TITLE
obj: small optimization in tx_post_commit_set

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -618,9 +618,11 @@ tx_post_commit_set(PMEMobjpool *pop, struct tx_undo_runtime *tx_rt,
 			sz = r->cache_offset;
 		}
 
-		VALGRIND_ADD_TO_TX(cache, sz);
-		pmemops_memset_persist(&pop->p_ops, cache, 0, sz);
-		VALGRIND_REMOVE_FROM_TX(cache, sz);
+		if (sz) {
+			VALGRIND_ADD_TO_TX(cache, sz);
+			pmemops_memset_persist(&pop->p_ops, cache, 0, sz);
+			VALGRIND_REMOVE_FROM_TX(cache, sz);
+		}
 
 #ifdef DEBUG
 		if (!zero_all) { /* for recovery we know we zeroed everything */


### PR DESCRIPTION
This change affects empty transactions.

We can't move this check to pmemops_memset_persist, because it has
built-in fence, which someone might rely on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1798)
<!-- Reviewable:end -->
