### PR TITLE
test: improve Device DAX alignment detection

### DIFF
--- a/src/test/blk_rw/TEST11
+++ b/src/test/blk_rw/TEST11
@@ -46,8 +46,7 @@ export UNITTEST_NUM=11
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/blk_rw/TEST12
+++ b/src/test/blk_rw/TEST12
@@ -46,8 +46,7 @@ export UNITTEST_NUM=11
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 2097152 # 2MiB
-require_dax_device_alignment 1 2097152 # 2MiB
+require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 

--- a/src/test/log_basic/TEST8
+++ b/src/test/log_basic/TEST8
@@ -56,8 +56,7 @@ export UNITTEST_NUM=8
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/log_basic/TEST9
+++ b/src/test/log_basic/TEST9
@@ -56,8 +56,7 @@ export UNITTEST_NUM=9
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 2097152 # 2MiB
-require_dax_device_alignment 1 2097152 # 2MiB
+require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 

--- a/src/test/obj_basic_integration/TEST11
+++ b/src/test/obj_basic_integration/TEST11
@@ -45,8 +45,7 @@ export UNITTEST_NUM=11
 
 require_test_type medium
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -45,8 +45,7 @@ export UNITTEST_NUM=12
 
 require_test_type medium
 require_dax_devices 2
-require_dax_device_alignment 0 2097152 # 2MiB
-require_dax_device_alignment 1 2097152 # 2MiB
+require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 

--- a/src/test/pmempool_check/TEST24
+++ b/src/test/pmempool_check/TEST24
@@ -45,8 +45,7 @@ require_test_type medium
 require_fs_type any
 
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 # covered by TEST21
 configure_valgrind memcheck force-disable $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_check/TEST25
+++ b/src/test/pmempool_check/TEST25
@@ -45,8 +45,7 @@ require_test_type medium
 require_fs_type any
 
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 # memcheck covered by TEST23, pmemcheck takes too long
 configure_valgrind force-disable $PMEMPOOL$EXESUFFIX

--- a/src/test/pmempool_info/TEST19
+++ b/src/test/pmempool_info/TEST19
@@ -44,8 +44,7 @@ export UNITTEST_NUM=19
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/pmempool_rm/TEST6
+++ b/src/test/pmempool_rm/TEST6
@@ -44,8 +44,7 @@ export UNITTEST_NUM=6
 require_test_type medium
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/util_poolset_parse/TEST2
+++ b/src/test/util_poolset_parse/TEST2
@@ -45,8 +45,7 @@ require_test_type medium
 require_build_type debug
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 4096
-require_dax_device_alignment 1 4096
+require_dax_device_alignments 4096 4096
 
 setup
 

--- a/src/test/util_poolset_parse/TEST3
+++ b/src/test/util_poolset_parse/TEST3
@@ -45,8 +45,7 @@ require_test_type medium
 require_build_type debug
 require_fs_type any
 require_dax_devices 2
-require_dax_device_alignment 0 2097152 # 2MiB
-require_dax_device_alignment 1 2097152 # 2MiB
+require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 


### PR DESCRIPTION
Allows to have multiple Device DAX devices with different alignment
specified in testconfig.sh.  The script would pick the devices having
the appropriate/requested alignment for given test.

Ref: pmem/issues#567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2051)
<!-- Reviewable:end -->
