### PR TITLE
obj: fix valgrind instrumentation for lane reuse

### DIFF
--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -454,7 +454,13 @@ lane_hold(PMEMobjpool *pop, struct lane_section **section,
 
 	if (section) {
 		ASSERT(type < MAX_LANE_SECTION);
-		*section = &pop->lanes_desc.lane[lane->lane_idx].sections[type];
+		struct lane_section *s =
+			&pop->lanes_desc.lane[lane->lane_idx].sections[type];
+
+		VALGRIND_ANNOTATE_NEW_MEMORY(s, sizeof(*s));
+		VALGRIND_ANNOTATE_NEW_MEMORY(s->layout, sizeof(*s->layout));
+
+		*section = s;
 	}
 
 	return (unsigned)lane->lane_idx;

--- a/src/libpmemobj/pvector.c
+++ b/src/libpmemobj/pvector.c
@@ -124,6 +124,15 @@ pvector_delete(struct pvector_context *ctx)
 }
 
 /*
+ * pvector_reinit -- reinitializes the pvector runtime data
+ */
+void
+pvector_reinit(struct pvector_context *vec)
+{
+	VALGRIND_ANNOTATE_NEW_MEMORY(vec, sizeof(*vec));
+}
+
+/*
  * find_highest_bit -- (internal) searches for the highest set bit
  */
 static unsigned

--- a/src/libpmemobj/pvector.h
+++ b/src/libpmemobj/pvector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,6 +77,7 @@ struct pvector {
 typedef void (*entry_op_callback)(PMEMobjpool *pop, uint64_t *entry);
 
 struct pvector_context *pvector_new(PMEMobjpool *pop, struct pvector *vec);
+void pvector_reinit(struct pvector_context *vec);
 void pvector_delete(struct pvector_context *ctx);
 
 uint64_t *pvector_push_back(struct pvector_context *ctx);

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -725,6 +725,8 @@ tx_rebuild_undo_runtime(PMEMobjpool *pop, struct lane_tx_layout *layout,
 	for (i = UNDO_ALLOC; i < MAX_UNDO_TYPES; ++i) {
 		if (tx_rt->ctx[i] == NULL)
 			tx_rt->ctx[i] = pvector_new(pop, &layout->undo_log[i]);
+		else
+			pvector_reinit(tx_rt->ctx[i]);
 
 		if (tx_rt->ctx[i] == NULL)
 			goto error_init;
@@ -1145,6 +1147,8 @@ pmemobj_tx_begin(PMEMobjpool *pop, jmp_buf env, ...)
 		lane_hold(pop, &tx->section, LANE_SECTION_TRANSACTION);
 
 		lane = tx->section->runtime;
+		VALGRIND_ANNOTATE_NEW_MEMORY(lane, sizeof(*lane));
+
 		SLIST_INIT(&lane->tx_entries);
 		SLIST_INIT(&lane->tx_locks);
 		lane->ranges = ctree_new();


### PR DESCRIPTION
Currently all applications ran under helgrind/drd that had two or more threads
use the same lane would report possible races due to reuse of memory.
This patch adds relevant instrumentation that marks all possible lane resources
as new when acquiring a lane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1881)
<!-- Reviewable:end -->
