### PR TITLE
common: disable branch detection in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,11 @@ comment:
   layout: "diff"
   behavior: default
   require_changes: yes
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: false
+      loop: false
+      method: false
+      macro: false


### PR DESCRIPTION
because we compile one source file multiple times codecov
cannot properly interpret branch data. As it is affecting our
test coverage results we have to disable this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2015)
<!-- Reviewable:end -->
