### PR TITLE
obj: tune allocation classes

### DIFF
--- a/src/test/obj_constructor/TEST0
+++ b/src/test/obj_constructor/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ configure_valgrind memcheck force-disable
 
 setup
 
-create_holey_file 8M $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 export PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_constructor/TEST0.PS1
+++ b/src/test/obj_constructor/TEST0.PS1
@@ -53,7 +53,7 @@ require_fs_type any
 
 setup
 
-create_holey_file 8M $DIR\testfile1
+create_holey_file 16M $DIR\testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 $Env:PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_constructor/TEST1
+++ b/src/test/obj_constructor/TEST1
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ require_build_type debug
 
 setup
 
-create_holey_file 8M $DIR/testfile1
+create_holey_file 16M $DIR/testfile1
 
 # This is a pretty length test on non-pmem devices, so force clflushes.
 export PMEM_IS_PMEM_FORCE=1

--- a/src/test/obj_constructor/TEST2
+++ b/src/test/obj_constructor/TEST2
@@ -49,7 +49,7 @@ configure_valgrind memcheck force-disable
 
 setup
 
-create_holey_file 16M $DIR/testfile1
+create_holey_file 32M $DIR/testfile1
 
 expect_normal_exit\
     ./obj_constructor$EXESUFFIX $DIR/testfile1 --big-alloc

--- a/src/test/obj_constructor/obj_constructor.c
+++ b/src/test/obj_constructor/obj_constructor.c
@@ -196,13 +196,13 @@ main(int argc, char *argv[])
 	 * heap and it should be possible to allocate it again.
 	 */
 	Canceled_ptr = NULL;
-	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 21), 1,
+	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 22), 1,
 		vg_test_save_ptr, NULL);
 	UT_ASSERTne(Canceled_ptr, NULL);
 	void *first_ptr = Canceled_ptr;
 	Canceled_ptr = NULL;
 
-	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 21), 1,
+	ret = pmemobj_alloc(pop, &oid, sizeof(struct foo) + (1 << 22), 1,
 		vg_test_save_ptr, NULL);
 
 	UT_ASSERTeq(first_ptr, Canceled_ptr);

