### PR TITLE
obj: fix huge allocations cancel

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -221,6 +221,9 @@ palloc_operation(struct palloc_heap *heap,
 				new_block = heap_coalesce_huge(
 					heap, &new_block);
 				bucket_insert_block(b, &new_block);
+				new_block.m_ops->prep_hdr(&new_block,
+					MEMBLOCK_FREE, ctx);
+				operation_process(ctx);
 			}
 
 			errno = ECANCELED;

--- a/src/test/obj_constructor/TEST2
+++ b/src/test/obj_constructor/TEST2
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ configure_valgrind memcheck force-disable
 
 setup
 
-create_holey_file 8M $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 expect_normal_exit\
     ./obj_constructor$EXESUFFIX $DIR/testfile1 --big-alloc

--- a/src/test/obj_constructor/obj_constructor.c
+++ b/src/test/obj_constructor/obj_constructor.c
@@ -191,6 +191,22 @@ main(int argc, char *argv[])
 	Canceled_ptr->bar = 5;
 	pmemobj_persist(pop, &Canceled_ptr->bar, sizeof(Canceled_ptr->bar));
 
+	/*
+	 * Allocate and cancel a huge object. It should return back to the
+	 * heap and it should be possible to allocate it again.
+	 */
+	Canceled_ptr = NULL;
+	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 21), 1,
+		vg_test_save_ptr, NULL);
+	UT_ASSERTne(Canceled_ptr, NULL);
+	void *first_ptr = Canceled_ptr;
+	Canceled_ptr = NULL;
+
+	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 21), 1,
+		vg_test_save_ptr, NULL);
+
+	UT_ASSERTeq(first_ptr, Canceled_ptr);
+
 	pmemobj_close(pop);
 
 	DONE(NULL);

--- a/src/test/obj_rpmem_constructor/TEST0
+++ b/src/test/obj_rpmem_constructor/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -75,16 +75,16 @@ rm_files_from_node 1 $TEST_FILE_LOCAL
 
 # XXX: Make sum of all parts and replicas sizes equal
 # create and upload poolset files
-create_poolset $DIR/$TEST_SET_LOCAL 8M:${NODE_DIRS[1]}/$TEST_FILE_LOCAL:x \
+create_poolset $DIR/$TEST_SET_LOCAL 16M:${NODE_DIRS[1]}/$TEST_FILE_LOCAL:x \
         m ${NODE_ADDR[0]}:$TEST_SET_REMOTE
-create_poolset $DIR/$TEST_SET_REMOTE 9M:${NODE_DIRS[0]}/$TEST_FILE_REMOTE:x
+create_poolset $DIR/$TEST_SET_REMOTE 17M:${NODE_DIRS[0]}/$TEST_FILE_REMOTE:x
 
 copy_files_to_node 0 . $DIR/$TEST_SET_REMOTE
 copy_files_to_node 1 . $DIR/$TEST_SET_LOCAL
 
 # create remote holey pool files
-create_holey_file_on_node 1 8M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
-create_holey_file_on_node 0 9M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
+create_holey_file_on_node 1 16M ${NODE_DIRS[1]}/$TEST_FILE_LOCAL
+create_holey_file_on_node 0 17M ${NODE_DIRS[0]}/$TEST_FILE_REMOTE
 
 # execute test
 # XXX: --big-alloc is required because remote replication on Travis is too slow


### PR DESCRIPTION
If a canceled huge allocation operated on split memory block,
that block didn't get properly coalesced in the persistent
state of the heap which could have lead to crashes when an
allocation of a similar block was attempted again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1934)
<!-- Reviewable:end -->
