### PR TITLE
obj: fix split snapshot being cut by 16 bytes

### DIFF
--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -1657,8 +1657,8 @@ pmemobj_tx_add_small(struct tx *tx, struct tx_add_range_args *args)
 		range_size = remaining_space;
 		data_size = remaining_space - sizeof(struct tx_range);
 
-		args->offset += range_size;
-		args->size -= range_size;
+		args->offset += data_size;
+		args->size -= data_size;
 	} else {
 		args->size = 0;
 	}
@@ -1680,9 +1680,8 @@ pmemobj_tx_add_small(struct tx *tx, struct tx_add_range_args *args)
 
 	VALGRIND_REMOVE_FROM_TX(range, range_size);
 
-	if (args->size != 0) {
-		pmemobj_tx_add_small(tx, args);
-	}
+	if (args->size != 0)
+		return pmemobj_tx_add_small(tx, args);
 
 	return 0;
 }

--- a/src/test/obj_tx_add_range_direct/pmemcheck1.log.match
+++ b/src/test/obj_tx_add_range_direct/pmemcheck1.log.match
@@ -46,6 +46,9 @@
 ==$(*)== Number of stores not made persistent: 0
 ==$(*)== ERROR SUMMARY: 0 errors
 ==$(*)== 
+==$(*)== Number of stores not made persistent: 0
+==$(*)== ERROR SUMMARY: 0 errors
+==$(*)== 
 ==$(*)== 
 ==$(*)== Number of stores not made persistent: 1
 ==$(*)== Stores not made persistent properly:


### PR DESCRIPTION
If there's not enough space in a tx cache, the snapshot is split into
two parts: one part is small enough to fit in the remaining space in the
cache, and the second one lands in a new cache.
There is a bug in this logic that results in the second part having
both offset and size cut by 16 bytes. This patch fixes that and adds
a test for that logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1967)
<!-- Reviewable:end -->
