### PR TITLE
obj: write free chunks footers on recovery

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -640,6 +640,7 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 		for (uint32_t i = 0; i < z->header.size_idx; ) {
 			struct chunk_header *hdr = &z->chunk_headers[i];
 			switch (hdr->type) {
+				case CHUNK_TYPE_FREE:
 				case CHUNK_TYPE_USED:
 					heap_chunk_write_footer(hdr,
 						hdr->size_idx);


### PR DESCRIPTION
This might have lead to some free chunks not being properly
coalesced when recoverying after a crash that happened in the
middle of a pmalloc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2105)
<!-- Reviewable:end -->
