### PR TITLE
common: allow new files in doc/generated

### DIFF
--- a/utils/check-commit.sh
+++ b/utils/check-commit.sh
@@ -58,7 +58,7 @@ fi
 # valid area names
 AREAS="pmem\|rpmem\|log\|blk\|obj\|pool\|test\|benchmark\|examples\|vmem\|jemalloc\|cpp\|doc\|common"
 
-# Check for changes in the generated docs directory
+# Check commit message
 for commit in $commits; do
 	subject=$(git log --format="%s" -n 1 $commit)
 	subject_len=$(echo $subject | wc -m)

--- a/utils/check-doc.sh
+++ b/utils/check-doc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,13 +61,14 @@ else
 fi
 
 # Check for changes in the generated docs directory
+# Only new files are allowed (first version)
 for commit in $commits; do
 	last_author=$(git --no-pager show -s --format='%aN <%aE>' $commit)
 	if [ "$last_author" == "$allowed_user" ]; then
 		continue
 	fi
 
-	fail=$(git diff-tree --no-commit-id --name-only -r $commit | grep ^$directory | wc -l)
+	fail=$(git diff-tree --no-commit-id --name-status -r $commit | grep -c ^M.*$directory)
 	if [ $fail -ne 0 ]; then
 		echo "FAIL: changes to ${directory} allowed only by \"${allowed_user}\""
 		exit 1


### PR DESCRIPTION
When the new man page is added, it is required to have its initial
version in doc/generated.  Otherwise, the build would fail on rpm/dpkg.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2000)
<!-- Reviewable:end -->
