### PR TITLE
common: device dax align from /sys is decimal

### DIFF
--- a/src/common/file_linux.c
+++ b/src/common/file_linux.c
@@ -213,8 +213,8 @@ device_dax_alignment(const char *path)
 	olderrno = errno;
 	errno = 0;
 
-	/* 'align' is in hex format w/o '0x' prefix */
-	size = strtoull(sizebuf, &endptr, 16);
+	/* 'align' is in decimal format */
+	size = strtoull(sizebuf, &endptr, 10);
 	if (endptr == sizebuf || *endptr != '\n' ||
 	    (size == ULLONG_MAX && errno == ERANGE)) {
 		ERR("invalid device alignment %s", sizebuf);


### PR DESCRIPTION
minor change to parse the align file in /sys as decimal instead of hex (the base was changed in more recent Linux kernels).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1906)
<!-- Reviewable:end -->
