### PR TITLE
pool: fix rm remote init / fini

### DIFF
--- a/src/tools/pmempool/rm.c
+++ b/src/tools/pmempool/rm.c
@@ -298,7 +298,6 @@ int
 pmempool_rm_func(char *appname, int argc, char *argv[])
 {
 #ifdef USE_RPMEM
-	util_remote_init();
 	/*
 	 * Try to load librpmem, if loading failed -
 	 * assume it is not available.
@@ -390,10 +389,6 @@ pmempool_rm_func(char *appname, int argc, char *argv[])
 		if (ret)
 			lret = ret;
 	}
-
-#ifdef USE_RPMEM
-	util_remote_fini();
-#endif
 
 	return lret;
 }


### PR DESCRIPTION
Remove redundant remote init / fini.

Ref: pmem/issues#587

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2068)
<!-- Reviewable:end -->
