### PR TITLE
obj: reclaim run immediately after deactivation

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -528,10 +528,13 @@ heap_reuse_run(struct palloc_heap *heap, struct bucket *b,
  */
 static int
 heap_reclaim_run(struct palloc_heap *heap, struct bucket *defb,
-	struct chunk_run *run, struct memory_block *m)
+	struct memory_block *m)
 {
 	if (m->m_ops->claim(m) != 0)
 		return 0; /* this run already has an owner */
+
+	struct chunk_run *run = (struct chunk_run *)
+		&ZID_TO_ZONE(heap->layout, m->zone_id)->chunks[m->chunk_id];
 
 	struct alloc_class_run_proto run_proto;
 	alloc_class_generate_run_proto(&run_proto,
@@ -582,11 +585,13 @@ heap_reclaim_run(struct palloc_heap *heap, struct bucket *defb,
 		struct alloc_class *c = alloc_class_by_unit_size(
 			heap->rt->alloc_classes,
 			run->block_size);
-		if (c != NULL && c->type == CLASS_RUN &&
-				c->run.size_idx == m->size_idx &&
-				c->header_type == m->header_type) {
-			recycler_put(heap->rt->recyclers[c->id], m);
-		}
+
+		if (c == NULL ||
+		    c->type != CLASS_RUN ||
+		    c->run.size_idx != m->size_idx ||
+		    c->header_type != m->header_type ||
+		    recycler_put(heap->rt->recyclers[c->id], m) < 0)
+			m->m_ops->claim_revoke(m);
 	}
 
 	util_mutex_unlock(lock);
@@ -629,7 +634,6 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 {
 	struct zone *z = ZID_TO_ZONE(heap->layout, zone_id);
 
-	struct chunk_run *run = NULL;
 	int rchunks = 0;
 
 	/*
@@ -665,9 +669,7 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 
 		switch (hdr->type) {
 			case CHUNK_TYPE_RUN:
-				run = (struct chunk_run *)&z->chunks[i];
-				rchunks += heap_reclaim_run(heap, bucket,
-					run, &m);
+				rchunks += heap_reclaim_run(heap, bucket, &m);
 				break;
 			case CHUNK_TYPE_FREE:
 				if (init)
@@ -716,10 +718,11 @@ heap_populate_bucket(struct palloc_heap *heap, struct bucket *bucket)
 static int
 heap_reclaim_garbage(struct palloc_heap *heap, struct bucket *bucket)
 {
-	struct memory_block m;
+	struct memory_block m = MEMORY_BLOCK_NONE;
 	for (size_t i = 0; i < MAX_ALLOCATION_CLASSES; ++i) {
 		while (recycler_get(heap->rt->recyclers[i], &m) == 0) {
 			m.m_ops->claim_revoke(&m);
+			m.size_idx = 0;
 		}
 	}
 
@@ -745,81 +748,22 @@ heap_ensure_huge_bucket_filled(struct palloc_heap *heap, struct bucket *bucket)
 }
 
 /*
- * heap_ensure_run_bucket_filled -- (internal) refills the bucket if needed
+ * heap_reuse_from_recycler -- (internal) try reusing runs that are currently
+ *	in the recycler
  */
 static int
-heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
-	uint32_t units)
+heap_reuse_from_recycler(struct palloc_heap *heap,
+	struct bucket *b, uint32_t units)
 {
-	ASSERTeq(b->aclass->type, CLASS_RUN);
-
-	if (b->is_active) {
-		b->c_ops->rm_all(b->container);
-		b->active_memory_block.m_ops
-			->claim_revoke(&b->active_memory_block);
-
-		b->is_active = 0;
-	}
-
-	struct heap_rt *h = heap->rt;
 	struct memory_block m = MEMORY_BLOCK_NONE;
+	m.size_idx = units;
 
-	if (recycler_get(h->recyclers[b->aclass->id], &m) == 0) {
+	if (recycler_get(heap->rt->recyclers[b->aclass->id], &m) == 0) {
 		os_mutex_t *lock = m.m_ops->get_lock(&m);
 
 		util_mutex_lock(lock);
 		heap_reuse_run(heap, b, &m);
 		util_mutex_unlock(lock);
-
-		b->active_memory_block = m;
-		b->is_active = 1;
-
-		return 0;
-	}
-
-	m.size_idx = b->aclass->run.size_idx;
-
-	/* cannot reuse an existing run, create a new one */
-	struct bucket *defb = heap_bucket_acquire_by_id(heap,
-			DEFAULT_ALLOC_CLASS_ID);
-	if (heap_get_bestfit_block(heap, defb, &m) == 0) {
-		ASSERTeq(m.block_off, 0);
-
-		heap_create_run(heap, b, &m);
-
-		b->active_memory_block = m;
-		b->is_active = 1;
-
-		heap_bucket_release(heap, defb);
-		return 0;
-	}
-	heap_bucket_release(heap, defb);
-
-	/*
-	 * Try the recycler again, the previous call to the bestfit_block for
-	 * huge chunks might have reclaimed some unused runs.
-	 */
-	if (recycler_get(h->recyclers[b->aclass->id], &m) == 0) {
-		os_mutex_t *lock = m.m_ops->get_lock(&m);
-		util_mutex_lock(lock);
-		heap_reuse_run(heap, b, &m);
-		util_mutex_unlock(lock);
-
-		/*
-		 * To verify that the recycler run is not able to satisfy our
-		 * request we attempt to retrieve a block. This is not ideal,
-		 * and should be replaced by a different heuristic once proper
-		 * memory block scoring is implemented.
-		 */
-		struct memory_block tmp = MEMORY_BLOCK_NONE;
-		tmp.size_idx = units;
-		if (b->c_ops->get_rm_bestfit(b->container, &tmp) != 0) {
-			b->c_ops->rm_all(b->container);
-			m.m_ops->claim_revoke(&m);
-			return ENOMEM;
-		} else {
-			bucket_insert_block(b, &tmp);
-		}
 
 		b->active_memory_block = m;
 		b->is_active = 1;
@@ -828,6 +772,65 @@ heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
 	}
 
 	return ENOMEM;
+}
+
+/*
+ * heap_ensure_run_bucket_filled -- (internal) refills the bucket if needed
+ */
+static int
+heap_ensure_run_bucket_filled(struct palloc_heap *heap, struct bucket *b,
+	uint32_t units)
+{
+	ASSERTeq(b->aclass->type, CLASS_RUN);
+
+	int ret = 0;
+
+	struct bucket *defb = heap_bucket_acquire_by_id(heap,
+			DEFAULT_ALLOC_CLASS_ID);
+
+	/* get rid of the active block in the bucket */
+	if (b->is_active) {
+		b->c_ops->rm_all(b->container);
+		b->is_active = 0;
+
+		b->active_memory_block.m_ops
+			->claim_revoke(&b->active_memory_block);
+
+		/* either convert to a full chunk or place it in the recycler */
+		heap_reclaim_run(heap, defb, &b->active_memory_block);
+	}
+
+	if (heap_reuse_from_recycler(heap, b, units) == 0)
+		goto out;
+
+	struct memory_block m = MEMORY_BLOCK_NONE;
+	m.size_idx = b->aclass->run.size_idx;
+
+	/* cannot reuse an existing run, create a new one */
+	if (heap_get_bestfit_block(heap, defb, &m) == 0) {
+		ASSERTeq(m.block_off, 0);
+
+		heap_create_run(heap, b, &m);
+
+		b->active_memory_block = m;
+		b->is_active = 1;
+
+		goto out;
+	}
+
+	/*
+	 * Try the recycler again, the previous call to the bestfit_block for
+	 * huge chunks might have reclaimed some unused runs.
+	 */
+	if (heap_reuse_from_recycler(heap, b, units) == 0)
+		goto out;
+
+	ret = ENOMEM;
+
+out:
+	heap_bucket_release(heap, defb);
+
+	return ret;
 }
 
 /*

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -40,14 +40,16 @@
 #include "sys_util.h"
 #include "ctree.h"
 
-#define RUN_KEY_PACK(z, c, s)\
-((uint64_t)(s) << 32 | (uint64_t)(c) << 16 | (z))
+#define RUN_KEY_PACK(z, c, free_space, max_block)\
+((uint64_t)(max_block) << 48 |\
+(uint64_t)(free_space) << 32 |\
+(uint64_t)(c) << 16 | (z))
 
 #define RUN_KEY_GET_ZONE_ID(k)\
 ((uint16_t)(k))
 
 #define RUN_KEY_GET_CHUNK_ID(k)\
-((uint16_t)(k >> 16))
+((uint16_t)((k) >> 16))
 
 struct recycler_element {
 	uint32_t chunk_id;
@@ -94,20 +96,57 @@ recycler_delete(struct recycler *r)
 }
 
 /*
- * recycler_calc_score -- calculates the overall free space of a run
+ * recycler_calc_score -- calculates how many free bytes does a run have and
+ *	what's the largest request that the run can handle
  */
-static uint32_t
+static uint64_t
 recycler_calc_score(struct recycler *r, const struct memory_block *m)
 {
 	struct zone *z = ZID_TO_ZONE(r->heap->layout, m->zone_id);
 	struct chunk_run *run = (struct chunk_run *)&z->chunks[m->chunk_id];
 
-	uint32_t score = 0;
-	for (int i = 0; i < MAX_BITMAP_VALUES; ++i)
-		if (run->bitmap[i] != UINT64_MAX)
-			score += !__builtin_popcountll(run->bitmap[i]);
+	uint16_t free_space = 0;
+	uint16_t max_block = 0;
 
-	return score;
+	for (int i = 0; i < MAX_BITMAP_VALUES; ++i) {
+		uint64_t value = ~run->bitmap[i];
+		if (value == 0)
+			continue;
+
+		uint16_t free_in_value = (uint16_t)__builtin_popcountll(value);
+		free_space = (uint16_t)(free_space + free_in_value);
+
+		/*
+		 * If this value has less free blocks than already found max,
+		 * there's no point in searching.
+		 */
+		if (free_in_value < max_block)
+			continue;
+
+		/* if the entire value is empty, no point in searching */
+		if (free_in_value == BITS_PER_VALUE) {
+			max_block = BITS_PER_VALUE;
+		}
+
+		/*
+		 * Find the biggest free block in the bitmap.
+		 * This algorithm is not the most clever imaginable, but it's
+		 * easy to implement and fast enough.
+		 */
+		uint16_t n = 0;
+		while (value != 0) {
+			value &= (value << 1ULL);
+			n++;
+		}
+
+		if (n > max_block)
+			max_block = n;
+	}
+
+	if (free_space == 0)
+		return 0;
+
+	return RUN_KEY_PACK(m->zone_id, m->chunk_id, free_space, max_block);
 }
 
 /*
@@ -117,9 +156,11 @@ int
 recycler_put(struct recycler *r, const struct memory_block *m)
 {
 	uint64_t score = recycler_calc_score(r, m);
-	uint64_t key = RUN_KEY_PACK(m->zone_id, m->chunk_id, score);
 
-	return ctree_insert(r->runs, key, 0);
+	if (score == 0)
+		return -1;
+
+	return ctree_insert(r->runs, score, 0);
 }
 
 /*
@@ -128,9 +169,8 @@ recycler_put(struct recycler *r, const struct memory_block *m)
 int
 recycler_get(struct recycler *r, struct memory_block *m)
 {
-	uint64_t key;
-	uint64_t value;
-	if (ctree_remove_max(r->runs, &key, &value) != 0)
+	uint64_t key = RUN_KEY_PACK(0, 0, 0, m->size_idx);
+	if ((key = ctree_remove(r->runs, key, 0)) == 0)
 		return ENOMEM;
 
 	m->chunk_id = RUN_KEY_GET_CHUNK_ID(key);

--- a/src/test/obj_constructor/memcheck1.log.match
+++ b/src/test/obj_constructor/memcheck1.log.match
@@ -7,10 +7,11 @@
 ==$(N)== Invalid write of size 4
 ==$(N)==    at 0x$(X): main (obj_constructor.c:$(N))
 ==$(N)==  Address 0x$(X) is $(N) bytes after a block of size $(N) free'd
-==$(N)==    at 0x$(X): palloc_operation (palloc.c:$(N))
+==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))
+==$(N)==    by 0x$(X): palloc_operation (palloc.c:$(N))
 ==$(N)==    by 0x$(X): pmalloc_operation (pmalloc.c:$(N))
-==$(N)==    by 0x$(X): obj_free (obj.c:$(N))
-==$(N)==    by 0x$(X): pmemobj_free (obj.c:$(N))
+==$(N)==    by 0x$(X): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(X): pmemobj_alloc (obj.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_constructor.c:$(N))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))
@@ -28,10 +29,11 @@ $(OPT)==$(N)==    by 0x$(X): main (obj_constructor.c:$(N))
 ==$(N)==    by 0x$(X): pmemobj_persist (obj.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_constructor.c:$(N))
 ==$(N)==  Address 0x$(X) is 16 bytes after a block of size 112 free'd
-==$(N)==    at 0x$(X): palloc_operation (palloc.c:$(N))
+==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))
+==$(N)==    by 0x$(X): palloc_operation (palloc.c:$(N))
 ==$(N)==    by 0x$(X): pmalloc_operation (pmalloc.c:$(N))
-==$(N)==    by 0x$(X): obj_free (obj.c:$(N))
-==$(N)==    by 0x$(X): pmemobj_free (obj.c:$(N))
+==$(N)==    by 0x$(X): obj_alloc_construct (obj.c:$(N))
+==$(N)==    by 0x$(X): pmemobj_alloc (obj.c:$(N))
 ==$(N)==    by 0x$(X): main (obj_constructor.c:$(N))
 $(OPT)==$(N)==  Block was alloc'd at
 $(OPT)==$(N)==    at 0x$(X): alloc_prep_block (palloc.c:$(N))

--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -45,7 +45,7 @@
 #define TEST_MEGA_ALLOC_SIZE (10 * 1024 * 1024)
 #define TEST_HUGE_ALLOC_SIZE (4 * 255 * 1024)
 #define TEST_SMALL_ALLOC_SIZE (1000)
-#define TEST_MEDIUM_ALLOC_SIZE (10000)
+#define TEST_MEDIUM_ALLOC_SIZE (1024 * 200)
 #define TEST_TINY_ALLOC_SIZE (64)
 #define TEST_RUNS 2
 
@@ -119,7 +119,7 @@ obj_memset(void *ctx, void *ptr, int c, size_t sz)
 	return ptr;
 }
 
-static void
+static size_t
 test_oom_allocs(size_t size)
 {
 	uint64_t max_allocs = MOCK_POOL_SIZE / size;
@@ -141,6 +141,8 @@ test_oom_allocs(size_t size)
 	}
 	UT_ASSERT(count != 0);
 	FREE(allocs);
+
+	return count;
 }
 
 static void
@@ -279,11 +281,22 @@ test_mock_pool_allocs(void)
 	 * Allocating till OOM and freeing the objects in a loop for different
 	 * buckets covers basically all code paths except error cases.
 	 */
-	test_oom_allocs(TEST_HUGE_ALLOC_SIZE);
-	test_oom_allocs(TEST_TINY_ALLOC_SIZE);
-	test_oom_allocs(TEST_HUGE_ALLOC_SIZE);
-	test_oom_allocs(TEST_SMALL_ALLOC_SIZE);
-	test_oom_allocs(TEST_MEGA_ALLOC_SIZE);
+	size_t medium0 = test_oom_allocs(TEST_MEDIUM_ALLOC_SIZE);
+	size_t mega0 = test_oom_allocs(TEST_MEGA_ALLOC_SIZE);
+	size_t huge0 = test_oom_allocs(TEST_HUGE_ALLOC_SIZE);
+	size_t small0 = test_oom_allocs(TEST_SMALL_ALLOC_SIZE);
+	size_t tiny0 = test_oom_allocs(TEST_TINY_ALLOC_SIZE);
+	size_t huge1 = test_oom_allocs(TEST_HUGE_ALLOC_SIZE);
+	size_t small1 = test_oom_allocs(TEST_SMALL_ALLOC_SIZE);
+	size_t mega1 = test_oom_allocs(TEST_MEGA_ALLOC_SIZE);
+	size_t tiny1 = test_oom_allocs(TEST_TINY_ALLOC_SIZE);
+	size_t medium1 = test_oom_allocs(TEST_MEDIUM_ALLOC_SIZE);
+
+	UT_ASSERTeq(mega0, mega1);
+	UT_ASSERTeq(huge0, huge1);
+	UT_ASSERTeq(small0, small1);
+	UT_ASSERTeq(tiny0, tiny1);
+	UT_ASSERTeq(medium0, medium1);
 
 	test_realloc(TEST_SMALL_ALLOC_SIZE, TEST_MEDIUM_ALLOC_SIZE);
 	test_realloc(TEST_HUGE_ALLOC_SIZE, TEST_MEGA_ALLOC_SIZE);


### PR DESCRIPTION
This patch improves the recycler by changing the score calculation
function to include the largest available block. This means that now
the threads can accurately tell if a run in the recycler satisfies the
users request and there's no need for different fallbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2114)
<!-- Reviewable:end -->
