### PR TITLE
common: fix failing localtime under docker

### DIFF
--- a/src/common/util.c
+++ b/src/common/util.c
@@ -40,6 +40,7 @@
 #include <unistd.h>
 #include <endian.h>
 #include <errno.h>
+#include <time.h>
 
 #include "util.h"
 #include "valgrind_internal.h"
@@ -268,4 +269,21 @@ util_concat_str(const char *s1, const char *s2)
 	strcat(result, s2);
 
 	return result;
+}
+
+/*
+ * util_localtime -- a wrapper for localtime function
+ *
+ * localtime can set nonzero errno even if it succeeds (e.g. when there is no
+ * /etc/localtime file under Linux) and we do not want the errno to be polluted
+ * in such cases.
+ */
+struct tm *
+util_localtime(const time_t *timep)
+{
+	int oerrno = errno;
+	struct tm *tm = localtime(timep);
+	if (!tm)
+		errno = oerrno;
+	return tm;
 }

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -88,6 +88,7 @@ char *util_part_realpath(const char *path);
 int util_compare_file_inodes(const char *path1, const char *path2);
 void *util_aligned_malloc(size_t alignment, size_t size);
 void util_aligned_free(void *ptr);
+struct tm *util_localtime(const time_t *timep);
 
 #ifdef _WIN32
 char *util_toUTF8(const wchar_t *wstr);

--- a/src/libpmempool/check_util.c
+++ b/src/libpmempool/check_util.c
@@ -654,7 +654,7 @@ const char *
 check_get_time_str(time_t time)
 {
 	static char str_buff[STR_MAX] = {0, };
-	struct tm *tm = localtime(&time);
+	struct tm *tm = util_localtime(&time);
 
 	if (tm)
 		strftime(str_buff, STR_MAX, TIME_STR_FMT, tm);

--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -50,23 +50,21 @@ POOL_P2=$DIR/pool.p2
 LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
-# XXX - this scenario is temporarily disabled due to unstable behavior
+create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
+expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 
-#create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
-#expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
+TIME=$(date +"%s")
+let "FUTURE_TIME=$TIME+60*60"
+let "PAST_TIME=$TIME-60*60"
+PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
+$PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
+touch -mt $PAST_TIME $POOL_P1
 
-#TIME=$(date +"%s")
-#let "FUTURE_TIME=$TIME+60*60"
-#let "PAST_TIME=$TIME-60*60"
-#PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
-#$PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
-#touch -mt $PAST_TIME $POOL_P1
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -vrya $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
-#expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
-#expect_abnormal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG
-#expect_normal_exit $PMEMPOOL$EXESUFFIX check -vrya $POOLSET >> $LOG
-#expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
-
-#check
+check
 
 pass

--- a/src/test/pmempool_check/TEST16.PS1
+++ b/src/test/pmempool_check/TEST16.PS1
@@ -55,26 +55,24 @@ $POOL_P2="$DIR\pool.p2"
 $LOG="out$Env:UNITTEST_NUM.log"
 rm $LOG -Force -ea si
 
-# XXX - this scenario is temporarily disabled due to unstable behavior
+create_poolset $POOLSET 20M:$POOL_P1 20M:$POOL_P2
 
-#create_poolset $POOLSET 20M:$POOL_P1 20M:$POOL_P2
+expect_normal_exit $PMEMPOOL create log $POOLSET
 
-#expect_normal_exit $PMEMPOOL create log $POOLSET
+[int]$FUTURE_TIME=[int64](([datetime]::UtcNow)-(Get-Date "1/1/1970")).TotalSeconds
+$FUTURE_TIME+=60*60
+&$PMEMSPOIL -v $POOL_P1 "pool_hdr.crtime=$FUTURE_TIME" >> $LOG
 
-#[int]$FUTURE_TIME=[int64](([datetime]::UtcNow)-(Get-Date "1/1/1970")).TotalSeconds
-#$FUTURE_TIME+=60*60
-#&$PMEMSPOIL -v $POOL_P1 "pool_hdr.crtime=$FUTURE_TIME" >> $LOG
+[DateTime]$past=Get-Date
+$past=$past.AddHours(-1)
+$file=Get-Item $POOL_P1
+$file.LastWriteTime=$past
 
-#[DateTime]$past=Get-Date
-#$past=$past.AddHours(-1)
-#$file=Get-Item $POOL_P1
-#$file.LastWriteTime=$past
+expect_abnormal_exit $PMEMPOOL check -v $POOLSET >> $LOG
+expect_abnormal_exit $PMEMPOOL check -vry $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL check -vrya $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL info $POOLSET >> $null
 
-#expect_abnormal_exit $PMEMPOOL check -v $POOLSET >> $LOG
-#expect_abnormal_exit $PMEMPOOL check -vry $POOLSET >> $LOG
-#expect_normal_exit $PMEMPOOL check -vrya $POOLSET >> $LOG
-#expect_normal_exit $PMEMPOOL info $POOLSET >> $null
-
-#check
+check
 
 pass

--- a/src/tools/pmempool/output.c
+++ b/src/tools/pmempool/output.c
@@ -374,7 +374,7 @@ const char *
 out_get_time_str(time_t time)
 {
 	static char str_buff[STR_MAX] = {0, };
-	struct tm *tm = localtime(&time);
+	struct tm *tm = util_localtime(&time);
 
 	if (tm) {
 		strftime(str_buff, STR_MAX, TIME_STR_FMT, tm);

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -110,5 +110,6 @@ sudo docker run --rm --privileged=true --name=$containerName -ti \
 	--env TRAVIS_BRANCH=$TRAVIS_BRANCH \
 	--env TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE \
 	-v $HOST_WORKDIR:$WORKDIR \
+	-v /etc/localtime:/etc/localtime \
 	-w $SCRIPTSDIR \
 	$imageName $command


### PR DESCRIPTION
/etc/localtime file is not present inside a Docker image with Ubuntu
16.04. Without this file a call to localtime(3) sets errno to 2.

This also reenables the test pmempool_check/TEST16.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1866)
<!-- Reviewable:end -->
