### PR TITLE
examples: Fix dynamic linking issues

### DIFF
--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -123,7 +123,7 @@ all: $(TMP_HEADERS)
 	$(call check-cstyle, $<, $@)
 
 $(PROGS): | $(TMP_HEADERS)
-	$(LINKER) -o $@ $(LDFLAGS) $^ $(LIBS)
+	$(LINKER) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 lib%.o:
 	$(LD) -o $@ -r $^
@@ -132,7 +132,7 @@ $(STATIC_LIBRARIES):
 	$(AR) rv $@ $<
 
 $(DYNAMIC_LIBRARIES):
-	$(LINKER) -shared -o $@ $(LDFLAGS) -Wl,-shared,-soname=$@ $<
+	$(LINKER) -shared -o $@ $(LDFLAGS) -Wl,-shared,-soname=$@ $(LIBS) $<
 
 .PHONY: all clean clobber cstyle\
 	all-dirs clean-dirs clobber-dirs cstyle-dirs\

--- a/src/examples/libpmemobj/hashmap/Makefile
+++ b/src/examples/libpmemobj/hashmap/Makefile
@@ -32,6 +32,8 @@
 
 LIBRARIES = hashmap_atomic hashmap_tx
 
+LIBS = -lpmemobj
+
 include ../../Makefile.inc
 
 libhashmap_atomic.o: hashmap_atomic.o

--- a/src/examples/libpmemobj/libart/Makefile
+++ b/src/examples/libpmemobj/libart/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright 2016, FUJITSU TECHNOLOGY SOLUTIONS GMBH
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,10 +52,10 @@ LIBRARIES = art
 
 include ../../Makefile.inc
 
-LIBS = -lpmemobj -pthread -lart
+LIBS = -lpmemobj
 
 $(PROGS): | $(DYNAMIC_LIBRARIES)
-$(PROGS): LDFLAGS += -Wl,-rpath=. -L.
+$(PROGS): LDFLAGS += -Wl,-rpath=. -L. -lart
 
 libart.o: art.o
 

--- a/src/examples/libpmemobj/list_map/Makefile
+++ b/src/examples/libpmemobj/list_map/Makefile
@@ -35,6 +35,8 @@
 #
 LIBRARIES = skiplist_map
 
+LIBS = -lpmemobj
+
 include ../../Makefile.inc
 
 libskiplist_map.o: skiplist_map.o

--- a/src/examples/libpmemobj/tree_map/Makefile
+++ b/src/examples/libpmemobj/tree_map/Makefile
@@ -35,6 +35,8 @@
 #
 LIBRARIES = ctree_map btree_map rtree_map rbtree_map
 
+LIBS = -lpmemobj
+
 include ../../Makefile.inc
 
 libctree_map.o: ctree_map.o

--- a/src/examples/libvmem/libart/Makefile
+++ b/src/examples/libvmem/libart/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright 2016, FUJITSU TECHNOLOGY SOLUTIONS GMBH
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,10 +51,10 @@ LIBRARIES = art
 
 include ../../Makefile.inc
 
-LIBS = -lvmem -pthread -lart
+LIBS = -lvmem
 
 $(PROGS): | $(DYNAMIC_LIBRARIES)
-$(PROGS): LDFLAGS += -Wl,-rpath=. -L.
+$(PROGS): LDFLAGS += -Wl,-rpath=. -L. -lart
 
 libart.o: art.o
 


### PR DESCRIPTION
The linking command in examples/Makefile.inc didn't use the LIB
variable.
Also, some libraries didn't reference pmemobj -- such shared objects
should reference all their dependecies.
Remove some references to pthreads, as it is already a dependancy
of libpmemobj, thus probably there should be no need to mention it when
using pmemobj.

This also reverts a few mistakes made in an earlier commit:
"examples: Remove unused LIBS variable from some makefiles"

Before:

```
$ ldd libart.so
        linux-vdso.so.1
        libc.so.6 => /usr/lib/libc.so.6
        /usr/lib64/ld-linux-x86-64.so.2

$ ldd libhashmap_tx.so
        linux-vdso.so.1
        libc.so.6 => /usr/lib/libc.so.6
        /usr/lib64/ld-linux-x86-64.so.2
```

After:

```
$ ldd libart.so
        linux-vdso.so.1
        libpmemobj.so.1 => ../../../debug/libpmemobj.so.1
        libpthread.so.0 => /usr/lib/libpthread.so.0
        libc.so.6 => /usr/lib/libc.so.6
        /usr/lib64/ld-linux-x86-64.so.2
        libpmem.so.1 => ../../../debug/libpmem.so.1
        libdl.so.2 => /usr/lib/libdl.so.2

$ ldd libhashmap_tx.so
        linux-vdso.so.1
        libpmemobj.so.1 => ../../../debug/libpmemobj.so.1
        libpthread.so.0 => /usr/lib/libpthread.so.0
        libc.so.6 => /usr/lib/libc.so.6
        /usr/lib64/ld-linux-x86-64.so.2
        libpmem.so.1 => ../../../debug/libpmem.so.1
        libdl.so.2 => /usr/lib/libdl.so.2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1825)
<!-- Reviewable:end -->
