### PR TITLE
test: dump trace.log on failure

### DIFF
--- a/src/test/unittest/unittest.ps1
+++ b/src/test/unittest/unittest.ps1
@@ -362,7 +362,7 @@ function check_exit_code {
         # XXX: if we implement a memcheck thing...
         # if [ "$RUN_MEMCHECK" ]; then
 
-        dump_last_n_lines out$Env:UNITTEST_NUM.log
+        dump_last_n_lines trace$Env:UNITTEST_NUM.log
         dump_last_n_lines $Env:PMEM_LOG_FILE
         dump_last_n_lines $Env:PMEMOBJ_LOG_FILE
         dump_last_n_lines $Env:PMEMLOG_LOG_FILE

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -697,7 +697,8 @@ function expect_normal_exit() {
 			for f in $(get_files "node_.*${UNITTEST_NUM}\.log"); do
 				dump_last_n_lines $f
 			done
-			dump_last_n_lines out$UNITTEST_NUM.log
+
+			dump_last_n_lines trace$UNITTEST_NUM.log
 			dump_last_n_lines $PMEM_LOG_FILE
 			dump_last_n_lines $PMEMOBJ_LOG_FILE
 			dump_last_n_lines $PMEMLOG_LOG_FILE


### PR DESCRIPTION
When the test failure occurs it might be helpful to dump not only
the "out.log", but also "err.log" file.
However, it's easier to simply dump "trace.log" as it contains
all the traces from the out/err log files plus some more
detailed info on file/line/function for each trace message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2017)
<!-- Reviewable:end -->
