### PR TITLE
vmmalloc: always export all aligned alloc variants

### DIFF
--- a/src/include/libvmmalloc.h
+++ b/src/include/libvmmalloc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016, Intel Corporation
+ * Copyright 2014-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,15 +46,11 @@ extern "C" {
 #endif
 
 #define VMMALLOC_MAJOR_VERSION 1
-#define VMMALLOC_MINOR_VERSION 0
+#define VMMALLOC_MINOR_VERSION 1
 
 #include <sys/types.h>
 
 #define VMMALLOC_MIN_POOL ((size_t)(1024 * 1024 * 14)) /* min pool size: 14MB */
-
-#define VMMALLOC_OVERRIDE_ALIGNED_ALLOC
-#define VMMALLOC_OVERRIDE_VALLOC
-#define VMMALLOC_OVERRIDE_MEMALIGN
 
 /*
  * check compiler support for various function attributes
@@ -133,21 +129,15 @@ extern void cfree(void *ptr);
 extern int posix_memalign(void **memptr, size_t alignment, size_t size)
 	__ATTR_NONNULL__(1);
 
-#ifdef VMMALLOC_OVERRIDE_MEMALIGN
 extern void *memalign(size_t boundary, size_t size)
 	__ATTR_MALLOC__ __ATTR_ALLOC_ALIGN__(1) __ATTR_ALLOC_SIZE__(2);
-#endif
 
-#ifdef VMMALLOC_OVERRIDE_ALIGNED_ALLOC
 extern void *aligned_alloc(size_t alignment, size_t size)
 	__ATTR_MALLOC__ __ATTR_ALLOC_ALIGN__(1) __ATTR_ALLOC_SIZE__(2);
-#endif
 
-#ifdef VMMALLOC_OVERRIDE_VALLOC
 extern void *valloc(size_t size) __ATTR_MALLOC__ __ATTR_ALLOC_SIZE__(1);
 
 extern void *pvalloc(size_t size) __ATTR_MALLOC__ __ATTR_ALLOC_SIZE__(1);
-#endif
 
 extern size_t malloc_usable_size(void *ptr);
 


### PR DESCRIPTION
Modifies libvmmalloc to always export aligned_alloc(), memalign(),
valloc() and pvalloc(), even if those functions are not supported by
installed version of glibc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2098)
<!-- Reviewable:end -->
