### PR TITLE
obj: optimize thread utilization of buckets

### DIFF
--- a/src/common/util.h
+++ b/src/common/util.h
@@ -151,6 +151,7 @@ util_clrbit(uint8_t *b, uint32_t i)
 #define util_bool_compare_and_swap32 __sync_bool_compare_and_swap
 #define util_bool_compare_and_swap64 __sync_bool_compare_and_swap
 #define util_fetch_and_add(ptr, value) __sync_fetch_and_add((ptr), value)
+#define util_fetch_and_sub(ptr, value) __sync_fetch_and_sub((ptr), value)
 #define util_popcount(value) __builtin_popcount(value)
 #else
 static __inline int
@@ -183,6 +184,9 @@ util_sync_fetch_and_add64(volatile LONGLONG *ptr, LONGLONG value)
 
 #define util_fetch_and_add(ptr, value)\
 	util_sync_fetch_and_add64((LONGLONG *)(ptr), (LONGLONG)(value))
+
+#define util_fetch_and_sub(ptr, value)\
+	util_sync_fetch_and_add64((LONGLONG *)(ptr), (LONGLONG)((-1) * value))
 
 #define util_popcount(value) __popcnt(value)
 #endif


### PR DESCRIPTION
This patch improves the way buckets are assigned by counting how many
threads are currently using a given bucket and always picking the
first one that is the least used.
This patch also changes the 'bucket_cache' name to a more meaningful
'arena', a term that is widely used and understood.

Ref: pmem/issues#564

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2002)
<!-- Reviewable:end -->
