### PR TITLE
test: disable memcheck for obj_convert TEST17

### DIFF
--- a/src/test/obj_convert/TEST17
+++ b/src/test/obj_convert/TEST17
@@ -49,6 +49,10 @@ require_build_type debug
 
 require_fs_type pmem
 
+# Triggers a bug in valgrind 3.10, we should update our valgrind tooling
+# to a newer version and remove this.
+configure_valgrind memcheck force-disable
+
 setup
 
 . common.sh


### PR DESCRIPTION
This test hits a bug in vg 3.10, we should revert this
once we move on to a newer version.

Ref: pmem/issues#581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2040)
<!-- Reviewable:end -->
