### PR TITLE
common: don't build tests when requested

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -156,6 +156,8 @@ Description: rpmem daemon
 EOF
 }
 
+if [ "${BUILD_PACKAGE_CHECK}" == "y" ]
+then
 CHECK_CMD="
 override_dh_auto_test:
 	dh_auto_test
@@ -164,13 +166,12 @@ override_dh_auto_test:
 	else\
 	        cp src/test/testconfig.sh.example src/test/testconfig.sh;\
 	fi
-"
-
-if [ "${BUILD_PACKAGE_CHECK}" == "y" ]
-then
-CHECK_CMD="
-${CHECK_CMD}
 	make pcheck ${PCHECK_OPTS}
+"
+else
+CHECK_CMD="
+override_dh_auto_test:
+
 "
 fi
 


### PR DESCRIPTION
... from make dpkg. It's already happening in make rpm.
It speeds up building packages with BUILD_PACKAGE_CHECK=n by a factor of 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1814)
<!-- Reviewable:end -->
