### PR TITLE
common: cstyle - escape left brace in regex...

### DIFF
--- a/utils/cstyle
+++ b/utils/cstyle
@@ -842,7 +842,7 @@ process_indent($)
 
 	# skip over enumerations, array definitions, initializers, etc.
 	if ($cont_off <= 0 && !/^\s*$special/ &&
-	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*)){/ ||
+	    (/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*))\{/ ||
 	    (/^\s*{/ && $prev =~ /=\s*(?:\/\*.*\*\/\s*)*$/))) {
 		$cont_in = 0;
 		$cont_off = tr/{/{/ - tr/}/}/;


### PR DESCRIPTION
as Perl 5.26 changelog states: "Unescaped literal "{" characters in regular expression paterns are no longer permissible".
This will become "fatal" in Perl 5.30

Message generated by Perl 5.26:
`Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), passed through in regex; marked by <-- HERE in m/(?:(?:\b(?:enum|struct|union)\s*[^\{]*)|(?:\s+=\s*)){ <-- HERE / at ../../../../src/../utils/cstyle line 845.`

Link to changelog:
https://metacpan.org/pod/distribution/perl/pod/perldelta.pod#Unescaped-literal-%22%7B%22-characters-in-regular-expression-patterns-are-no-longer-permissible

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2052)
<!-- Reviewable:end -->
