### PR TITLE
pool: ignore error while loading librpmem

### DIFF
--- a/src/libpmempool/rm.c
+++ b/src/libpmempool/rm.c
@@ -208,8 +208,10 @@ pmempool_rmU(const char *path, int flags)
 	}
 	os_close(fd);
 
-	if (set->remote)
-		util_remote_load(); /* error will be handled in rm_remote() */
+	if (set->remote) {
+		/* ignore error - it will be handled in rm_remote() */
+		(void) util_remote_load();
+	}
 
 	util_poolset_free(set);
 


### PR DESCRIPTION
This patch is only to silence Coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2097)
<!-- Reviewable:end -->
