### PR TITLE
test: fix memleak in obj_ringbuf

### DIFF
--- a/src/test/obj_ringbuf/obj_ringbuf.c
+++ b/src/test/obj_ringbuf/obj_ringbuf.c
@@ -221,6 +221,8 @@ many_consumers_many_producers(int nconsumers, int nproducers, int msg_total)
 	UT_ASSERTeq(consumers_msg_sum, expected_sum);
 
 	ringbuf_delete(arg_proto.rbuf);
+	FREE(producer_args);
+	FREE(consumer_args);
 	FREE(msg_per_producer_sum);
 	FREE(consumers);
 	FREE(producers);


### PR DESCRIPTION
Ref: pmem/issues#557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1960)
<!-- Reviewable:end -->
