### PR TITLE
obj: reorder workloads in obj_pmalloc_mt

### DIFF
--- a/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
+++ b/src/test/obj_pmalloc_mt/obj_pmalloc_mt.c
@@ -207,8 +207,13 @@ main(int argc, char *argv[])
 	run_worker(realloc_worker, args);
 	run_worker(free_worker, args);
 	run_worker(mix_worker, args);
-	run_worker(tx_worker, args);
 	run_worker(alloc_free_worker, args);
+
+	/*
+	 * This workload might create many allocation classes due to pvector,
+	 * keep it last.
+	 */
+	run_worker(tx_worker, args);
 
 	pmemobj_close(pop);
 


### PR DESCRIPTION
The test was not deterministic because depending on the performance of
allocations in a transaction, various different undo log alloc vectors
might have been allocated, which in turn triggered creation of buckets.

Ref: pmem/issues#523

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1858)
<!-- Reviewable:end -->
