### PR TITLE
obj: don't put runs with incompat hdr in recycler

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -583,7 +583,8 @@ heap_reclaim_run(struct palloc_heap *heap, struct bucket *defb,
 			heap->rt->alloc_classes,
 			run->block_size);
 		if (c != NULL && c->type == CLASS_RUN &&
-				c->run.size_idx == m->size_idx) {
+				c->run.size_idx == m->size_idx &&
+				c->header_type == m->header_type) {
 			recycler_put(heap->rt->recyclers[c->id], m);
 		}
 	}


### PR DESCRIPTION
The old behavior theoretically might have lead to a situation where
a bucket associated with an allocation class that had runs with
different header types, might have given out blocks that were
too small (or too large) for the requested object.

FYI: this might only happen with legacy headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2107)
<!-- Reviewable:end -->
