### PR TITLE
test: create obj_convert scenarios from head

### DIFF
--- a/src/test/obj_convert/TEST0
+++ b/src/test/obj_convert/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST11
+++ b/src/test/obj_convert/TEST11
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST12
+++ b/src/test/obj_convert/TEST12
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST13
+++ b/src/test/obj_convert/TEST13
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type long
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST14
+++ b/src/test/obj_convert/TEST14
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST15
+++ b/src/test/obj_convert/TEST15
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST16
+++ b/src/test/obj_convert/TEST16
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST17
+++ b/src/test/obj_convert/TEST17
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type long
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST18
+++ b/src/test/obj_convert/TEST18
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type medium
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/TEST19
+++ b/src/test/obj_convert/TEST19
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ require_test_type long
 # of the libpmemobj library
 require_build_type debug
 
-require_fs_type non-pmem
+require_fs_type pmem
 
 setup
 

--- a/src/test/obj_convert/common.sh
+++ b/src/test/obj_convert/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1
 
-verify_scenario() {
+verify_scenario_1_0() {
 	# convert tool always ask for confirmation, so say yes ;)
 	echo -e "y\ny\n" | expect_normal_exit\
 		$PMEMPOOL$EXESUFFIX convert $DIR/scenario$1a &> /dev/null
@@ -49,17 +49,54 @@ verify_scenario() {
 	expect_normal_exit ./obj_convert$EXESUFFIX $DIR/scenario$1c vc $1
 }
 
-create_scenario() {
-	LD_LIBRARY_PATH=$PATH_TO_1_0_DBG gdb --batch\
-		--command=trip_on_pre_commit.gdb --args\
-		./obj_convert$EXESUFFIX $DIR/scenario$1a c $1 &> /dev/null
-
-	LD_LIBRARY_PATH=$PATH_TO_1_0_DBG gdb --batch\
-		--command=trip_on_post_commit.gdb --args\
-		./obj_convert$EXESUFFIX $DIR/scenario$1c c $1 &> /dev/null
+verify_scenario_head() {
+	expect_normal_exit ./obj_convert$EXESUFFIX $DIR/scenario$1a va $1
+	expect_normal_exit ./obj_convert$EXESUFFIX $DIR/scenario$1c vc $1
 }
 
-run_scenarios() {
+create_scenario() {
+	LD_LIBRARY_PATH=$1 gdb --batch\
+		--command=trip_on_pre_commit.gdb --args\
+		./obj_convert$EXESUFFIX $DIR/scenario$2a c $2 &> /dev/null
+
+	LD_LIBRARY_PATH=$1 gdb --batch\
+		--command=trip_on_post_commit.gdb --args\
+		./obj_convert$EXESUFFIX $DIR/scenario$2c c $2 &> /dev/null
+}
+
+create_scenario_1_0() {
+	create_scenario $PATH_TO_1_0_DBG $1
+}
+
+create_scenario_head() {
+	create_scenario $TEST_LD_LIBRARY_PATH $1
+}
+
+clear_scenarios() {
+	sc=("$@")
+
+	for i in "${sc[@]}"
+	do
+		rm -rf $DIR/scenario$1a
+		rm -rf $DIR/scenario$1c
+	done
+}
+
+run_scenarios_head() {
+	sc=("$@")
+
+	for i in "${sc[@]}"
+	do
+		create_scenario_head $i
+	done
+
+	for i in "${sc[@]}"
+	do
+		verify_scenario_head $i
+	done
+}
+
+run_scenarios_1_0() {
 	sc=("$@")
 
 	if [ -z ${PATH_TO_1_0_DBG+x} ];
@@ -68,12 +105,20 @@ run_scenarios() {
 	else
 		for i in "${sc[@]}"
 		do
-			create_scenario $i
+			create_scenario_1_0 $i
 		done
 	fi
 
 	for i in "${sc[@]}"
 	do
-		verify_scenario $i
+		verify_scenario_1_0 $i
 	done
+}
+
+run_scenarios() {
+	run_scenarios_head $@
+	clear_scenarios $@
+
+	run_scenarios_1_0 $@
+	clear_scenarios $@
 }

--- a/utils/docker/images/Dockerfile.fedora-25
+++ b/utils/docker/images/Dockerfile.fedora-25
@@ -42,7 +42,7 @@ MAINTAINER wojciech.uss@intel.com
 RUN dnf install -y git gcc clang openssh-server autoconf automake make \
 	wget tar lbzip2 passwd sudo pkgconfig findutils man libunwind-devel \
 	file rpm-build rpm-build-libs which fuse fuse-devel ncurses-devel \
-	libuv-devel glib2-devel libtool pandoc doxygen cmake
+	libuv-devel glib2-devel libtool pandoc doxygen cmake gdb
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
@@ -70,4 +70,3 @@ ENV OS_VER 25
 ENV START_SSH_COMMAND /usr/sbin/sshd
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
-

--- a/utils/docker/images/Dockerfile.ubuntu-16.04
+++ b/utils/docker/images/Dockerfile.ubuntu-16.04
@@ -39,11 +39,11 @@ FROM ubuntu:16.04
 MAINTAINER wojciech.uss@intel.com
 
 # Update the Apt cache and install basic tools
-RUN apt-get update
-RUN apt-get install -y software-properties-common libunwind8-dev autoconf \
+RUN apt-get update && apt-get install -y software-properties-common\
+	libunwind8-dev autoconf \
 	devscripts pkg-config ssh git gcc clang debhelper sudo whois \
 	libc6-dbg libncurses5-dev libuv1-dev libfuse-dev libglib2.0-dev \
-	libtool pandoc doxygen graphviz clang-format-3.8 cmake ruby
+	libtool pandoc doxygen graphviz clang-format-3.8 cmake ruby gdb
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
@@ -69,4 +69,3 @@ ENV OS_VER 16.04
 ENV START_SSH_COMMAND service ssh start
 ENV PACKAGE_MANAGER dpkg
 ENV NOTTY 1
-


### PR DESCRIPTION
This patch changes the obj_convert test so that it also runs all of
the scenarios on the current version of the library. This makes sure
that a) the test is correct and b) the library didn't have a
regression in recovery path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1974)
<!-- Reviewable:end -->
