### PR TITLE
common: use <sys/sysmacros.h> for major()/minor()

### DIFF
--- a/src/common/file_linux.c
+++ b/src/common/file_linux.c
@@ -40,6 +40,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <sys/sysmacros.h>
 
 #include "file.h"
 #include "os.h"


### PR DESCRIPTION
Use <sys/sysmacros.h> for makedev(), major() and minor() decls.
Otherwise, on latest Fedora (glibc 2.25+) compilation fails with
the following error:

"error: In the GNU C Library, "major" is defined by <sys/sysmacros.h>.
For historical compatibility, it is currently defined by <sys/types.h>
as well, but we plan to remove this soon. To use "major", include
<sys/sysmacros.h> directly. (...)"

Ref: pmem/issues#551

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1936)
<!-- Reviewable:end -->
