### PR TITLE
rpmem: add attribute packed

### DIFF
--- a/src/librpmem/rpmem_obc.c
+++ b/src/librpmem/rpmem_obc.c
@@ -196,7 +196,7 @@ rpmem_obc_alloc_create_msg(const struct rpmem_req_attr *req,
 			req->pool_desc, pool_desc_size);
 
 	if (pool_attr) {
-		memcpy(&msg->pool_attr, pool_attr, sizeof(msg->pool_attr));
+		pack_rpmem_pool_attr(pool_attr, &msg->pool_attr);
 	} else {
 		RPMEM_LOG(INFO, "using zeroed pool attributes");
 		memset(&msg->pool_attr, 0, sizeof(msg->pool_attr));
@@ -577,12 +577,13 @@ rpmem_obc_open(struct rpmem_obc *rpc,
 
 	rpmem_ntoh_msg_open_resp(&resp);
 
+
 	if (rpmem_obc_check_open_resp(&resp))
 		goto err_msg_resp;
 
 	rpmem_obc_get_res(res, &resp.ibc);
 	if (pool_attr)
-		memcpy(pool_attr, &resp.pool_attr, sizeof(*pool_attr));
+		unpack_rpmem_pool_attr(&resp.pool_attr, pool_attr);
 
 	free(msg);
 	return 0;

--- a/src/rpmem_common/rpmem_proto.h
+++ b/src/rpmem_common/rpmem_proto.h
@@ -66,6 +66,22 @@ enum rpmem_msg_type {
 };
 
 /*
+ * rpmem_pool_attr_packed -- a packed version
+ */
+struct rpmem_pool_attr_packed {
+	char signature[RPMEM_POOL_HDR_SIG_LEN]; /* pool signature */
+	uint32_t major; /* format major version number */
+	uint32_t compat_features; /* mask: compatible "may" features */
+	uint32_t incompat_features; /* mask: "must support" features */
+	uint32_t ro_compat_features; /* mask: force RO if unsupported */
+	unsigned char poolset_uuid[RPMEM_POOL_HDR_UUID_LEN]; /* pool uuid */
+	unsigned char uuid[RPMEM_POOL_HDR_UUID_LEN]; /* first part uuid */
+	unsigned char next_uuid[RPMEM_POOL_HDR_UUID_LEN]; /* next pool uuid */
+	unsigned char prev_uuid[RPMEM_POOL_HDR_UUID_LEN]; /* prev pool uuid */
+	unsigned char user_flags[RPMEM_POOL_USER_FLAGS_LEN]; /* user flags */
+} PACKED;
+
+/*
  * rpmem_msg_ibc_attr -- in-band connection attributes
  *
  * Used by create request response and open request response.
@@ -125,7 +141,7 @@ struct rpmem_msg_create {
 	uint64_t pool_size;		/* minimum required size of a pool */
 	uint32_t nlanes;		/* number of lanes used by initiator */
 	uint32_t provider;		/* provider */
-	struct rpmem_pool_attr pool_attr;	/* pool attributes */
+	struct rpmem_pool_attr_packed pool_attr;	/* pool attributes */
 	struct rpmem_msg_pool_desc pool_desc;	/* pool descriptor */
 } PACKED;
 
@@ -166,7 +182,7 @@ struct rpmem_msg_open {
 struct rpmem_msg_open_resp {
 	struct rpmem_msg_hdr_resp hdr;	/* message header */
 	struct rpmem_msg_ibc_attr ibc;	/* in-band connection attributes */
-	struct rpmem_pool_attr pool_attr; /* pool attributes */
+	struct rpmem_pool_attr_packed pool_attr; /* pool attributes */
 } PACKED;
 
 /*
@@ -215,7 +231,7 @@ struct rpmem_msg_persist_resp {
  */
 struct rpmem_msg_set_attr {
 	struct rpmem_msg_hdr hdr;	/* message header */
-	struct rpmem_pool_attr pool_attr;	/* pool attributes */
+	struct rpmem_pool_attr_packed pool_attr;	/* pool attributes */
 } PACKED;
 
 /*
@@ -253,7 +269,7 @@ rpmem_ntoh_msg_pool_desc(struct rpmem_msg_pool_desc *pool_desc)
  * rpmem_ntoh_pool_attr -- convert rpmem_pool_attr to host byte order
  */
 static inline void
-rpmem_ntoh_pool_attr(struct rpmem_pool_attr *attr)
+rpmem_ntoh_pool_attr(struct rpmem_pool_attr_packed *attr)
 {
 	attr->major = be32toh(attr->major);
 	attr->ro_compat_features = be32toh(attr->ro_compat_features);
@@ -464,4 +480,42 @@ static inline void
 rpmem_hton_msg_close_resp(struct rpmem_msg_close_resp *msg)
 {
 	rpmem_ntoh_msg_close_resp(msg);
+}
+
+/*
+ * pack_rpmem_pool_attr -- copy pool attributes to a packed structure
+ */
+static inline void
+pack_rpmem_pool_attr(const struct rpmem_pool_attr *src,
+		struct rpmem_pool_attr_packed *dst)
+{
+	memcpy(dst->signature, src->signature, sizeof(src->signature));
+	dst->major = src->major;
+	dst->compat_features = src->compat_features;
+	dst->incompat_features = src->incompat_features;
+	dst->ro_compat_features = src->ro_compat_features;
+	memcpy(dst->poolset_uuid, src->poolset_uuid, sizeof(dst->poolset_uuid));
+	memcpy(dst->uuid, src->uuid, sizeof(dst->uuid));
+	memcpy(dst->next_uuid, src->next_uuid, sizeof(dst->next_uuid));
+	memcpy(dst->prev_uuid, src->prev_uuid, sizeof(dst->prev_uuid));
+	memcpy(dst->user_flags, src->user_flags, sizeof(dst->user_flags));
+}
+
+/*
+ * unpack_rpmem_pool_attr -- copy pool attributes to an unpacked structure
+ */
+static inline void
+unpack_rpmem_pool_attr(const struct rpmem_pool_attr_packed *src,
+		struct rpmem_pool_attr *dst)
+{
+	memcpy(dst->signature, src->signature, sizeof(src->signature));
+	dst->major = src->major;
+	dst->compat_features = src->compat_features;
+	dst->incompat_features = src->incompat_features;
+	dst->ro_compat_features = src->ro_compat_features;
+	memcpy(dst->poolset_uuid, src->poolset_uuid, sizeof(dst->poolset_uuid));
+	memcpy(dst->uuid, src->uuid, sizeof(dst->uuid));
+	memcpy(dst->next_uuid, src->next_uuid, sizeof(dst->next_uuid));
+	memcpy(dst->prev_uuid, src->prev_uuid, sizeof(dst->prev_uuid));
+	memcpy(dst->user_flags, src->user_flags, sizeof(dst->user_flags));
 }

--- a/src/test/rpmem_proto/rpmem_proto.c
+++ b/src/test/rpmem_proto/rpmem_proto.c
@@ -71,6 +71,19 @@ main(int argc, char *argv[])
 	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr, user_flags);
 	ASSERT_ALIGNED_CHECK(struct rpmem_pool_attr);
 
+	ASSERT_ALIGNED_BEGIN(struct rpmem_pool_attr_packed);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, signature);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, major);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, compat_features);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, incompat_features);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, ro_compat_features);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, poolset_uuid);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, uuid);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, next_uuid);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, prev_uuid);
+	ASSERT_ALIGNED_FIELD(struct rpmem_pool_attr_packed, user_flags);
+	ASSERT_ALIGNED_CHECK(struct rpmem_pool_attr_packed);
+
 	ASSERT_ALIGNED_BEGIN(struct rpmem_msg_ibc_attr);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_ibc_attr, port);
 	ASSERT_ALIGNED_FIELD(struct rpmem_msg_ibc_attr, persist_method);

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -455,8 +455,7 @@ rpmemd_req_create(struct rpmemd_obc *obc, void *arg,
 	}
 
 	rpmemd->pool = rpmemd_db_pool_create(rpmemd->db,
-			req->pool_desc,
-			0, (struct rpmem_pool_attr *)pool_attr);
+			req->pool_desc, 0, pool_attr);
 	if (!rpmemd->pool) {
 		ret = -1;
 		status = rpmemd_db_get_status(errno);

--- a/src/tools/rpmemd/rpmemd_obc.c
+++ b/src/tools/rpmemd/rpmemd_obc.c
@@ -248,6 +248,8 @@ rpmemd_obc_process_create(struct rpmemd_obc *obc,
 	struct rpmem_msg_hdr *hdrp)
 {
 	struct rpmem_msg_create *msg = (struct rpmem_msg_create *)hdrp;
+	struct rpmem_pool_attr attr;
+	unpack_rpmem_pool_attr(&msg->pool_attr, &attr);
 	struct rpmem_req_attr req = {
 		.pool_size = msg->pool_size,
 		.nlanes = (unsigned)msg->nlanes,
@@ -255,7 +257,7 @@ rpmemd_obc_process_create(struct rpmemd_obc *obc,
 		.provider = (enum rpmem_provider)msg->provider,
 	};
 
-	return req_cb->create(obc, arg, &req, &msg->pool_attr);
+	return req_cb->create(obc, arg, &req, &attr);
 }
 
 /*
@@ -297,8 +299,10 @@ rpmemd_obc_process_set_attr(struct rpmemd_obc *obc,
 	struct rpmem_msg_hdr *hdrp)
 {
 	struct rpmem_msg_set_attr *msg = (struct rpmem_msg_set_attr *)hdrp;
+	struct rpmem_pool_attr attr;
+	unpack_rpmem_pool_attr(&msg->pool_attr, &attr);
 
-	return req_cb->set_attr(obc, arg, &msg->pool_attr);
+	return req_cb->set_attr(obc, arg, &attr);
 }
 
 typedef int (*rpmemd_obc_process_fn)(struct rpmemd_obc *obc,
@@ -517,9 +521,9 @@ rpmemd_obc_open_resp(struct rpmemd_obc *obc,
 			.persist_method = res->persist_method,
 			.nlanes = res->nlanes,
 		},
-		.pool_attr = *pool_attr,
 	};
 
+	pack_rpmem_pool_attr(pool_attr, &resp.pool_attr);
 	rpmem_hton_msg_open_resp(&resp);
 
 	return rpmemd_obc_send(obc, &resp, sizeof(resp));


### PR DESCRIPTION
Add a __attribute__((packed)) version of the rpmem_pool_attr structure
which is sent OTA/OTC. This causes an unaligned access on clang-4.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2061)
<!-- Reviewable:end -->
