### PR TITLE
obj: fix root size field when upgrading from 1.2

### DIFF
--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -121,6 +121,8 @@ struct pmemobjpool {
 
 	uint64_t root_size;
 
+	char pmem_reserved[512]; /* must be zeroed */
+
 	/* some run-time state, allocated out of memory pool... */
 	void *addr;		/* mapped region */
 	size_t size;		/* size of mapped region */
@@ -167,7 +169,7 @@ struct pmemobjpool {
 
 	/* padding to align size of this structure to page boundary */
 	/* sizeof(unused2) == 8192 - offsetof(struct pmemobjpool, unused2) */
-	char unused2[1548];
+	char unused2[1036];
 };
 
 /*

--- a/src/test/obj_convert/common.sh
+++ b/src/test/obj_convert/common.sh
@@ -108,7 +108,6 @@ run_scenarios_1_0() {
 			create_scenario_1_0 $i
 		done
 	fi
-
 	for i in "${sc[@]}"
 	do
 		verify_scenario_1_0 $i

--- a/src/test/obj_convert/obj_convert.c
+++ b/src/test/obj_convert/obj_convert.c
@@ -140,6 +140,8 @@ sc0_create(PMEMobjpool *pop)
 static void
 sc0_verify_abort(PMEMobjpool *pop)
 {
+	UT_ASSERTeq(pmemobj_root_size(pop), sizeof(struct root));
+
 	TOID(struct root) rt = POBJ_ROOT(pop, struct root);
 	UT_ASSERTeq(D_RW(rt)->value[0], 0);
 }
@@ -147,6 +149,8 @@ sc0_verify_abort(PMEMobjpool *pop)
 static void
 sc0_verify_commit(PMEMobjpool *pop)
 {
+	UT_ASSERTeq(pmemobj_root_size(pop), sizeof(struct root));
+
 	TOID(struct root) rt = POBJ_ROOT(pop, struct root);
 	UT_ASSERTeq(D_RW(rt)->value[0], TEST_VALUE);
 }


### PR DESCRIPTION
This patch fixes the automatic root size update, thus eliminating the need to bump the major layout version or adding any incompat flags.

I've also added a zeroed 'pmem_reserved' space so that we don't have this problem in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2064)
<!-- Reviewable:end -->
