### PR TITLE
test: make pcheck handle dev-dax tests

### DIFF
--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -12,3 +12,5 @@ testfile*
 libs.tar
 *.synced
 .sync-dir
+# ignore lock files
+*.lock

--- a/utils/docker/build-local.sh
+++ b/utils/docker/build-local.sh
@@ -117,6 +117,7 @@ sudo docker run --privileged=true --name=$containerName -ti \
 	--env EXPERIMENTAL=$EXPERIMENTAL \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
 	--env CLANG_FORMAT=clang-format-3.8 \
+	--env KEEP_TEST_CONFIG=$KEEP_TEST_CONFIG \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-v /etc/localtime:/etc/localtime \
 	$DAX_SETTING \

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -41,7 +41,8 @@ echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=6G
 
 # Configure tests (e.g. ssh for remote tests) unless the current configuration
 # should be preserved
-if [[ "$KEEP_TEST_CONFIG" != "1" ]]; then
+KEEP_TEST_CONFIG=${KEEP_TEST_CONFIG:-0}
+if [[ "$KEEP_TEST_CONFIG" == 0 ]]; then
 	./configure-tests.sh
 fi
 


### PR DESCRIPTION
This patch adds a lock on Device DAXes for tests executed with `make pcheck`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2084)
<!-- Reviewable:end -->
