### PR TITLE
obj: implement primary lanes

### DIFF
--- a/src/libpmemobj/lane.h
+++ b/src/libpmemobj/lane.h
@@ -54,6 +54,13 @@
  */
 #define LANE_JUMP (64 / sizeof(uint64_t))
 
+/*
+ * Number of times the algorithm will try to reacquire the primary lane for the
+ * thread. If this threshold is exceeded, a new primary lane is selected for the
+ * thread.
+ */
+#define LANE_PRIMARY_ATTEMPTS 128
+
 #define RLANE_DEFAULT 0
 
 enum lane_section_type {
@@ -115,6 +122,15 @@ struct lane_info {
 	uint64_t pop_uuid_lo;
 	uint64_t lane_idx;
 	unsigned long nest_count;
+
+	/*
+	 * The index of the primary lane for the thread. A thread will always
+	 * try to acquire the primary lane first, and only if that fails it will
+	 * look for a different available lane.
+	 */
+	uint64_t primary;
+	int primary_attempts;
+
 	struct lane_info *prev, *next;
 };
 


### PR DESCRIPTION
This patch introduces an optimization that makes false sharing of
lanes less likely. It does so by assigning threads a *primary*
lane which is always picked as the first candidate for acqurining.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1850)
<!-- Reviewable:end -->
