### PR TITLE
benchmarks: add msync option to pmem_memset

### DIFF
--- a/src/benchmarks/pmembench_memset.cfg
+++ b/src/benchmarks/pmembench_memset.cfg
@@ -82,3 +82,15 @@ memset = true
 persist = false
 mem-mode = seq
 
+# memset benchmark with variable data sizes
+# from 64 to 8k bytes
+# mode sequential
+# memset followed by pmem_msync()
+[pmem_memset_libc_memset_persist]
+bench = pmem_memset
+threads = 1
+data-size = 64:*2:8192
+memset = true
+persist = false
+msync = true
+mem-mode = seq


### PR DESCRIPTION
Add option to sync data with pmem_msync after libc memset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1913)
<!-- Reviewable:end -->
