### PR TITLE
common: work around Travis bug

### DIFF
--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -72,6 +72,14 @@ if [[ -z "$HOST_WORKDIR" ]]; then
 	exit 1
 fi
 
+# TRAVIS_COMMIT_RANGE is usually invalid for force pushes - ignore such values
+# when used with non-upstream repository
+if [ -n "$TRAVIS_COMMIT_RANGE" -a $TRAVIS_REPO_SLUG != "pmem/nvml" ]; then
+	if ! git rev-list $TRAVIS_COMMIT_RANGE; then
+		TRAVIS_COMMIT_RANGE=
+	fi
+fi
+
 # Find all the commits for the current build
 if [[ -n "$TRAVIS_COMMIT_RANGE" ]]; then
 	commits=$(git rev-list $TRAVIS_COMMIT_RANGE)


### PR DESCRIPTION
TRAVIS_COMMIT_RANGE usually contains invalid range when developer
uses git push -f to his own repository.

Travis build failures caused by push -f are much more frequent
then Dockerfile modifications.

Work around this problem by ignoring invalid TRAVIS_COMMIT_RANGE
values and relying on TRAVIS_COMMIT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1888)
<!-- Reviewable:end -->
