### PR TITLE
common: hush error messages during coverage build

### DIFF
--- a/src/test/match
+++ b/src/test/match
@@ -65,7 +65,7 @@
 #
 #	-d	debug -- show lots of debug output
 #
-#	-q	don't print any output on mismatch (just exit with result code)
+#	-q	don't print log files on mismatch
 #
 #	-v	verbose -- show every line as it is being matched
 #
@@ -205,7 +205,11 @@ sub match {
 				$opt = 0;
 			} else {
 				if (!$opt_v) {
-					print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+					if ($opt_q) {
+						print "[MATCHING FAILED]\n";
+					} else {
+						print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+					}
 					$opt_v = 1;
 					match($mfile, $ofile);
 				}
@@ -217,7 +221,11 @@ sub match {
 
 	if ($output ne '') {
 		if (!$opt_v) {
-			print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+			if ($opt_q) {
+				print "[MATCHING FAILED]\n";
+			} else {
+				print "[MATCHING FAILED, COMPLETE FILE ($ofile) BELOW]\n$all_lines\n[EOF]\n";
+			}
 		}
 
 		# make it a little more print-friendly...

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1138,6 +1138,10 @@ function configure_valgrind() {
 		fi
 		require_valgrind_tool $CHECK_TYPE $3
 	fi
+
+	if [ "$UT_VALGRIND_SKIP_PRINT_MISMATCHED" == 1 ]; then
+		export UT_SKIP_PRINT_MISMATCHED=1
+	fi
 }
 
 #
@@ -1946,7 +1950,11 @@ function setup() {
 # check_local -- check local test results (using .match files)
 #
 function check_local() {
-	../match $(get_files "[^0-9w]*${UNITTEST_NUM}\.log\.match")
+	if [ "$UT_SKIP_PRINT_MISMATCHED" == 1 ]; then
+		option=-q
+	fi
+
+	../match $option $(get_files "[^0-9w]*${UNITTEST_NUM}\.log\.match")
 }
 
 #
@@ -1976,7 +1984,11 @@ function check() {
 			done
 		done
 
-		../match $(get_files "node_[0-9]+_[^0-9]*${UNITTEST_NUM}\.log\.match")
+		if [ "$UT_SKIP_PRINT_MISMATCHED" == 1 ]; then
+			option=-q
+		fi
+
+		../match $option $(get_files "node_[0-9]+_[^0-9]*${UNITTEST_NUM}\.log\.match")
 	fi
 }
 

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -41,6 +41,12 @@
 # Build librpmem even if libfabric is not compiled with ibverbs
 export RPMEM_DISABLE_LIBIBVERBS=y
 
+# Hush error messages, mainly from Valgrind
+export UT_DUMP_LINES=0
+
+# Skip printing mismached files for tests with Valgrind
+export UT_VALGRIND_SKIP_PRINT_MISMATCHED=1
+
 # Build all and run tests
 cd $WORKDIR
 make -j2 USE_LIBUNWIND=1 COVERAGE=1


### PR DESCRIPTION
On Travis, the amount of log produced during a coverage measuring build sometimes exceeds 4MB, which causes the build to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2045)
<!-- Reviewable:end -->
