### PR TITLE
common: fix pkg-config generation fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -134,7 +134,7 @@ new_pc="version=$(SRCVERSION) libdir=$(libdir) prefix=$(prefix)"
 update_pc=$(findstring $(old_pc), $(new_pc))
 
 pkg-cfg-common:
-	@$(if $(update_pc),, echo -e "version=$(SRCVERSION)\nlibdir=$(libdir)\nprefix=$(prefix)\n" > $(PKG_CONFIG_COMMON))
+	@$(if $(update_pc),, printf "version=%s\nlibdir=%s\nprefix=%s\n" "$(SRCVERSION)" "$(libdir)" "$(prefix)" > $(PKG_CONFIG_COMMON))
 
 $(PKG_CONFIG_COMMON): pkg-cfg-common
 


### PR DESCRIPTION
After previous fix all pc files started with
"-e version=1.2+b1-391-g5ba7c8d39".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1930)
<!-- Reviewable:end -->
