### PR TITLE
common: make docker-related shell scripts safer

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -35,6 +35,8 @@
 #            prepared for building NVML project.
 #
 
+set -o pipefail
+
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
 	&& "$COVERITY" -eq 1 ]]; then
 	echo "INFO: Skip Coverity scan job if build is triggered neither by " \

--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -35,6 +35,8 @@
 #                      and ssh server for use during build of NVML project.
 #
 
+set -o pipefail
+
 # Configure tests
 cat << EOF > $WORKDIR/src/test/testconfig.sh
 NON_PMEM_FS_DIR=/tmp

--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -39,6 +39,8 @@
 # The script can be run locally.
 #
 
+set -o pipefail
+
 function usage {
 	echo "Usage:"
 	echo "    build-image.sh <OS-VER>"

--- a/utils/docker/images/install-libcxx.sh
+++ b/utils/docker/images/install-libcxx.sh
@@ -34,6 +34,8 @@
 # install-libcxx.sh - installs a customized version of libcxx
 #
 
+set -o pipefail
+
 llvm_url=https://github.com/llvm-mirror/llvm.git
 libcxxabi_url=https://github.com/llvm-mirror/libcxxabi.git
 libcxx_url=https://github.com/pmem/libcxx.git

--- a/utils/docker/images/install-libfabric.sh
+++ b/utils/docker/images/install-libfabric.sh
@@ -34,6 +34,8 @@
 # install-libfabric.sh - installs a customized version of libfabric
 #
 
+set -o pipefail
+
 libfabric_ver=1.4.1
 libfabric_url=https://github.com/ofiwg/libfabric/archive
 libfabric_dir=libfabric-$libfabric_ver

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -34,6 +34,8 @@
 # install-valgrind.sh - installs valgrind for persistent memory
 #
 
+set -o pipefail
+
 git clone --recursive --depth 1 https://github.com/pmem/valgrind.git
 cd valgrind
 ./autogen.sh

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -39,6 +39,8 @@
 # for automated builds.
 #
 
+set -o pipefail
+
 function usage {
 	echo "Usage:"
 	echo "    push-image.sh <OS-VER>"

--- a/utils/docker/prepare-environment.sh
+++ b/utils/docker/prepare-environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@
 # prepare-environment.sh - installs Docker on the host environment and
 #                          pulls a Docker image for building NVML project.
 #
+
+set -o pipefail
 
 # Install the newest Docker engine
 sudo sh -c "echo deb https://apt.dockerproject.org/repo ubuntu-precise main >> /etc/apt/sources.list.d/docker.list"

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@
 #                        the environment inside a Docker container for
 #                        running build of NVML project.
 #
+
+set -o pipefail
 
 # Mount filesystem for tests
 echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=6G

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -47,6 +47,8 @@
 # Docker Hub.
 #
 
+set -o pipefail
+
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
 	&& "$COVERITY" -eq 1 ]]; then
 	echo "INFO: Skip Coverity scan job if build is triggered neither by " \

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,8 @@
 # run-build-package.sh - is called inside a Docker container; prepares
 #                        the environment and starts a build of NVML project.
 #
+
+set -o pipefail
 
 # Get and prepare nvml source
 ./prepare-for-build.sh

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -35,6 +35,8 @@
 #                and starts a build of NVML project.
 #
 
+set -o pipefail
+
 # Get and prepare NVML source
 ./prepare-for-build.sh
 

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -34,6 +34,8 @@
 # run-coverity.sh - runs the Coverity scan build
 #
 
+set -o pipefail
+
 # Download Coverity certificate
 echo -n | openssl s_client -connect scan.coverity.com:443 | \
 	sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | \


### PR DESCRIPTION
'set -o pipefail' makes script fail when any of &&-ed or ||-ed command fail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1919)
<!-- Reviewable:end -->