--- a/src/test/obj_convert/obj_convert.c
+++ b/src/test/obj_convert/obj_convert.c
@@ -479,19 +479,14 @@ sc8_verify_abort(PMEMobjpool *pop)
 static void
 sc8_verify_commit(PMEMobjpool *pop)
 {
-	TX_BEGIN(pop) {
-		/*
-		 * Due to a bug in clang-3.4 a pmemobj_tx_alloc call with its
-		 * result being casted to union immediately is optimized out and
-		 * the verify fails even though it should work. Assigning the
-		 * TX_NEW result to a variable is a hacky workaround for this
-		 * problem.
-		 */
-		TOID(struct bar) f = TX_NEW(struct bar);
-		(void) f;
-	} TX_ONCOMMIT {
-		UT_ASSERT(0);
-	} TX_END
+	int nallocs = 0;
+
+	TOID(struct bar) f;
+	POBJ_FOREACH_TYPE(pop, f) {
+		nallocs++;
+	}
+
+	UT_ASSERTne(nallocs, 0);
 }
 
 /*

--- a/src/test/obj_memcheck/memcheck0.log.match
+++ b/src/test/obj_memcheck/memcheck0.log.match
@@ -65,19 +65,19 @@ $(OPT)==$(N)==  Address 0x$(X) is in a rw- mapped file $(nW) segment
 ==$(N)== Invalid write of size 4
 ==$(N)==    at 0x$(X): test_everything (obj_memcheck.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-==$(N)==  Address 0x$(X) is $(N) bytes after a block of size $(N) free'd
+==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): palloc_operation $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmalloc_operation $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): obj_realloc_common $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): obj_free $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
 ==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): alloc_prep_block $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): palloc_operation $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmalloc_operation $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): obj_alloc_construct $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_alloc $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): obj_realloc_common $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 
@@ -88,19 +88,19 @@ $(OPT)==$(N)==    by 0x$(X): pmemops_persist $(*)
 $(OPT)==$(N)==    by 0x$(X): pmemobj_persist $(*)
 ==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
-==$(N)==  Address 0x$(X) is $(N) bytes after a block of size $(N) free'd
+==$(N)==  Address 0x$(X) is $(N) bytes inside a block of size $(N) free'd
 $(OPT)==$(N)==    $(S) 0x$(X): palloc_operation $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmalloc_operation $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): obj_realloc_common $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): obj_free $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_free $(*)
 ==$(N)==    by 0x$(X): test_everything (obj_memcheck.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_memcheck.c:$(N))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    $(S) 0x$(X): alloc_prep_block $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): palloc_operation $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): pmalloc_operation $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): obj_alloc_construct $(*)
-$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_alloc $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): obj_realloc_common $(*)
+$(OPT)==$(N)==    $(S) 0x$(X): pmemobj_realloc $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): test_everything $(*)
 $(OPT)==$(N)==    $(S) 0x$(X): main $(*)
 ==$(N)== 

--- a/src/test/obj_memcheck/obj_memcheck.c
+++ b/src/test/obj_memcheck/obj_memcheck.c
@@ -150,8 +150,6 @@ test_everything(const char *path)
 	s2->dyn[0] = 9;
 	pmemobj_persist(pop, s2, sizeof(struct struct1) + 100 * sizeof(int));
 
-
-
 	POBJ_ALLOC(pop, &rt->s2, struct struct1, sizeof(struct struct1),
 			NULL, NULL);
 	POBJ_REALLOC(pop, &rt->s2, struct struct1,

--- a/src/test/obj_out_of_memory/out0.log.match
+++ b/src/test/obj_out_of_memory/out0.log.match
@@ -1,7 +1,7 @@
 obj_out_of_memory$(nW)TEST0: START: obj_out_of_memory
  $(nW)obj_out_of_memory$(nW) 1024 $(nW)testfile1 $(nW)testfile2 $(nW)testset1 $(nW)testset2
-size: 1024 allocs: 3410
-size: 1024 allocs: 10912
-size: 1024 allocs: 3410
-size: 1024 allocs: 10912
+size: 1024 allocs: 3610
+size: 1024 allocs: 11552
+size: 1024 allocs: 3610
+size: 1024 allocs: 11552
 obj_out_of_memory$(nW)TEST0: DONE

--- a/src/test/obj_out_of_memory/out1.log.match
+++ b/src/test/obj_out_of_memory/out1.log.match
@@ -1,4 +1,4 @@
 obj_out_of_memory$(nW)TEST1: START: obj_out_of_memory
  $(nW)obj_out_of_memory$(nW) 1024 $(nW)testset1
-size: 1024 allocs: 3410
+size: 1024 allocs: 3610
 obj_out_of_memory$(nW)TEST1: DONE

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -41,11 +41,11 @@
 #include "unittest.h"
 #include "valgrind_internal.h"
 
-#define MOCK_POOL_SIZE PMEMOBJ_MIN_POOL
-#define TEST_MEGA_ALLOC_SIZE (1024 * 1024)
-#define TEST_HUGE_ALLOC_SIZE (255 * 1024)
-#define TEST_SMALL_ALLOC_SIZE (200)
-#define TEST_MEDIUM_ALLOC_SIZE (300)
+#define MOCK_POOL_SIZE (PMEMOBJ_MIN_POOL * 3)
+#define TEST_MEGA_ALLOC_SIZE (10 * 1024 * 1024)
+#define TEST_HUGE_ALLOC_SIZE (4 * 255 * 1024)
+#define TEST_SMALL_ALLOC_SIZE (1000)
+#define TEST_MEDIUM_ALLOC_SIZE (10000)
 #define TEST_TINY_ALLOC_SIZE (64)
 #define TEST_RUNS 2
 

--- a/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
+++ b/src/test/obj_pmalloc_rand_mt/obj_pmalloc_rand_mt.c
@@ -103,7 +103,7 @@ main(int argc, char *argv[])
 
 	if (os_access(argv[1], F_OK) != 0) {
 		pop = pmemobj_create(argv[1], "TEST",
-		(PMEMOBJ_MIN_POOL) + (nthreads * nobjects * object_size),
+		(PMEMOBJ_MIN_POOL * 10) + (nthreads * nobjects * object_size),
 		0666);
 	} else {
 		if ((pop = pmemobj_open(argv[1], "TEST")) == NULL) {

--- a/src/test/obj_pvector/obj_pvector.c
+++ b/src/test/obj_pvector/obj_pvector.c
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
 
 	PMEMobjpool *pop;
 	if ((pop = pmemobj_create(path, "obj_pvector",
-			PMEMOBJ_MIN_POOL * 3, S_IWUSR | S_IRUSR)) == NULL)
+			PMEMOBJ_MIN_POOL * 5, S_IWUSR | S_IRUSR)) == NULL)
 		UT_FATAL("!pmemobj_create: %s", path);
 
 	PMEMoid root = pmemobj_root(pop, sizeof(struct test_root));

--- a/src/test/obj_realloc/TEST0
+++ b/src/test/obj_realloc/TEST0
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@ setup
 
 rm -f $DIR/testfile1
 expect_normal_exit $PMEMPOOL$EXESUFFIX\
-	create obj --layout realloc --size=128M $DIR/testfile1
+	create obj --layout realloc --size=512M $DIR/testfile1
 
 export PMEM_IS_PMEM_FORCE=1
 expect_normal_exit ./obj_realloc$EXESUFFIX $DIR/testfile1

--- a/src/test/obj_realloc/TEST0.PS1
+++ b/src/test/obj_realloc/TEST0.PS1
@@ -55,7 +55,7 @@ setup
 
 rm $DIR\testfile1 -Force -ErrorAction SilentlyContinue
 
-expect_normal_exit $PMEMPOOL create obj --layout realloc --size=128M $DIR\testfile1
+expect_normal_exit $PMEMPOOL create obj --layout realloc --size=512M $DIR\testfile1
 
 $Env:PMEM_IS_PMEM_FORCE=1
 

--- a/src/test/obj_realloc/TEST1
+++ b/src/test/obj_realloc/TEST1
@@ -53,7 +53,7 @@ configure_valgrind pmemcheck force-enable
 setup
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX\
-	create obj --layout realloc --size=128M $DIR/testfile1
+	create obj --layout realloc --size=512M $DIR/testfile1
 
 # last parameter disables integrity tests, because they are veeeeeery slow
 # under pmemcheck (19 minutes vs 7 seconds)

--- a/src/test/obj_realloc/TEST1.PS1
+++ b/src/test/obj_realloc/TEST1.PS1
@@ -56,7 +56,7 @@ require_fs_type non-pmem
 
 setup
 
-expect_normal_exit $PMEMPOOL create obj --layout realloc --size=128M $DIR\testfile1
+expect_normal_exit $PMEMPOOL create obj --layout realloc --size=512M $DIR\testfile1
 
 expect_normal_exit $Env:EXE_DIR\obj_realloc$Env:EXESUFFIX $DIR\testfile1 0
 

--- a/src/test/obj_tx_alloc/TEST1
+++ b/src/test/obj_tx_alloc/TEST1
@@ -49,7 +49,7 @@ configure_valgrind pmemcheck force-enable
 export VALGRIND_OPTS="--mult-stores=no"
 setup
 
-create_nonzeroed_file 16M 8K $DIR/testfile1
+create_nonzeroed_file 32M 8K $DIR/testfile1
 
 expect_normal_exit ./obj_tx_alloc$EXESUFFIX $DIR/testfile1
 

--- a/src/test/obj_tx_alloc/obj_tx_alloc.c
+++ b/src/test/obj_tx_alloc/obj_tx_alloc.c
@@ -652,7 +652,7 @@ do_tx_xalloc_commit(PMEMobjpool *pop)
 	UT_ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
 
 	TOID(struct object) next;
-	TOID_ASSIGN(next, pmemobj_next(first.oid));
+	TOID_ASSIGN(next, POBJ_NEXT_TYPE_NUM(first.oid));
 	UT_ASSERT(TOID_IS_NULL(next));
 
 	/* xalloc ZERO */
