### PR TITLE
obj: fix memleak in ctl after pmemobj_check

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1787,6 +1787,8 @@ pmemobj_checkU(const char *path, const char *layout)
 	if (consistent) {
 		obj_pool_cleanup(pop);
 	} else {
+		ctl_delete(pop->ctl);
+
 		/* unmap all the replicas */
 		obj_replicas_cleanup(pop->set);
 		util_poolset_close(pop->set, DO_NOT_DELETE_PARTS);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1829)
<!-- Reviewable:end -->
