### PR TITLE
common: fix matches unknown srcversion

### DIFF
--- a/utils/SRCVERSION.ps1
+++ b/utils/SRCVERSION.ps1
@@ -75,9 +75,9 @@ if ($null -ne $args[0]) {
     $REVISION = 0
     $BUILD = 0
 
-    $version = "UNKNOWN VERSION"
+    $version = "UNKNOWN_VERSION"
     $CUSTOM = $true
-    $version_custom_msg = "#define VERSION_CUSTOM_MSG `"UNKNOWN VERSION`" "
+    $version_custom_msg = "#define VERSION_CUSTOM_MSG `"UNKNOWN_VERSION`" "
 }
 
 if ($null -ne $ver_array) {


### PR DESCRIPTION
This patch removes spaces in srcversion to avoid issues with tests match failed when version is not detected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2125)
<!-- Reviewable:end -->
