### PR TITLE
rpmem: add attribute packed

### DIFF
--- a/src/include/librpmem.h
+++ b/src/include/librpmem.h
@@ -66,7 +66,7 @@ struct rpmem_pool_attr {
 	unsigned char next_uuid[RPMEM_POOL_HDR_UUID_LEN]; /* next pool uuid */
 	unsigned char prev_uuid[RPMEM_POOL_HDR_UUID_LEN]; /* prev pool uuid */
 	unsigned char user_flags[RPMEM_POOL_USER_FLAGS_LEN]; /* user flags */
-};
+} __attribute__((packed));
 
 RPMEMpool *rpmem_create(const char *target, const char *pool_set_name,
 		void *pool_addr, size_t pool_size, unsigned *nlanes,


### PR DESCRIPTION
Add __attribute__((packed)) to the rpmem_pool_attr structure which
is sent OTA/OTC. This causes an unaligned access on clang-4.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2055)
<!-- Reviewable:end -->
