### PR TITLE
doc: change man page versioning

### DIFF
--- a/doc/libpmem.3.md
+++ b/doc/libpmem.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libpmem(3)
+title: LIBPMEM(3)
 header: NVM Library
-date: pmem API version 1.0.4
+date: pmem API version 1.0
 ...
 
 [comment]: <> (Copyright 2016-2017, Intel Corporation)

--- a/doc/libpmemblk.3.md
+++ b/doc/libpmemblk.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libpmemblk(3)
+title: LIBPMEMBLK(3)
 header: NVM Library
-date: pmemblk API version 1.0.7
+date: pmemblk API version 1.0
 ...
 
 [comment]: <> (Copyright 2016-2017, Intel Corporation)

--- a/doc/libpmemlog.3.md
+++ b/doc/libpmemlog.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libpmemlog(3)
+title: LIBPMEMLOG(3)
 header: NVM Library
-date: pmemlog API version 1.0.6
+date: pmemlog API version 1.0
 ...
 
 [comment]: <> (Copyright 2016-2017, Intel Corporation)

--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libpmemobj(3)
+title: LIBPMEMOBJ(3)
 header: NVM Library
-date: pmemobj API version 2.1.1
+date: pmemobj API version 2.1
 ...
 
 [comment]: <> (Copyright 2016-2017, Intel Corporation)

--- a/doc/libpmempool.3.md
+++ b/doc/libpmempool.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libpmempool(3)
+title: LIBPMEMPOOL(3)
 header: NVM Library
-date: pmempool API version 1.1.0
+date: pmempool API version 1.1
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: librpmem(3)
+title: LIBRPMEM(3)
 header: NVM Library
-date: rpmem API version 1.1.0
+date: rpmem API version 1.1
 ...
 
 [comment]: <> (Copyright 2016-2017, Intel Corporation)

--- a/doc/libvmem.3.md
+++ b/doc/libvmem.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libvmem(3)
+title: LIBVMEM(3)
 header: NVM Library
-date: vmem API version 1.0.2
+date: vmem API version 1.0
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/libvmmalloc.3.md
+++ b/doc/libvmmalloc.3.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: libvmmalloc(3)
+title: LIBVMMALLOC(3)
 header: NVM Library
-date: vmmalloc API version 1.0.2
+date: vmmalloc API version 1.0
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-check.1.md
+++ b/doc/pmempool-check.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-check(1)
+title: PMEMPOOL-CHECK(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-convert.1.md
+++ b/doc/pmempool-convert.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-convert(1)
+title: PMEMPOOL-CONVERT(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-create.1.md
+++ b/doc/pmempool-create.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-create(1)
+title: PMEMPOOL-CREATE(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-dump.1.md
+++ b/doc/pmempool-dump.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-dump(1)
+title: PMEMPOOL-DUMP(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-info.1.md
+++ b/doc/pmempool-info.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-info(1)
+title: PMEMPOOL-INFO(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-rm.1.md
+++ b/doc/pmempool-rm.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-rm(1)
+title: PMEMPOOL-RM(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-sync.1.md
+++ b/doc/pmempool-sync.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-sync(1)
+title: PMEMPOOL-SYNC(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool-transform.1.md
+++ b/doc/pmempool-transform.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool-transform(1)
+title: PMEMPOOL-TRANSFORM(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/pmempool.1.md
+++ b/doc/pmempool.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: pmempool(1)
+title: PMEMPOOL(1)
 header: NVM Library
-date: pmem Tools version 1.2.0
+date: pmem Tools version 1.2
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)

--- a/doc/rpmemd.1.md
+++ b/doc/rpmemd.1.md
@@ -1,9 +1,9 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: rpmemd(1)
+title: RPMEMD(1)
 header: NVM Library
-date: version 1.0.2
+date: version 1.0
 ...
 
 [comment]: <> (Copyright 2016, Intel Corporation)


### PR DESCRIPTION
Removes revision number from the man page version, leaving only
the API major.minor version number.  Revision number is replaced
with the date of the last modification.

It also changes the man page titles to be written all in caps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1984)
<!-- Reviewable:end -->
