### PR TITLE
common: use hint address when mapping pool hdr

### DIFF
--- a/src/common/mmap.c
+++ b/src/common/mmap.c
@@ -140,7 +140,7 @@ util_map(int fd, size_t len, int flags, int rdonly, size_t req_align)
 			rdonly, req_align);
 
 	void *base;
-	void *addr = util_map_hint(fd, len, req_align);
+	void *addr = util_map_hint(len, req_align);
 	if (addr == MAP_FAILED) {
 		ERR("cannot find a contiguous region of given size");
 		return NULL;

--- a/src/common/mmap.h
+++ b/src/common/mmap.h
@@ -85,7 +85,7 @@ int util_range_rw(void *addr, size_t len);
 int util_range_none(void *addr, size_t len);
 
 char *util_map_hint_unused(void *minaddr, size_t len, size_t align);
-char *util_map_hint(int fd, size_t len, size_t req_align);
+char *util_map_hint(size_t len, size_t req_align);
 
 #define MEGABYTE ((uintptr_t)1 << 20)
 #define GIGABYTE ((uintptr_t)1 << 30)

--- a/src/common/mmap_linux.c
+++ b/src/common/mmap_linux.c
@@ -141,9 +141,9 @@ util_map_hint_unused(void *minaddr, size_t len, size_t align)
  * address.
  */
 char *
-util_map_hint(int fd, size_t len, size_t req_align)
+util_map_hint(size_t len, size_t req_align)
 {
-	LOG(3, "fd %d len %zu req_align %zu", fd, len, req_align);
+	LOG(3, "len %zu req_align %zu", len, req_align);
 
 	char *hint_addr = MAP_FAILED;
 

--- a/src/common/mmap_windows.c
+++ b/src/common/mmap_windows.c
@@ -97,9 +97,9 @@ util_map_hint_unused(void *minaddr, size_t len, size_t align)
  * no point in aligning for the same.
  */
 char *
-util_map_hint(int fd, size_t len, size_t req_align)
+util_map_hint(size_t len, size_t req_align)
 {
-	LOG(3, "fd %d len %zu req_align %zu", fd, len, req_align);
+	LOG(3, "len %zu req_align %zu", len, req_align);
 
 	char *hint_addr = MAP_FAILED;
 

--- a/src/test/util_map_proc/util_map_proc.c
+++ b/src/test/util_map_proc/util_map_proc.c
@@ -95,7 +95,7 @@ main(int argc, char *argv[])
 
 		void *h1 =
 			util_map_hint_unused((void *)TERABYTE, len, GIGABYTE);
-		void *h2 = util_map_hint(-1, len, 0);
+		void *h2 = util_map_hint(len, 0);
 		if (h1 != MAP_FAILED && h1 != NULL)
 			UT_ASSERTeq((uintptr_t)h1 & (GIGABYTE - 1), 0);
 		if (h2 != MAP_FAILED && h2 != NULL)


### PR DESCRIPTION
This fixes the problem with invalid mapping address alignment
on Device DAX (if the internal alignment is other than 4096), when
the program is run under memcheck.

Ref: pmem/issues#556
Ref: pmem/issues#558
Ref: pmem/issues#559
Ref: pmem/issues#560
Ref: pmem/issues#561
Ref: pmem/issues#562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2001)
<!-- Reviewable:end -->
