### PR TITLE
doc: Chelsio pool size limit

### DIFF
--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -376,6 +376,10 @@ For this reason, all functions that might trigger destruction (e.g.
 **dlclose**()) should be called in the main thread. Otherwise some of the
 resources associated with that thread might not be cleaned up properly.
 
+**librpmem** registers a pool as a single memory region. A Chelsio T4 and T5
+hardware can not handle a memory region greater than or equal to 8GB due to
+a hardware bug. So *pool_size* value for **rpmem_create**() and **rpmem_open**()
+using this hardware can not be greater than or equal to 8GB.
 
 # LIBRARY API VERSIONING #
 


### PR DESCRIPTION
A Chelsio T4 and T5 hardware can not handle a memory region grater
than or equal to 8GB due to a hardware bug.

Ref: torvalds/linux@2550a88d956fb77c34d71b46a0a8e9ebf1c5b4a3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2067)
<!-- Reviewable:end -->
