### PR TITLE
common: add checking printf-like formats

### DIFF
--- a/src/common/out.c
+++ b/src/common/out.c
@@ -359,7 +359,7 @@ out_set_vsnprintf_func(int (*vsnprintf_func)(char *str, size_t size,
 /*
  * out_snprintf -- (internal) custom snprintf implementation
  */
-__attribute__((format(printf, 3, 4)))
+FORMAT_PRINTF(3, 4)
 static int
 out_snprintf(char *str, size_t size, const char *format, ...)
 {

--- a/src/common/out.h
+++ b/src/common/out.h
@@ -189,18 +189,14 @@ void out_init(const char *log_prefix, const char *log_level_var,
 		const char *log_file_var, int major_version,
 		int minor_version);
 void out_fini(void);
-void out(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void out_nonl(int level, const char *fmt,
-	...) __attribute__((format(printf, 2, 3)));
+void out(const char *fmt, ...) FORMAT_PRINTF(1, 2);
+void out_nonl(int level, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 void out_log(const char *file, int line, const char *func, int level,
-	const char *fmt, ...)
-	__attribute__((format(printf, 5, 6)));
+	const char *fmt, ...) FORMAT_PRINTF(5, 6);
 void out_err(const char *file, int line, const char *func,
-	const char *fmt, ...)
-	__attribute__((format(printf, 4, 5)));
+	const char *fmt, ...) FORMAT_PRINTF(4, 5);
 void out_fatal(const char *file, int line, const char *func,
-	const char *fmt, ...)
-	__attribute__((format(printf, 4, 5)))
+	const char *fmt, ...) FORMAT_PRINTF(4, 5)
 	__attribute__((noreturn));
 void out_set_print_func(void (*print_func)(const char *s));
 void out_set_vsnprintf_func(int (*vsnprintf_func)(char *str, size_t size,

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -64,6 +64,7 @@ extern unsigned long long Mmap_align;
 #define ADDR_SUM(vp, lp) ((void *)((char *)(vp) + lp))
 
 #define util_alignof(t) offsetof(struct {char _util_c; t _util_m; }, _util_m)
+#define FORMAT_PRINTF(a, b) __attribute__((__format__(__printf__, (a), (b))))
 
 /*
  * overridable names for malloc & friends used by this library

--- a/src/libpmempool/check_btt_map_flog.c
+++ b/src/libpmempool/check_btt_map_flog.c
@@ -252,7 +252,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->bitmap) {
 		ERR("!calloc");
 		CHECK_ERR(ppc, "arena %u: cannot allocate memory for blocks "
-			"bitmap");
+			"bitmap", arenap->id);
 		goto error;
 	}
 
@@ -260,7 +260,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->dup_bitmap) {
 		ERR("!calloc");
 		CHECK_ERR(ppc, "arena %u: cannot allocate memory for "
-			"duplicated blocks bitmap");
+			"duplicated blocks bitmap", arenap->id);
 		goto error;
 	}
 
@@ -268,7 +268,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->fbitmap) {
 		ERR("!calloc");
 		CHECK_ERR(ppc, "arena %u: cannot allocate memory for BTT Flog "
-			"bitmap");
+			"bitmap", arenap->id);
 		goto error;
 	}
 
@@ -277,7 +277,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->list_inval) {
 		CHECK_ERR(ppc,
 			"arena %u: cannot allocate memory for invalid BTT map "
-			"entries list");
+			"entries list", arenap->id);
 		goto error;
 	}
 
@@ -286,7 +286,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->list_flog_inval) {
 		CHECK_ERR(ppc,
 			"arena %u: cannot allocate memory for invalid BTT Flog "
-			"entries list");
+			"entries list", arenap->id);
 		goto error;
 	}
 
@@ -295,7 +295,7 @@ init(PMEMpoolcheck *ppc, location *loc)
 	if (!loc->list_unmap) {
 		CHECK_ERR(ppc,
 			"arena %u: cannot allocate memory for unmaped blocks "
-			"list");
+			"list", arenap->id);
 		goto error;
 	}
 
@@ -538,7 +538,8 @@ arena_map_flog_check(PMEMpoolcheck *ppc, location *loc)
 	return check_questions_sequence_validate(ppc);
 
 error_push:
-	CHECK_ERR(ppc, "arena %u: cannot allocate momory for list item");
+	CHECK_ERR(ppc, "arena %u: cannot allocate momory for list item",
+			arenap->id);
 	ppc->result = CHECK_RESULT_ERROR;
 cleanup:
 	cleanup(ppc, loc);

--- a/src/libpmempool/check_log_blk.c
+++ b/src/libpmempool/check_log_blk.c
@@ -281,7 +281,7 @@ blk_hdr_check(PMEMpoolcheck *ppc, location *loc)
 		if (ppc->pool->hdr.blk.bsize != btt_bsize) {
 			CHECK_ASK(ppc, Q_BLK_BSIZE,
 				"invalid pmemblk.bsize.|Do you want to set "
-				"pmemblk.bsize to %lu from BTT Info?",
+				"pmemblk.bsize to %u from BTT Info?",
 				btt_bsize);
 		}
 	} else if (!ppc->pool->bttc.zeroed) {

--- a/src/libpmempool/check_pool_hdr.c
+++ b/src/libpmempool/check_pool_hdr.c
@@ -347,6 +347,7 @@ pool_hdr_nondefault_fix(PMEMpoolcheck *ppc, location *loc, uint32_t question,
 	LOG(3, NULL);
 
 	ASSERTne(loc, NULL);
+	uint64_t *flags = NULL;
 
 	switch (question) {
 	case Q_CRTIME:
@@ -358,8 +359,9 @@ pool_hdr_nondefault_fix(PMEMpoolcheck *ppc, location *loc, uint32_t question,
 		util_convert2le_hdr(&loc->hdr);
 		break;
 	case Q_ARCH_FLAGS:
-		CHECK_INFO(ppc, "%ssetting pool_hdr.arch_flags to 0x%x",
-			loc->prefix, loc->valid_part_hdrp->arch_flags);
+		flags = (uint64_t *)&loc->valid_part_hdrp->arch_flags;
+		CHECK_INFO(ppc, "%ssetting pool_hdr.arch_flags to 0x%08" PRIx64
+				"%08" PRIx64, loc->prefix, flags[0], flags[1]);
 		util_convert2h_hdr_nocheck(&loc->hdr);
 		memcpy(&loc->hdr.arch_flags, &loc->valid_part_hdrp->arch_flags,
 			sizeof(struct arch_flags));

--- a/src/libpmempool/check_util.h
+++ b/src/libpmempool/check_util.h
@@ -143,7 +143,7 @@ void check_end(struct check_data *data);
 int check_is_end_util(struct check_data *data);
 
 int check_status_create(PMEMpoolcheck *ppc, enum pmempool_check_msg_type type,
-	uint32_t question, const char *fmt, ...);
+		uint32_t question, const char *fmt, ...) FORMAT_PRINTF(4, 5);
 void check_status_release(PMEMpoolcheck *ppc, struct check_status *status);
 void check_clear_status_cache(struct check_data *data);
 struct check_status *check_pop_question(struct check_data *data);

--- a/src/test/pmempool_info/out12.log.match
+++ b/src/test/pmempool_info/out12.log.match
@@ -40,7 +40,7 @@ Chunk size               : $(*)
 Chunks per zone          : $(*)
 Checksum                 : $(*) [OK]
 
-Zone:
+Zone 0:
 Magic                    : $(*) [OK]
 Size idx                 : $(*)
  
@@ -97,7 +97,7 @@ Heap:
 Number of zones          : 1
 Number of used zones     : 1 [100 %]
 
- Zone:
+ Zone 0:
  Number of chunks         : $(*)
   free                     : $(*)
   used                     : $(*)

--- a/src/test/pmempool_info/out13.log.match
+++ b/src/test/pmempool_info/out13.log.match
@@ -40,7 +40,7 @@ Chunk size               : $(*)
 Chunks per zone          : $(*)
 Checksum                 : $(*) [OK]
 
-Zone:
+Zone 0:
 Magic                    : $(*) [OK]
 Size idx                 : $(*)
  
@@ -73,7 +73,7 @@ Heap:
 Number of zones          : 1
 Number of used zones     : 1 [100 %]
 
- Zone:
+ Zone 0:
  Number of chunks         : 1
   used                     : 1 [100 %]
 

--- a/src/test/pmempool_info/out14.log.match
+++ b/src/test/pmempool_info/out14.log.match
@@ -31,7 +31,7 @@ Heap size                : $(*)
 Checksum                 : $(*) [OK]
 Root offset              : $(*)
 
-Lane:
+Lane 0:
 
  Lane section             : allocator
   Redo log entries         : 10
@@ -156,7 +156,7 @@ Heap size                : $(*)
 Checksum                 : $(*) [OK]
 Root offset              : $(*)
 
-Lane:
+Lane 0:
 
  Lane section             : tx
   State                    : none
@@ -204,7 +204,7 @@ Heap size                : $(*)
 Checksum                 : $(*) [OK]
 Root offset              : $(*)
 
-Lane:
+Lane 0:
 
  Lane section             : tx
   State                    : none
@@ -252,7 +252,7 @@ Heap size                : $(*)
 Checksum                 : $(*) [OK]
 Root offset              : $(*)
 
-Lane:
+Lane 0:
 
  Lane section             : tx
   State                    : none

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -1339,7 +1339,7 @@ main(int argc, char *argv[])
 		err(1, "%s", psp->fname);
 
 	if (pool_set_file_set_replica(psp->pfile, psp->replica)) {
-		outv_err("invalid replica argument max is %lu\n",
+		outv_err("invalid replica argument max is %u\n",
 				psp->pfile->poolset ?
 				psp->pfile->poolset->nreplicas :
 				0);

--- a/src/tools/pmempool/check.c
+++ b/src/tools/pmempool/check.c
@@ -219,7 +219,7 @@ static check_result_t pmempool_check_2_check_res_t[] =
 static char *
 check_ask(const char *msg)
 {
-	char answer = ask_Yn('?', msg);
+	char answer = ask_Yn('?', "%s", msg);
 
 	switch (answer) {
 	case 'y':

--- a/src/tools/pmempool/common.h
+++ b/src/tools/pmempool/common.h
@@ -113,6 +113,8 @@
 /* invalid answer for ask_* functions */
 #define INV_ANS	'\0'
 
+#define FORMAT_PRINTF(a, b) __attribute__((__format__(__printf__, (a), (b))))
+
 /*
  * pmem_pool_type_t -- pool types
  */
@@ -219,8 +221,8 @@ int util_parse_chunk_types(const char *str, uint64_t *types);
 int util_parse_lane_sections(const char *str, uint64_t *types);
 char ask(char op, char *answers, char def_ans, const char *fmt, va_list ap);
 char ask_yn(char op, char def_ans, const char *fmt, va_list ap);
-char ask_Yn(char op, const char *fmt, ...);
-char ask_yN(char op, const char *fmt, ...);
+char ask_Yn(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
+char ask_yN(char op, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 unsigned util_heap_max_zone(size_t size);
 int util_heap_get_bitmap_params(uint64_t block_size, uint64_t *nallocsp,
 		uint64_t *nvalsp, uint64_t *last_valp);

--- a/src/tools/pmempool/create.c
+++ b/src/tools/pmempool/create.c
@@ -207,7 +207,7 @@ pmempool_create_blk(struct pmempool_create *pcp)
 	}
 
 	if (pcp->write_btt_layout) {
-		outv(1, "Writing BTT layout using block %lu.\n",
+		outv(1, "Writing BTT layout using block %d.\n",
 				pcp->write_btt_layout);
 
 		if (pmemblk_set_error(pbp, 0) || pmemblk_set_zero(pbp, 0)) {
@@ -512,7 +512,7 @@ pmempool_create_func(char *appname, int argc, char *argv[])
 
 	if (pc.layout && strlen(pc.layout) >= PMEMOBJ_MAX_LAYOUT) {
 		outv_err("Layout name is to long, maximum number of characters"
-			" (including the terminating null byte) is %d\n",
+			" (including the terminating null byte) is %zu\n",
 			PMEMOBJ_MAX_LAYOUT);
 		return -1;
 	}

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -705,15 +705,15 @@ pmempool_info_pool_hdr(struct pmem_info *pip, int v)
 		uint64_t a = GET_ALIGNMENT(ad, i);
 		if (ad == cur_ad) {
 			outv_field(v + 1, alignment_desc_str[i],
-					"%2d", a);
+					"%2lu", a);
 		} else {
 			uint64_t av = GET_ALIGNMENT(cur_ad, i);
 			if (a == av) {
 				outv_field(v + 1, alignment_desc_str[i],
-					"%2d [OK]", a);
+					"%2lu [OK]", a);
 			} else {
 				outv_field(v + 1, alignment_desc_str[i],
-					"%2d [wrong! should be %2d]", a, av);
+					"%2lu [wrong! should be %2lu]", a, av);
 			}
 		}
 	}

--- a/src/tools/pmempool/info_blk.c
+++ b/src/tools/pmempool/info_blk.c
@@ -169,7 +169,7 @@ info_btt_data(struct pmem_info *pip, int v, struct btt_info *infop,
 
 			if (pmempool_info_read(pip, block_buff,
 					infop->external_lbasize, block_off)) {
-				outv_err("cannot read %d block\n", i);
+				outv_err("cannot read %lu block\n", i);
 				ret = -1;
 				goto error;
 			}
@@ -181,7 +181,7 @@ info_btt_data(struct pmem_info *pip, int v, struct btt_info *infop,
 			 * Print block number, offset and flags
 			 * from map entry.
 			 */
-			outv(v, "Block %10d: offset: %s\n",
+			outv(v, "Block %10lu: offset: %s\n",
 				offset + i,
 				out_get_btt_map_entry(map_entry));
 
@@ -258,7 +258,7 @@ info_btt_map(struct pmem_info *pip, int v,
 				arena_count++;
 				(*count)++;
 
-				outv(v, "%010d: %s\n", offset + i,
+				outv(v, "%010lu: %s\n", offset + i,
 					out_get_btt_map_entry(entry));
 			}
 		}

--- a/src/tools/pmempool/info_log.c
+++ b/src/tools/pmempool/info_log.c
@@ -93,7 +93,7 @@ info_log_data(struct pmem_info *pip, int v, struct pmemlog *plp)
 			uint64_t i;
 			for (i = curp->first; i <= curp->last &&
 					i < nchunks; i++) {
-				outv(v, "Chunk %10u:\n", i);
+				outv(v, "Chunk %10lu:\n", i);
 				outv_hexdump(v, addr + i * pip->args.log.walk,
 					pip->args.log.walk,
 					plp->start_offset +

--- a/src/tools/pmempool/output.h
+++ b/src/tools/pmempool/output.h
@@ -42,16 +42,17 @@ void out_set_vlevel(int vlevel);
 void out_set_stream(FILE *stream);
 void out_set_prefix(const char *prefix);
 void out_set_col_width(unsigned col_width);
-void outv_err(const char *fmt, ...);
+void outv_err(const char *fmt, ...) FORMAT_PRINTF(1, 2);
 void out_err(const char *file, int line, const char *func,
-		const char *fmt, ...);
+		const char *fmt, ...) FORMAT_PRINTF(4, 5);
 void outv_err_vargs(const char *fmt, va_list ap);
 void outv_indent(int vlevel, int i);
-void outv(int vlevel, const char *fmt, ...);
+void outv(int vlevel, const char *fmt, ...) FORMAT_PRINTF(2, 3);
 void outv_nl(int vlevel);
 int outv_check(int vlevel);
-void outv_title(int vlevel, const char *fmt, ...);
-void outv_field(int vlevel, const char *field, const char *fmt, ...);
+void outv_title(int vlevel, const char *fmt, ...) FORMAT_PRINTF(2, 3);
+void outv_field(int vlevel, const char *field, const char *fmt,
+		...) FORMAT_PRINTF(3, 4);
 void outv_hexdump(int vlevel, const void *addr, size_t len, size_t offset,
 		int sep);
 const char *out_get_uuid_str(uuid_t uuid);

--- a/utils/cstyle
+++ b/utils/cstyle
@@ -620,6 +620,8 @@ line: while (<$filehandle>) {
 		s/\w\s\(+\*/XXX(*/g;
 		s/\b($typename|void)\s+\(+/XXX(/og;
 		s/\btypedef\s($typename|void)\s+\(+/XXX(/og;
+		# do not match "__attribute__ ((format (...)))"
+		s/\b__attribute__\s*\(\(format\s*\(/__attribute__((XXX(/g;
 		if (/\w\s\(/) {
 			err("extra space between function name and left paren");
 		}


### PR DESCRIPTION
Adding "format" attribute to functions which accept printf-like format arguments enforces verifying format specifiers in compile time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1880)
<!-- Reviewable:end -->
