### PR TITLE
test: use different column in unicode_api

### DIFF
--- a/src/test/unicode_api/TEST0
+++ b/src/test/unicode_api/TEST0
@@ -52,6 +52,14 @@ HEADERS_DIR=$SRC/include
 INC_DIR=$SRC/include/libpmemobj
 EXC_PATT="set_funcs|strdup|rpmem|vmem_stats_print"
 FAILED=0
+DEF_COL=6
+
+function pick_col {
+	local ver=$(clang --version | grep version | sed "s/.*clang version \([0-9]*\)\.\([0-9]*\).*/\1*100+\2*10/" | bc)
+	if [ $ver -le 340 ]; then
+		DEF_COL=5
+	fi
+}
 
 function check_file {
 	local file=$1
@@ -59,7 +67,7 @@ function check_file {
 	local pat=$3
 
 	local funcs=$(clang -Xclang -ast-dump -I$HEADERS_DIR $file -fno-color-diagnostics 2> /dev/null |\
-		grep "FunctionDecl.*\(vmem\|pmem\).*char \*" | cut -d " " -f 6)
+		grep "FunctionDecl.*\(vmem\|pmem\).*char \*" | cut -d " " -f $DEF_COL)
 	for func in $funcs
 	do
 		local good=0
@@ -81,6 +89,8 @@ function check_file {
 }
 
 setup
+
+pick_col
 
 for f in $HEADERS_DIR/*.h
 do


### PR DESCRIPTION
Use a different column for the function name for older clang
versions.

Refs: pmem/issues#524

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1857)
<!-- Reviewable:end -->
