### PR TITLE
common: (win) fix mapping alignment

### DIFF
--- a/src/common/mmap.c
+++ b/src/common/mmap.c
@@ -142,11 +142,14 @@ util_map(int fd, size_t len, int flags, int rdonly, size_t req_align)
 			rdonly, req_align);
 
 	void *base;
-	void *addr = util_map_hint(len, req_align);
+	void *addr = util_map_hint(fd, len, req_align);
 	if (addr == MAP_FAILED) {
 		ERR("cannot find a contiguous region of given size");
 		return NULL;
 	}
+
+	if (req_align)
+		ASSERTeq((uintptr_t)addr % req_align, 0);
 
 	if ((base = mmap(addr, len, rdonly ? PROT_READ : PROT_READ|PROT_WRITE,
 			flags, fd, 0)) == MAP_FAILED) {

--- a/src/common/mmap.h
+++ b/src/common/mmap.h
@@ -85,8 +85,8 @@ int util_range_ro(void *addr, size_t len);
 int util_range_rw(void *addr, size_t len);
 int util_range_none(void *addr, size_t len);
 
-char *util_map_hint_unused(void *addr, size_t len, size_t align);
-char *util_map_hint(size_t len, size_t req_align);
+char *util_map_hint_unused(void *minaddr, size_t len, size_t align);
+char *util_map_hint(int fd, size_t len, size_t req_align);
 
 #define MEGABYTE ((uintptr_t)1 << 20)
 #define GIGABYTE ((uintptr_t)1 << 30)

--- a/src/common/mmap_linux.c
+++ b/src/common/mmap_linux.c
@@ -141,9 +141,9 @@ util_map_hint_unused(void *minaddr, size_t len, size_t align)
  * address.
  */
 char *
-util_map_hint(size_t len, size_t req_align)
+util_map_hint(int fd, size_t len, size_t req_align)
 {
-	LOG(3, "len %zu req_align %zu", len, req_align);
+	LOG(3, "fd %d len %zu req_align %zu", fd, len, req_align);
 
 	char *hint_addr = MAP_FAILED;
 

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -1917,7 +1917,7 @@ util_replica_create_local(struct pool_set *set, unsigned repidx, int flags,
 		mapsize = rep->part[0].filesize & ~(Mmap_align - 1);
 
 		/* determine a hint address for mmap() */
-		addr = util_map_hint(rep->repsize, 0);
+		addr = util_map_hint(rep->part[0].fd, rep->repsize, 0);
 		if (addr == MAP_FAILED) {
 			ERR("cannot find a contiguous region of given size");
 			return -1;
@@ -2345,7 +2345,7 @@ util_replica_open_local(struct pool_set *set, unsigned repidx, int flags)
 		retry_for_contiguous_addr = 0;
 
 		/* determine a hint address for mmap() */
-		addr = util_map_hint(rep->repsize, 0);
+		addr = util_map_hint(rep->part[0].fd, rep->repsize, 0);
 		if (addr == MAP_FAILED) {
 			ERR("cannot find a contiguous region of given size");
 			return -1;

--- a/src/libvmem/vmem.c
+++ b/src/libvmem/vmem.c
@@ -163,14 +163,14 @@ vmem_createU(const char *dir, size_t size)
 
 	int is_dev_dax = util_file_is_device_dax(dir);
 
-	/* silently enforce multiple of page size */
-	size = roundup(size, Pagesize);
+	/* silently enforce multiple of mapping alignment */
+	size = roundup(size, Mmap_align);
 	void *addr;
 	if (is_dev_dax) {
 		if ((addr = util_file_map_whole(dir)) == NULL)
 			return NULL;
 	} else {
-		if ((addr = util_map_tmpfile(dir, size, 4 << 20)) == NULL)
+		if ((addr = util_map_tmpfile(dir, size, 4 * MEGABYTE)) == NULL)
 			return NULL;
 	}
 

--- a/src/test/util_map_proc/util_map_proc.c
+++ b/src/test/util_map_proc/util_map_proc.c
@@ -95,7 +95,7 @@ main(int argc, char *argv[])
 
 		void *h1 =
 			util_map_hint_unused((void *)TERABYTE, len, GIGABYTE);
-		void *h2 = util_map_hint(len, 0);
+		void *h2 = util_map_hint(-1, len, 0);
 		if (h1 != MAP_FAILED && h1 != NULL)
 			UT_ASSERTeq((uintptr_t)h1 & (GIGABYTE - 1), 0);
 		if (h2 != MAP_FAILED && h2 != NULL)


### PR DESCRIPTION
Adds support for user defined hint address (via PMEM_MMAP_HINT)
and for proper mapping address alignment on Windows.

Ref: pmem/issues#513

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1851)
<!-- Reviewable:end -->
