### PR TITLE
obj: fix bogus OOM after exhausting first zone

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -670,9 +670,11 @@ heap_reclaim_zone_garbage(struct palloc_heap *heap, struct bucket *bucket,
 					run, &m);
 				break;
 			case CHUNK_TYPE_FREE:
-				if (init)
+				if (init) {
+					rchunks += (int)m.size_idx;
 					heap_init_free_chunk(heap, bucket,
 						hdr, &m);
+				}
 				break;
 			case CHUNK_TYPE_USED:
 				break;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -123,7 +123,8 @@ OBJ_TESTS = \
 	obj_tx_realloc\
 	obj_tx_strdup\
 	obj_constructor\
-	obj_oid
+	obj_oid\
+	obj_zones
 
 OBJ_REMOTE_TESTS = \
 	obj_rpmem_basic_integration\

--- a/src/test/obj_zones/.gitignore
+++ b/src/test/obj_zones/.gitignore
@@ -1,0 +1,1 @@
+obj_zones

--- a/src/test/obj_zones/Makefile
+++ b/src/test/obj_zones/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/obj_zones/Makefile -- build obj_zones test
+#
+TARGET = obj_zones
+OBJS = obj_zones.o
+
+LIBPMEM=y
+LIBPMEMOBJ=y
+
+include ../Makefile.inc

--- a/src/test/obj_zones/TEST0
+++ b/src/test/obj_zones/TEST0
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+export UNITTEST_NAME=obj_zones/TEST0
+export UNITTEST_NUM=0
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+# too large
+configure_valgrind force-disable
+
+require_test_type medium
+
+setup
+
+create_holey_file 64G $DIR/testfile1
+
+expect_normal_exit ./obj_zones$EXESUFFIX $DIR/testfile1
+
+check
+
+pass

--- a/src/test/obj_zones/obj_zones.c
+++ b/src/test/obj_zones/obj_zones.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * obj_zones.c -- allocates from a very large pool (exceeding 1 zone)
+ *
+ */
+
+#include <stddef.h>
+
+#include "unittest.h"
+
+#define LAYOUT_NAME "obj_zones"
+
+#define ALLOC_SIZE (1 << 27) /* 128 megabytes */
+
+int
+main(int argc, char *argv[])
+{
+	START(argc, argv, "obj_zones");
+
+	if (argc != 2)
+		UT_FATAL("usage: %s file-name", argv[0]);
+
+	const char *path = argv[1];
+
+	PMEMobjpool *pop = NULL;
+
+	if ((pop = pmemobj_create(path, LAYOUT_NAME,
+			0, S_IWUSR | S_IRUSR)) == NULL)
+		UT_FATAL("!pmemobj_create: %s", path);
+
+	int n = 0;
+	while (1) {
+		PMEMoid oid;
+		if (pmemobj_alloc(pop, &oid, ALLOC_SIZE, 0, NULL, NULL) != 0)
+			break;
+		n++;
+	}
+
+	UT_OUT("allocated: %d", n);
+
+	pmemobj_close(pop);
+
+	DONE(NULL);
+}

--- a/src/test/obj_zones/out0.log.match
+++ b/src/test/obj_zones/out0.log.match
@@ -1,0 +1,4 @@
+obj_zones$(nW)TEST0: START: obj_zones
+ $(nW)obj_zones$(nW) $(nW)testfile1
+allocated: 508
+obj_zones$(nW)TEST0: DONE


### PR DESCRIPTION
The function that initialized a zone for the first time had
a wrong return value that indicated that no memory was found
when an entire new zone was inserted into the bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2128)
<!-- Reviewable:end -->
