### PR TITLE
test: fix assumptions in obj_many_size_allocs

### DIFF
--- a/src/test/obj_many_size_allocs/obj_many_size_allocs.c
+++ b/src/test/obj_many_size_allocs/obj_many_size_allocs.c
@@ -91,7 +91,7 @@ test_allocs(PMEMobjpool *pop, const char *path)
 	return pop;
 }
 
-static void
+static PMEMobjpool *
 test_lazy_load(PMEMobjpool *pop, const char *path)
 {
 	PMEMoid oid[3];
@@ -110,6 +110,8 @@ test_lazy_load(PMEMobjpool *pop, const char *path)
 
 	ret = pmemobj_alloc(pop, &oid[1], LAZY_LOAD_BIG_SIZE, 0, NULL, NULL);
 	UT_ASSERTeq(ret, 0);
+
+	return pop;
 }
 
 #define ALLOC_BLOCK_SIZE 64
@@ -150,7 +152,7 @@ main(int argc, char *argv[])
 			0, S_IWUSR | S_IRUSR)) == NULL)
 		UT_FATAL("!pmemobj_create: %s", path);
 
-	test_lazy_load(pop, path);
+	pop = test_lazy_load(pop, path);
 	pop = test_allocs(pop, path);
 	test_all_classes(pop);
 


### PR DESCRIPTION
This test relied on sequence of open,close,open always returning the
same address in the second open as the first time - this is not always
true.

Ref: pmem/issues#563

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1962)
<!-- Reviewable:end -->
