### PR TITLE
pmempool: unified capital letters in info output

### DIFF
--- a/src/test/pmempool_info/out1.log.match
+++ b/src/test/pmempool_info/out1.log.match
@@ -22,7 +22,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : 0x2000
 Write offset             : 0x2000 [OK]
 End offset               : $(*)

--- a/src/test/pmempool_info/out16.log.match
+++ b/src/test/pmempool_info/out16.log.match
@@ -73,7 +73,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : $(*)
 Write offset             : $(*) [OK]
 End offset               : $(*)

--- a/src/test/pmempool_info/out16w.log.match
+++ b/src/test/pmempool_info/out16w.log.match
@@ -73,7 +73,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : $(*)
 Write offset             : $(*) [OK]
 End offset               : $(*)

--- a/src/test/pmempool_info/out4.log.match
+++ b/src/test/pmempool_info/out4.log.match
@@ -76,12 +76,12 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : $(*)
 Write offset             : $(*) [OK]
 End offset               : $(*)
 
-PMEM LOG statistics:
+PMEM LOG Statistics:
 Total                    : $(*)
 Available                : $(*) [100 %]
 Used                     : 0 [0 %]

--- a/src/test/pmempool_info/out5.log.match
+++ b/src/test/pmempool_info/out5.log.match
@@ -33,7 +33,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 00001000$(*)|$(*)|
 00001010$(*)|$(*)|
 00001020$(*)|$(*)|

--- a/src/test/pmempool_info/out5w.log.match
+++ b/src/test/pmempool_info/out5w.log.match
@@ -33,7 +33,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 00001000$(*)|$(*)|
 00001010$(*)|$(*)|
 00001020$(*)|$(*)|

--- a/src/test/pmempool_info/out6.log.match
+++ b/src/test/pmempool_info/out6.log.match
@@ -22,7 +22,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : $(*)
 Write offset             : $(*) [OK]
 End offset               : $(*)

--- a/src/test/pmempool_info/out7.log.match
+++ b/src/test/pmempool_info/out7.log.match
@@ -22,7 +22,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(*) [OK]
 
-PMEM LOG header:
+PMEM LOG Header:
 Start offset             : $(*)
 Write offset             : $(*) [OK]
 End offset               : $(*)

--- a/src/tools/pmempool/info_log.c
+++ b/src/tools/pmempool/info_log.c
@@ -122,7 +122,7 @@ info_log_stats(struct pmem_info *pip, int v, struct pmemlog *plp)
 	double perc_used = (double)size_used / (double)size_total * 100.0;
 	double perc_avail =  100.0 - perc_used;
 
-	outv_title(v, "PMEM LOG statistics");
+	outv_title(v, "PMEM LOG Statistics");
 	outv_field(v, "Total", "%s",
 			out_get_size_str(size_total, pip->args.human));
 	outv_field(v, "Available", "%s [%s]",
@@ -141,7 +141,7 @@ info_log_stats(struct pmem_info *pip, int v, struct pmemlog *plp)
 static int
 info_log_descriptor(struct pmem_info *pip, int v, struct pmemlog *plp)
 {
-	outv_title(v, "PMEM LOG header");
+	outv_title(v, "PMEM LOG Header");
 
 	/* dump pmemlog header without pool_hdr */
 	outv_hexdump(pip->args.vhdrdump, (uint8_t *)plp + sizeof(plp->hdr),


### PR DESCRIPTION
Unified naming in output of pmempool info command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1833)
<!-- Reviewable:end -->
