### PR TITLE
vmem: increase the pool size of mallctl tests

### DIFF
--- a/src/jemalloc/test/unit/mallctl.c
+++ b/src/jemalloc/test/unit/mallctl.c
@@ -507,9 +507,17 @@ TEST_BEGIN(test_stats_arenas)
 }
 TEST_END
 
+/*
+ * Each arena allocates 32 kilobytes of CTL metadata, and since we only
+ * have 12 megabytes, we have to hard-limit it to a known value, otherwise
+ * on systems with high CPU count, the tests might run out of memory.
+ */
+#define NARENAS_IN_POOL 64
+
 int
 main(void)
 {
+	opt_narenas = NARENAS_IN_POOL;
 
 	return (test(
 	    test_mallctl_errors,


### PR DESCRIPTION
The mallctl tests are currently failing on machines with large amount
of CPUs because there's not enough room for CTL arena statistics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1956)
<!-- Reviewable:end -->