@@ -673,7 +673,7 @@ do_tx_xalloc_commit(PMEMobjpool *pop)
 	UT_ASSERT(TOID_EQUALS(first, obj));
 	UT_ASSERTeq(D_RO(first)->value, D_RO(obj)->value);
 
-	TOID_ASSIGN(next, pmemobj_next(first.oid));
+	TOID_ASSIGN(next, POBJ_NEXT_TYPE_NUM(first.oid));
 	UT_ASSERT(TOID_IS_NULL(next));
 }
 

--- a/src/test/pmemobjcli/TEST0.PS1
+++ b/src/test/pmemobjcli/TEST0.PS1
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ $SCRIPT = "..\tools\pmemobjcli\pmemobjcli_example.posc"
 $LOG = "out${Env:UNITTEST_NUM}.log"
 
 rm $POOL -Force -ea si
-expect_normal_exit $PMEMPOOL create obj $POOL
+expect_normal_exit $PMEMPOOL create obj $POOL -s 16M
 expect_normal_exit $PMEMOBJCLI -s $SCRIPT $POOL > $LOG
 
 check

--- a/src/test/pmempool_info/TEST12
+++ b/src/test/pmempool_info/TEST12
@@ -48,7 +48,7 @@ rm -rf $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL
-expect_normal_exit $PMEMALLOC$EXESUFFIX -o $((1*1024*1024)) -t 1 $POOL
+expect_normal_exit $PMEMALLOC$EXESUFFIX -o $((3*1024*1024)) -t 1 $POOL
 expect_normal_exit $PMEMALLOC$EXESUFFIX -o 16 -t 2 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -O -E -a -A -H -Z -C -s $POOL >> $LOG
 

