### PR TITLE
doc: sync supports only pmemobj

### DIFF
--- a/doc/libpmempool.3.md
+++ b/doc/libpmempool.3.md
@@ -411,6 +411,9 @@ return one of the following values:
 
 # POOL SET SYNCHRONIZATION AND TRANSFORMATION #
 
+Currently, the following operations are allowed only for **pmemobj** pools (see
+**libpmemobj**(3)).
+
 ### POOL SET SYNC ###
 
 ```c
@@ -468,9 +471,6 @@ It supports the following operations:
 * removing one or more replicas,
 
 * reordering of replicas.
-
-Currently these operations are allowed only for **pmemobj** pools (see
-**libpmemobj**(3)).
 
 
 **pmempool_transform**() accepts three arguments:

--- a/doc/pmempool-sync.1.md
+++ b/doc/pmempool-sync.1.md
@@ -61,6 +61,8 @@ a pool set. It checks if metadata of all replicas in a pool set
 are consistent, i.e. all parts are healthy, and if any of them is not,
 the corrupted or missing parts are recreated and filled with data from one of
 the healthy replicas.
+Currently synchronizing data is allowed only for **pmemobj** pools (see
+**libpmemobj**(3)).
 
 ##### Available options: #####
 


### PR DESCRIPTION
Added note that pmempool and libpmempool sync only supports pmemobj pools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2078)
<!-- Reviewable:end -->
