### PR TITLE
common: (win) allow to override SRCVERSION

### DIFF
--- a/src/windows/srcversion/srcversion.vcxproj
+++ b/src/windows/srcversion/srcversion.vcxproj
@@ -72,7 +72,7 @@
       </Command>
     </PreBuildEvent>
     <CustomBuildStep>
-      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1"</Command>
+      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
       <Outputs>__NON_EXISTENT_FILE__</Outputs>
       <Message>generate srcversion.h</Message>
     </CustomBuildStep>
@@ -99,7 +99,7 @@
       </Command>
     </PreBuildEvent>
     <CustomBuildStep>
-      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1"</Command>
+      <Command>powershell.exe -file "$(SolutionDir)..\utils\SRCVERSION.ps1" $(SRCVERSION)</Command>
       <Outputs>__NON_EXISTENT_FILE__</Outputs>
       <Message>generate srcversion.h</Message>
     </CustomBuildStep>

--- a/utils/SRCVERSION.ps1
+++ b/utils/SRCVERSION.ps1
@@ -63,7 +63,13 @@ $BUGFIX = $false
 $PRIVATE = $true
 $CUSTOM = $false
 
-if ($null -eq $git) {
+if ($null -ne $args[0]) {
+    $version = $args[0]
+    $ver_array = $version.split("-+")
+} elseif ($null -ne $git) {
+    $version = $(git describe)
+    $ver_array = $(git describe --long).split("-+")
+} else {
     $MAJOR = 0
     $MINOR = 0
     $REVISION = 0
@@ -71,10 +77,9 @@ if ($null -eq $git) {
 
     $CUSTOM = $true
     $version_custom_msg = "#define VERSION_CUSTOM_MSG `"UNKNOWN VERSION`" "
-} else {
-    $version = $(git describe)
-    $ver_array = $(git describe --long).split("-+")
+}
 
+if ($null -ne $ver_array) {
     $MAJOR = $ver_array[0].split(".")[0]
     $MINOR = $ver_array[0].split(".")[1]
     $BUILD = $ver_array[$ver_array.length - 2]


### PR DESCRIPTION
When building NVML from a source tarball, it is not possible to obtain
the version number via 'git describe' and '1.0' will be used in such
case.  This patch allows to pass the version string as an argument to
msbuild (/p:SRCVERSION=...) and override the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/1996)
<!-- Reviewable:end -->
