### PR TITLE
common: set some flags for release packages

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -698,7 +698,12 @@ tail -n1 $CHANGELOG_TMP >> debian/changelog
 rm $CHANGELOG_TMP
 
 # This is our first release but we do
-debuild --preserve-envvar=EXTRA_CFLAGS --preserve-envvar=EXTRA_LDFLAGS -us -uc
+debuild --preserve-envvar=EXTRA_CFLAGS_RELEASE \
+	--preserve-envvar=EXTRA_CFLAGS_DEBUG \
+	--preserve-envvar=EXTRA_CFLAGS \
+	--preserve-envvar=EXTRA_CXXFLAGS \
+	--preserve-envvar=EXTRA_LDFLAGS \
+	-us -uc
 
 cd $OLD_DIR
 

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -58,6 +58,9 @@ INC_DIR=$PREFIX/include
 MAN1_DIR=$PREFIX/share/man/man1
 MAN3_DIR=$PREFIX/share/man/man3
 DOC_DIR=$PREFIX/share/doc
+if [ "$EXTRA_CFLAGS_RELEASE" = "" ]; then
+	export EXTRA_CFLAGS_RELEASE="-ggdb -fno-omit-frame-pointer"
+fi
 
 function convert_changelog() {
 	while read line

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -52,6 +52,9 @@ OUT_DIR=$4
 EXPERIMENTAL=$5
 BUILD_PACKAGE_CHECK=$6
 TEST_CONFIG_FILE=$7
+if [ "$EXTRA_CFLAGS_RELEASE" = "" ]; then
+	export EXTRA_CFLAGS_RELEASE="-ggdb -fno-omit-frame-pointer"
+fi
 
 function create_changelog() {
 	echo


### PR DESCRIPTION
-ggdb does not affect generated code and for distro packages all
debug info is moved to a separate package with debug informations.
    
-fno-omit-frame-pointer affects generated code, but its overhead
should be negligible.
    
With those two flags in release builds it's possible to analyze
performance traces. Without -fno-omit-frame-pointer the stacktraces
are flat and spread randomly making the analysis impossible.
Without -ggdb stacktraces are reliable, but the part in NVML has
"unknown" as function names. (-ggdb without -fno-omit-frame-pointer
is useless)

Builds on top of #1819.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1820)
<!-- Reviewable:end -->
