### PR TITLE
vmmalloc: cfree removal (master)

### DIFF
--- a/src/test/vmmalloc_calloc/TEST0
+++ b/src/test/vmmalloc_calloc/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,8 +32,7 @@
 #
 
 #
-# src/test/vmmalloc_calloc/TEST0 -- unit test for
-# libvmmalloc calloc/cfree
+# src/test/vmmalloc_calloc/TEST0 -- unit test for libvmmalloc calloc
 #
 export UNITTEST_NAME=vmmalloc_calloc/TEST0
 export UNITTEST_NUM=0

--- a/src/test/vmmalloc_calloc/vmmalloc_calloc.c
+++ b/src/test/vmmalloc_calloc/vmmalloc_calloc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016, Intel Corporation
+ * Copyright 2014-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
  */
 
 /*
- * vmmalloc_calloc.c -- unit test for libvmmalloc calloc/cfree
+ * vmmalloc_calloc.c -- unit test for libvmmalloc calloc
  *
  * usage: vmmalloc_calloc
  */
@@ -42,6 +42,11 @@
 
 #define DEFAULT_COUNT	(SMALL_MAXCLASS / 4)
 #define DEFAULT_N	100
+
+/* cfree() has been removed from glibc since version 2.26 */
+#ifndef cfree
+#define cfree free
+#endif
 
 int
 main(int argc, char *argv[])


### PR DESCRIPTION
Makes cfree() an alias to free(), if cfree() is not exported by glibc.
The cfree() function has been removed from glibc since version 2.26.
This is why vmmalloc_calloc test compilation started to fail
on Fedora 27.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1923)
<!-- Reviewable:end -->