--- a/src/test/pmempool_info/TEST12.PS1
+++ b/src/test/pmempool_info/TEST12.PS1
@@ -54,7 +54,7 @@ $LOG="out$Env:UNITTEST_NUM.log"
 rm $LOG -Force -Recurse -ea si
 
 expect_normal_exit $PMEMPOOL create --layout pmempool$Env:SUFFIX obj $POOL
-expect_normal_exit $PMEMALLOC -o (1*1024*1024) -t 1 $POOL
+expect_normal_exit $PMEMALLOC -o (3*1024*1024) -t 1 $POOL
 expect_normal_exit $PMEMALLOC -o 16 -t 2 $POOL
 expect_normal_exit $PMEMPOOL info -O -E -a -A -H -Z -C -s $POOL >> $LOG
 

--- a/src/test/pmempool_info/TEST13
+++ b/src/test/pmempool_info/TEST13
@@ -50,7 +50,7 @@ rm -rf $LOG && touch $LOG
 
 rm -rf $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout "pmempool$SUFFIX" obj $POOL
-expect_normal_exit $PMEMALLOC$EXESUFFIX -o $((1*1024*1024)) -t 1 $POOL
+expect_normal_exit $PMEMALLOC$EXESUFFIX -o $((3*1024*1024)) -t 1 $POOL
 expect_normal_exit $PMEMALLOC$EXESUFFIX -o 16 -t 2 $POOL
 expect_normal_exit $PMEMPOOL$EXESUFFIX info -O -E -a -A -H -Z -Cr0 -s $POOL >> $LOG
 

--- a/src/test/pmempool_info/TEST13.PS1
+++ b/src/test/pmempool_info/TEST13.PS1
@@ -54,7 +54,7 @@ $LOG="out$Env:UNITTEST_NUM.log"
 rm $LOG -Force -Recurse -ea si
 
 expect_normal_exit $PMEMPOOL create --layout pmempool$Env:SUFFIX obj $POOL
-expect_normal_exit $PMEMALLOC -o $((1*1024*1024)) -t 1 $POOL
+expect_normal_exit $PMEMALLOC -o $((3*1024*1024)) -t 1 $POOL
 expect_normal_exit $PMEMALLOC -o 16 -t 2 $POOL
 expect_normal_exit $PMEMPOOL info -O -E -a -A -H -Z -Cr0 -s $POOL >> $LOG
 

--- a/src/test/pmempool_info/out12.log.match
+++ b/src/test/pmempool_info/out12.log.match
@@ -47,7 +47,7 @@ Size idx                 : $(*)
  Chunk                    : 0
  Type                     : used
  Flags                    : $(*)
- Size idx                 : 5
+ Size idx                 : 13
 
   Object                   : $(*)
   Offset                   : $(*)


### PR DESCRIPTION
This patch significantly improves the allocation classes with regards
to the new header sizes. The algorithm now takes the header sizes
into account.

There are also changes that simplify generation interface.

Internal fragmentation comes down from average of 6.77% to 3.46%
while using less alloc classes.

This patch also increases the maximum run blocks size to
4 megabytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2014)
<!-- Reviewable:end -->
