### PR TITLE
test: add missing test type

### DIFF
--- a/src/test/obj_rpmem_basic_integration/config.sh
+++ b/src/test/obj_rpmem_basic_integration/config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 
 CONF_GLOBAL_FS_TYPE=pmem
 CONF_GLOBAL_BUILD_TYPE="debug nondebug"
+CONF_GLOBAL_TEST_TYPE=medium
 
 CONF_GLOBAL_RPMEM_PROVIDER=all
 CONF_GLOBAL_RPMEM_PMETHOD=all


### PR DESCRIPTION
Because some tests from this unittest requires valgrind support
missing test type causes printing skip messages. For other
unittests a test type value in config.sh is still optional.

Ref: pmem/issues#495

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2095)
<!-- Reviewable:end -->
