### PR TITLE
rpmem: clarify pool and part file sizes

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -444,8 +444,9 @@ check when **pmemobj_open**() is called. The layout name, including the terminat
 use when creating the file as described by **creat**(2). The memory pool file is fully allocated to the size *poolsize* using **posix_fallocate**(3). The
 caller may choose to take responsibility for creating the memory pool file by creating it before calling **pmemobj_create**() and then specifying *poolsize* as
 zero. In this case **pmemobj_create**() will take the pool size from the size of the existing file and will verify that the file appears to be empty by
-searching for any non-zero data in the pool header at the beginning of the file. The minimum file size allowed by the library for a transactional object store
-is defined in **\<libpmemobj.h\>** as **PMEMOBJ_MIN_POOL**.
+searching for any non-zero data in the pool header at the beginning of the file. The minimum file size allowed by the library for a local transactional object store
+is defined in **\<libpmemobj.h\>** as **PMEMOBJ_MIN_POOL**. For remote replicas the minimum file size is defined in
+**\<librpmem.h\>** as **RPMEM_MIN_PART**.
 
 ```c
 void pmemobj_close(PMEMobjpool *pop);

--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -132,7 +132,7 @@ argument. Both *pool_addr* and *pool_size* must be aligned to system's page
 size (see **sysconf**(3)). The size of the remote pool must be at least
 *pool_size*. See **REMOTE POOL SIZE** section for details.
 The *nlanes* points to the maximum number of lanes which the caller requests to
-use. Upon successfully opening of the remote pool, the *nlanes* contains the
+use. Upon successful creation of the remote pool, the *nlanes* contains the
 maximum number of lanes supported by both local and remote nodes' hardware.
 See **LANES** section for details.
 The *create_attr* structure contains the attributes used for creating the
@@ -159,7 +159,7 @@ argument. Both *pool_addr* and *pool_size* must be aligned to system's page
 size (see **sysconf**(3)). The size of the remote pool must be at least
 *pool_size*. See **REMOTE POOL SIZE** section for details.
 The *nlanes* points to the maximum number of lanes which the caller requests to
-use. Upon successfully opening of the remote pool, the *nlanes* contains the
+use. Upon successful opening of the remote pool, the *nlanes* contains the
 maximum number of lanes supported by both local and remote nodes' hardware.
 See **LANES** section for details.
 If the *open_attr* argument is not NULL the remote pool attributes
@@ -350,12 +350,13 @@ any resources using **libibverbs**, otherwise **rpmem_open** and
 **rpmem_create** functions will return an error.
 
 # REMOTE POOL SIZE #
-The remote pool size depends on the configuration of pool set file on remote
+A remote pool size depends on the configuration of a pool set file on the remote
 node. The remote pool size is a sum of sizes of all part files decreased by 4096
 bytes per each part file. The 4096 bytes of each part file is utilized for
-storing internal metadata of the pool part files. The minimum size of the
-remote pool is 4096 bytes (not including required 4096 bytes per each part
-file).
+storing internal metadata of the pool part files. The minimum size of a part
+file for a remote pool is defined as **RPMEM_MIN_PART** in **\<librpmem.h\>**.
+The minimum size of a remote pool allowed by the library is defined as
+**RPMEM_MIN_POOL** therein.
 
 # LIBRARY API VERSIONING #
 

--- a/src/include/librpmem.h
+++ b/src/include/librpmem.h
@@ -104,6 +104,8 @@ const char *rpmem_errormsg(void);
 
 /* minimum size of a pool */
 #define RPMEM_MIN_POOL ((size_t)(1024 * 8)) /* 8 KB */
+/* minimum size of a part file */
+#define RPMEM_MIN_PART ((size_t)(1024 * 8)) /* 8 KB */
 
 #ifdef __cplusplus
 }

--- a/src/tools/rpmemd/rpmemd_db.c
+++ b/src/tools/rpmemd/rpmemd_db.c
@@ -222,7 +222,7 @@ rpmemd_db_pool_create(struct rpmemd_db *db, const char *pool_desc,
 	pattr.user_flags = attr->user_flags;
 
 	ret = util_pool_create_uuids(&set, path,
-					0, RPMEM_MIN_POOL,
+					0, RPMEM_MIN_PART,
 					attr->signature,
 					attr->major,
 					attr->compat_features,
@@ -295,7 +295,7 @@ rpmemd_db_pool_open(struct rpmemd_db *db, const char *pool_desc,
 		goto err_free_prp;
 	}
 
-	ret = util_pool_open_remote(&set, path, 0, RPMEM_MIN_POOL,
+	ret = util_pool_open_remote(&set, path, 0, RPMEM_MIN_PART,
 					attr->signature,
 					&attr->major,
 					&attr->compat_features,
@@ -421,7 +421,7 @@ rpmemd_db_pool_remove(struct rpmemd_db *db, const char *pool_desc,
 	} else {
 		struct rpmem_pool_attr attr;
 		ret = util_pool_open_remote(&set, path, 0,
-				RPMEM_MIN_POOL,
+				RPMEM_MIN_PART,
 				attr.signature,
 				&attr.major,
 				&attr.compat_features,


### PR DESCRIPTION
This patch clarifies what sizes are allowed for a pool and part files in librpmem.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1892)
<!-- Reviewable:end -->
