### PR TITLE
obj: stop grabbing a lock when querying pool ptr

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -414,8 +414,15 @@ information, when enabled, as described under **DEBUGGING AND ERROR HANDLING** b
 
 # MOST COMMONLY USED FUNCTIONS #
 
-To use the pmem-resident transactional object store provided by **libpmemobj**, a *memory pool* is first created. This is done with the **pmemobj_create**()
-function described in this section. The other functions described in this section then operate on the resulting memory pool.
+To use the pmem-resident transactional object store provided by **libpmemobj**,
+a *memory pool* is first created.
+This is done with the **pmemobj_create**() function described in this section.
+The other functions described in this section then operate on the resulting
+memory pool.
+
+Additionally, none of the three functions described below are thread-safe with
+respect to any other **libpmemobj** functions. In other words, when creating,
+opening or deleting a pool, nothing else in the library can happen in parallel.
 
 Once created, the memory pool is represented by an opaque handle, of type *PMEMobjpool\**, which is passed to most of the other functions in this section.
 Internally, **libpmemobj** will use either **pmem_persist**() or **msync**(2) when it needs to flush changes, depending on whether the memory pool appears to

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1917,7 +1917,7 @@ pmemobj_pool_by_ptr(const void *addr)
 		return NULL;
 
 	uint64_t key = (uint64_t)addr;
-	size_t pool_size = ctree_find_le(pools_tree, &key);
+	size_t pool_size = ctree_find_le_unlocked(pools_tree, &key);
 
 	if (pool_size == 0)
 		return NULL;


### PR DESCRIPTION
Ref: pmem/issues#549

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2031)
<!-- Reviewable:end -->
