### PR TITLE
obj: refactor heap bucket retrieval

### DIFF
--- a/src/libpmemobj/heap.h
+++ b/src/libpmemobj/heap.h
@@ -62,16 +62,23 @@ int heap_check_remote(void *heap_start, uint64_t heap_size,
 		struct remote_ops *ops);
 int heap_buckets_init(struct palloc_heap *heap);
 
-struct bucket *heap_get_default_bucket(struct palloc_heap *heap);
 struct alloc_class *
 heap_get_best_class(struct palloc_heap *heap, size_t size);
+
 struct bucket *
-heap_get_bucket_by_class(struct palloc_heap *heap, struct alloc_class *c);
+heap_bucket_acquire(struct palloc_heap *heap, struct alloc_class *c);
+
+struct bucket *
+heap_bucket_acquire_by_id(struct palloc_heap *heap, uint8_t class_id);
+
+void
+heap_bucket_release(struct palloc_heap *heap, struct bucket *b);
 
 int heap_get_bestfit_block(struct palloc_heap *heap, struct bucket *b,
 	struct memory_block *m);
 struct memory_block
-heap_coalesce_huge(struct palloc_heap *heap, const struct memory_block *m);
+heap_coalesce_huge(struct palloc_heap *heap, struct bucket *b,
+	const struct memory_block *m);
 pthread_mutex_t *heap_get_run_lock(struct palloc_heap *heap,
 		uint32_t chunk_id);
 

--- a/src/test/obj_heap/obj_heap.c
+++ b/src/test/obj_heap/obj_heap.c
@@ -236,17 +236,19 @@ test_heap(void)
 		{0, 0, 1, 0}
 	};
 
-	struct bucket *b_def = heap_get_default_bucket(heap);
+	struct bucket *b_def = heap_bucket_acquire_by_id(heap,
+		DEFAULT_ALLOC_CLASS_ID);
 
 	for (int i = 0; i < MAX_BLOCKS; ++i) {
 		heap_get_bestfit_block(heap, b_def, &blocks[i]);
 		UT_ASSERT(blocks[i].block_off == 0);
 	}
+	heap_bucket_release(heap, b_def);
 
 	struct memory_block old_run = {0, 0, 1, 0};
 	struct memory_block new_run = {0, 0, 0, 0};
 	struct alloc_class *c_run = heap_get_best_class(heap, 1024);
-	struct bucket *b_run = heap_get_bucket_by_class(heap, c_run);
+	struct bucket *b_run = heap_bucket_acquire(heap, c_run);
 
 	/*
 	 * Allocate blocks from a run until one run is exhausted an another is
@@ -266,6 +268,8 @@ test_heap(void)
 
 	/* the old block should be unclaimed now */
 	UT_ASSERTeq(old_run.m_ops->claim(&old_run), 0);
+
+	heap_bucket_release(heap, b_run);
 
 	UT_ASSERT(heap_check(heap_start, heap_size) == 0);
 	heap_cleanup(heap);


### PR DESCRIPTION
This patch moves all bucket retrievals to the earliest possible place
in the code path which makes locking explicit for functions that
require access to memory block containers.

This is purely a refactor, there are no functional changes.

The changes are in preparation for a larger patch that overhauls
the way buckets are scheduled for threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1931)
<!-- Reviewable:end -->
