### PR TITLE
common: modify os_cpu_set_t definition

### DIFF
--- a/src/common/os_thread.h
+++ b/src/common/os_thread.h
@@ -37,6 +37,7 @@
 
 #ifndef OS_THREAD_H
 #define OS_THREAD_H 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -75,7 +76,7 @@ typedef union {
 
 typedef union {
 	long long align;
-	char padding[128];
+	char padding[512];
 } os_cpu_set_t;
 
 typedef volatile int os_spinlock_t; /* XXX: not implemented on windows */
@@ -148,7 +149,6 @@ int os_thread_join(os_thread_t thread, void **result);
 int os_thread_setaffinity_np(os_thread_t thread, size_t set_size,
 	const os_cpu_set_t *set);
 
-
 int os_thread_atfork(void (*prepare)(void), void (*parent)(void),
 	void (*child)(void));
 
@@ -158,7 +158,6 @@ int os_semaphore_destroy(os_semaphore_t *sem);
 int os_semaphore_wait(os_semaphore_t *sem);
 int os_semaphore_trywait(os_semaphore_t *sem);
 int os_semaphore_post(os_semaphore_t *sem);
-
 
 #ifdef __cplusplus
 }

--- a/src/common/os_thread_linux.c
+++ b/src/common/os_thread_linux.c
@@ -330,7 +330,7 @@ os_cond_wait(os_cond_t *__restrict cond,
 }
 
 /*
- * os_thread_create - pthread_create abstraction layer
+ * os_thread_create -- pthread_create abstraction layer
  */
 int
 os_thread_create(os_thread_t *thread, const os_thread_attr_t *attr,
@@ -342,7 +342,7 @@ os_thread_create(os_thread_t *thread, const os_thread_attr_t *attr,
 }
 
 /*
- * os_thread_join - pthread_join abstraction layer
+ * os_thread_join -- pthread_join abstraction layer
  */
 int
 os_thread_join(os_thread_t thread, void **result)
@@ -351,7 +351,7 @@ os_thread_join(os_thread_t thread, void **result)
 }
 
 /*
- * os_thread_atfork - pthread_atfork abstraction layer
+ * os_thread_atfork -- pthread_atfork abstraction layer
  */
 int
 os_thread_atfork(void (*prepare)(void), void (*parent)(void),
@@ -361,7 +361,7 @@ os_thread_atfork(void (*prepare)(void), void (*parent)(void),
 }
 
 /*
- * os_thread_setaffinity_np - pthread_atfork abstraction layer
+ * os_thread_setaffinity_np -- pthread_atfork abstraction layer
  */
 int
 os_thread_setaffinity_np(os_thread_t thread, size_t set_size,
@@ -373,7 +373,7 @@ os_thread_setaffinity_np(os_thread_t thread, size_t set_size,
 }
 
 /*
- * os_cpu_zero - CP_ZERO abstraction layer
+ * os_cpu_zero -- CP_ZERO abstraction layer
  */
 void
 os_cpu_zero(os_cpu_set_t *set)
@@ -382,7 +382,7 @@ os_cpu_zero(os_cpu_set_t *set)
 }
 
 /*
- * os_cpu_set- CP_SET abstraction layer
+ * os_cpu_set -- CP_SET abstraction layer
  */
 void
 os_cpu_set(size_t cpu, os_cpu_set_t *set)


### PR DESCRIPTION
Fixes os_cpu_set_t size to make it compatible with SLES12.

Ref: pmem/issues#554

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1978)
<!-- Reviewable:end -->
