### PR TITLE
common: display test execution time

### DIFF
--- a/src/test/testconfig.ps1.example
+++ b/src/test/testconfig.ps1.example
@@ -59,7 +59,7 @@ $Env:NON_PMEM_FS_DIR = "\temp"
 #
 # To display execution time of each test
 #
-#$Env:TM = "1"
+$Env:TM = "1"
 
 #
 # 2) *** REMOTE CONFIGURATION ***

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -72,6 +72,11 @@ NON_PMEM_FS_DIR=/tmp
 #TEST_TIMEOUT=3m
 
 #
+# To display execution time of each test
+#
+TM=1
+
+#
 # 2) *** REMOTE CONFIGURATION ***
 #
 # The second part of the file tells the script unittest/unittest.sh

--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -41,6 +41,7 @@ NON_PMEM_FS_DIR=/tmp
 PMEM_FS_DIR=/tmp
 PMEM_FS_DIR_FORCE_PMEM=1
 TEST_BUILD="debug nondebug"
+TM=1
 EOF
 
 # Configure remote tests


### PR DESCRIPTION
Turns on printing test execution time for Travis builds and for example
test configurations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1902)
<!-- Reviewable:end -->
