### PR TITLE
pool: remove util_remote_load from lib ctor

### DIFF
--- a/src/common/os.h
+++ b/src/common/os.h
@@ -43,6 +43,7 @@ extern "C" {
 
 #include <sys/stat.h>
 #include <stdio.h>
+#include <unistd.h>
 
 struct iovec;
 

--- a/src/libpmempool/libpmempool.c
+++ b/src/libpmempool/libpmempool.c
@@ -69,7 +69,6 @@ libpmempool_init(void)
 	LOG(3, NULL);
 #ifdef USE_RPMEM
 	util_remote_init();
-	util_remote_load();
 	rpmem_util_cmds_init();
 #endif
 }


### PR DESCRIPTION
The librpmem library is loaded on demand only if there are any remote
replicas in the pool set.

This also fixes one of the issues detected by Coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1812)
<!-- Reviewable:end -->
