### PR TITLE
common: fix default version string

### DIFF
--- a/utils/SRCVERSION.ps1
+++ b/utils/SRCVERSION.ps1
@@ -75,6 +75,7 @@ if ($null -ne $args[0]) {
     $REVISION = 0
     $BUILD = 0
 
+    $version = "UNKNOWN VERSION"
     $CUSTOM = $true
     $version_custom_msg = "#define VERSION_CUSTOM_MSG `"UNKNOWN VERSION`" "
 }


### PR DESCRIPTION
If the build scripts have no access to GIT, then the source version
cannot be determined (git describe) and the version string is empty.
This patch changes the default to "UNKNOWN VERSION".

Ref: pmem/issues#578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2030)
<!-- Reviewable:end -->
