### PR TITLE
examples: fix misaligned memory access

### DIFF
--- a/src/examples/libpmemlog/logfile/printlog.c
+++ b/src/examples/libpmemlog/logfile/printlog.c
@@ -69,8 +69,8 @@ printlog(const void *buf, size_t len, void *arg)
 		printf("       Created: %s", ctime(&headerp->timestamp));
 		printf("      Contents:\n");
 
-		/* print the log data itself */
-		fwrite(buf, headerp->len, 1, stdout);
+		/* print the log data itself, it is NUL-terminated */
+		printf("%s", (char *)buf);
 		buf = (char *)buf + headerp->len;
 	}
 


### PR DESCRIPTION
This patch makes headers aligned to sizeof(long) bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1872)
<!-- Reviewable:end -->
