### PR TITLE
common: fix fetching Device DAX alignment

### DIFF
--- a/src/common/file_linux.c
+++ b/src/common/file_linux.c
@@ -222,6 +222,21 @@ device_dax_alignment(const char *path)
 		goto out;
 	}
 
+	/*
+	 * If the alignment value is not a power of two, try with
+	 * hex format, as this is how it was printed in older kernels.
+	 * Just in case someone is using kernel <4.9.
+	 */
+	if ((size & (size - 1)) != 0) {
+		size = strtoull(sizebuf, &endptr, 16);
+		if (endptr == sizebuf || *endptr != '\n' ||
+		    (size == ULLONG_MAX && errno == ERANGE)) {
+			ERR("invalid device alignment %s", sizebuf);
+			size = 0;
+			goto out;
+		}
+	}
+
 	errno = olderrno;
 
 out:


### PR DESCRIPTION
In older kernels (4.8.x) Device DAX alignment was printed
in hex format, so if the alignment value does not match any valid
number (4K, 2M or 1G) in decimal format, try to interpret it as hex
number.  This would make it work with both new and older kernels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1914)
<!-- Reviewable:end -->
