### PR TITLE
common: fix silent build fails under docker

### DIFF
--- a/utils/docker/images/install-libfabric.sh
+++ b/utils/docker/images/install-libfabric.sh
@@ -40,11 +40,13 @@ libfabric_dir=libfabric-$libfabric_ver
 libfabric_tarball=v${libfabric_ver}.zip
 wget "${libfabric_url}/${libfabric_tarball}"
 unzip $libfabric_tarball
-cd $libfabric_dir \
-	&& ./autogen.sh \
-	&& ./configure --prefix=/usr --enable-sockets \
-	&& make -j2 \
-	&& make install
+
+cd $libfabric_dir
+./autogen.sh
+./configure --prefix=/usr --enable-sockets
+make -j2
+make install
+
 cd ..
 rm -f ${libfabric_tarball}
 rm -rf ${libfabric_dir}

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -43,10 +43,10 @@ export RPMEM_DISABLE_LIBIBVERBS=y
 
 # Build all and run tests
 cd $WORKDIR
-make check-license \
-	&& make cstyle \
-	&& make -j2 USE_LIBUNWIND=1 \
-	&& make -j2 test USE_LIBUNWIND=1 \
-	&& make -j2 pcheck TEST_BUILD=$TEST_BUILD \
-	&& make DESTDIR=/tmp source
+make check-license
+make cstyle
+make -j2 USE_LIBUNWIND=1
+make -j2 test USE_LIBUNWIND=1
+make -j2 pcheck TEST_BUILD=$TEST_BUILD
+make DESTDIR=/tmp source
 


### PR DESCRIPTION
Inappropriate use of '&&' inside a batch script (even with 'set -e' option) caused docker image build to happily succeed despite a failure of one of the &&-ed command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1920)
<!-- Reviewable:end -->
