### PR TITLE
test: remove invalid rpmem obj dependencies

### DIFF
--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -378,14 +378,6 @@ $(OBJ_TESTS): $(OBJ_DEPS)
 $(LIBPMEMPOOL_TESTS): $(LIBPMEMPOOL_DEPS)
 $(LIBPMEMPOOL_MOD_TESTS): $(LIBPMEMPOOL_MOD_DEPS)
 
-obj_rpmem_basic_integration: obj_basic_integration
-
-obj_rpmem_constuctor: obj_constructor
-
-obj_rpmem_heap_interrupt: obj_heap_interrupt
-
-obj_rpmem_heap_state: obj_heap_state
-
 $(TESTS_BUILD):
 	$(MAKE) -C $@ $(TARGET)
 


### PR DESCRIPTION
Ref: pmem/issues#472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2104)
<!-- Reviewable:end -->
