### PR TITLE
common: Portability changes commit 1: script invocation

### DIFF
--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/arch_flags/TEST0
+++ b/src/test/arch_flags/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_include/TEST0
+++ b/src/test/blk_include/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_nblock/TEST0
+++ b/src/test/blk_nblock/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_nblock/TEST1
+++ b/src/test/blk_nblock/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_nblock/TEST2
+++ b/src/test/blk_nblock/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_non_zero/TEST0
+++ b/src/test/blk_non_zero/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_non_zero/TEST1
+++ b/src/test/blk_non_zero/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_non_zero/TEST2
+++ b/src/test/blk_non_zero/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_non_zero/TEST3
+++ b/src/test/blk_non_zero/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_non_zero/TEST4
+++ b/src/test/blk_non_zero/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_non_zero/TEST5
+++ b/src/test/blk_non_zero/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_non_zero/TEST6
+++ b/src/test/blk_non_zero/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_non_zero/TEST7
+++ b/src/test/blk_non_zero/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_non_zero/TEST8
+++ b/src/test/blk_non_zero/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_non_zero/TEST9
+++ b/src/test/blk_non_zero/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST0
+++ b/src/test/blk_pool/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST1
+++ b/src/test/blk_pool/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST10
+++ b/src/test/blk_pool/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST11
+++ b/src/test/blk_pool/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST12
+++ b/src/test/blk_pool/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST13
+++ b/src/test/blk_pool/TEST13
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST14
+++ b/src/test/blk_pool/TEST14
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST15
+++ b/src/test/blk_pool/TEST15
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST16
+++ b/src/test/blk_pool/TEST16
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST17
+++ b/src/test/blk_pool/TEST17
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/blk_pool/TEST2
+++ b/src/test/blk_pool/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST20
+++ b/src/test/blk_pool/TEST20
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST21
+++ b/src/test/blk_pool/TEST21
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST22
+++ b/src/test/blk_pool/TEST22
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST23
+++ b/src/test/blk_pool/TEST23
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST24
+++ b/src/test/blk_pool/TEST24
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST25
+++ b/src/test/blk_pool/TEST25
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST26
+++ b/src/test/blk_pool/TEST26
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST27
+++ b/src/test/blk_pool/TEST27
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST28
+++ b/src/test/blk_pool/TEST28
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST29
+++ b/src/test/blk_pool/TEST29
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST3
+++ b/src/test/blk_pool/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST30
+++ b/src/test/blk_pool/TEST30
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST31
+++ b/src/test/blk_pool/TEST31
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/blk_pool/TEST32
+++ b/src/test/blk_pool/TEST32
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/blk_pool/TEST4
+++ b/src/test/blk_pool/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST5
+++ b/src/test/blk_pool/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST6
+++ b/src/test/blk_pool/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool/TEST7
+++ b/src/test/blk_pool/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST8
+++ b/src/test/blk_pool/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_pool/TEST9
+++ b/src/test/blk_pool/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_pool_lock/TEST0
+++ b/src/test/blk_pool_lock/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/blk_recovery/TEST0
+++ b/src/test/blk_recovery/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST0
+++ b/src/test/blk_rw/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/blk_rw/TEST1
+++ b/src/test/blk_rw/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST10
+++ b/src/test/blk_rw/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST11
+++ b/src/test/blk_rw/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST12
+++ b/src/test/blk_rw/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST2
+++ b/src/test/blk_rw/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw/TEST3
+++ b/src/test/blk_rw/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST4
+++ b/src/test/blk_rw/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST5
+++ b/src/test/blk_rw/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST6
+++ b/src/test/blk_rw/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST7
+++ b/src/test/blk_rw/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST8
+++ b/src/test/blk_rw/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw/TEST9
+++ b/src/test/blk_rw/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/blk_rw_mt/TEST0
+++ b/src/test/blk_rw_mt/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw_mt/TEST1
+++ b/src/test/blk_rw_mt/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw_mt/TEST2
+++ b/src/test/blk_rw_mt/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/blk_rw_mt/config.sh
+++ b/src/test/blk_rw_mt/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/bttdevice/TEST0
+++ b/src/test/bttdevice/TEST0
@@ -49,15 +49,15 @@ LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
 echo "Create btt device - uuid defined by the user" >> $LOG
-expect_normal_exit $BTTCREATE -s 20M -b 1K -l 256 \
-		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v $POOL >> $LOG
+expect_normal_exit $BTTCREATE $POOL -s 20M -b 1K -l 256\
+		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL
 rm -rf $POOL
 
 echo -e "\nCreate btt device - automatic uuid generation" >> $LOG
-expect_normal_exit $BTTCREATE -s 40M -b 2K -l 256 -v $POOL >> $LOG
+expect_normal_exit $BTTCREATE $POOL -s 40M -b 2K -l 256 -v >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL

--- a/src/test/bttdevice/TEST0
+++ b/src/test/bttdevice/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,15 +49,15 @@ LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
 echo "Create btt device - uuid defined by the user" >> $LOG
-expect_normal_exit $BTTCREATE $POOL -s 20M -b 1K -l 256\
-		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v >> $LOG
+expect_normal_exit $BTTCREATE -s 20M -b 1K -l 256 \
+		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v $POOL >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL
 rm -rf $POOL
 
 echo -e "\nCreate btt device - automatic uuid generation" >> $LOG
-expect_normal_exit $BTTCREATE $POOL -s 40M -b 2K -l 256 -v >> $LOG
+expect_normal_exit $BTTCREATE -s 40M -b 2K -l 256 -v $POOL >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL

--- a/src/test/bttdevice/TEST1
+++ b/src/test/bttdevice/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
-expect_normal_exit $BTTCREATE $POOL -v >> $LOG
+expect_normal_exit $BTTCREATE -v $POOL >> $LOG
 
 $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\

--- a/src/test/bttdevice/TEST1
+++ b/src/test/bttdevice/TEST1
@@ -48,7 +48,7 @@ POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
-expect_normal_exit $BTTCREATE -v $POOL >> $LOG
+expect_normal_exit $BTTCREATE $POOL -v >> $LOG
 
 $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\

--- a/src/test/checksum/TEST0
+++ b/src/test/checksum/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmem/TEST0
+++ b/src/test/ex_libpmem/TEST0
@@ -54,11 +54,7 @@ create_nonzeroed_file 2M 0K $DIR/testfile1
 expect_normal_exit $EX_PATH/simple_copy $DIR/testfile1 $DIR/testfile2 \
 	> out$UNITTEST_NUM.log 2>&1
 
-# XXX FreeBSD does not support the -n option to cmp(1)
-dd if=$DIR/testfile1 of=$DIR/testfile1.4k bs=4096 count=1 status=none
-dd if=$DIR/testfile2 of=$DIR/testfile2.4k bs=4096 count=1 status=none
-cmp $DIR/testfile1.4k $DIR/testfile2.4k > cmp$UNITTEST_NUM.log 2>&1
-rm -f $DIR/testfile1.4k $DIR/testfile2.4k
+cmp -n 4096 $DIR/testfile1 $DIR/testfile2 > cmp$UNITTEST_NUM.log 2>&1
 
 check
 

--- a/src/test/ex_libpmem/TEST0
+++ b/src/test/ex_libpmem/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,11 @@ create_nonzeroed_file 2M 0K $DIR/testfile1
 expect_normal_exit $EX_PATH/simple_copy $DIR/testfile1 $DIR/testfile2 \
 	> out$UNITTEST_NUM.log 2>&1
 
-cmp -n 4096 $DIR/testfile1 $DIR/testfile2 > cmp$UNITTEST_NUM.log 2>&1
+# XXX FreeBSD does not support the -n option to cmp(1)
+dd if=$DIR/testfile1 of=$DIR/testfile1.4k bs=4096 count=1 status=none
+dd if=$DIR/testfile2 of=$DIR/testfile2.4k bs=4096 count=1 status=none
+cmp $DIR/testfile1.4k $DIR/testfile2.4k > cmp$UNITTEST_NUM.log 2>&1
+rm -f $DIR/testfile1.4k $DIR/testfile2.4k
 
 check
 

--- a/src/test/ex_libpmem/TEST1
+++ b/src/test/ex_libpmem/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/ex_libpmemblk/TEST0
+++ b/src/test/ex_libpmemblk/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/ex_libpmemlog/TEST0
+++ b/src/test/ex_libpmemlog/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/ex_libpmemobj/TEST0
+++ b/src/test/ex_libpmemobj/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST1
+++ b/src/test/ex_libpmemobj/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST10
+++ b/src/test/ex_libpmemobj/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/ex_libpmemobj/TEST11
+++ b/src/test/ex_libpmemobj/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST12
+++ b/src/test/ex_libpmemobj/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/ex_libpmemobj/TEST13
+++ b/src/test/ex_libpmemobj/TEST13
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST14
+++ b/src/test/ex_libpmemobj/TEST14
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST15
+++ b/src/test/ex_libpmemobj/TEST15
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST16
+++ b/src/test/ex_libpmemobj/TEST16
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST17
+++ b/src/test/ex_libpmemobj/TEST17
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST18
+++ b/src/test/ex_libpmemobj/TEST18
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST19
+++ b/src/test/ex_libpmemobj/TEST19
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST2
+++ b/src/test/ex_libpmemobj/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST20
+++ b/src/test/ex_libpmemobj/TEST20
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST3
+++ b/src/test/ex_libpmemobj/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST4
+++ b/src/test/ex_libpmemobj/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST5
+++ b/src/test/ex_libpmemobj/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST6
+++ b/src/test/ex_libpmemobj/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST7
+++ b/src/test/ex_libpmemobj/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST8
+++ b/src/test/ex_libpmemobj/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj/TEST9
+++ b/src/test/ex_libpmemobj/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj_cpp/TEST0
+++ b/src/test/ex_libpmemobj_cpp/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_libpmemobj_cpp/TEST1
+++ b/src/test/ex_libpmemobj_cpp/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_linkedlist/TEST0
+++ b/src/test/ex_linkedlist/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/ex_linkedlist/TEST1
+++ b/src/test/ex_linkedlist/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_api/TEST0
+++ b/src/test/libpmempool_api/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST1
+++ b/src/test/libpmempool_api/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST10
+++ b/src/test/libpmempool_api/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST11
+++ b/src/test/libpmempool_api/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST12
+++ b/src/test/libpmempool_api/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST13
+++ b/src/test/libpmempool_api/TEST13
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST2
+++ b/src/test/libpmempool_api/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST3
+++ b/src/test/libpmempool_api/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST4
+++ b/src/test/libpmempool_api/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST5
+++ b/src/test/libpmempool_api/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST6
+++ b/src/test/libpmempool_api/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST7
+++ b/src/test/libpmempool_api/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST8
+++ b/src/test/libpmempool_api/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_api/TEST9
+++ b/src/test/libpmempool_api/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_backup/TEST0
+++ b/src/test/libpmempool_backup/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST1
+++ b/src/test/libpmempool_backup/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST2
+++ b/src/test/libpmempool_backup/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST3
+++ b/src/test/libpmempool_backup/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST4
+++ b/src/test/libpmempool_backup/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST5
+++ b/src/test/libpmempool_backup/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/TEST6
+++ b/src/test/libpmempool_backup/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_backup/TEST7
+++ b/src/test/libpmempool_backup/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_backup/common.sh
+++ b/src/test/libpmempool_backup/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # libpmempool_backup/common.sh -- functions for libpmempool_backup unittest
 #
+set -e
+
 POOLSET=$DIR/pool.set
 BACKUP=_backup
 REPLICA=_replica

--- a/src/test/libpmempool_backup/config.sh
+++ b/src/test/libpmempool_backup/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_bttdev/TEST0
+++ b/src/test/libpmempool_bttdev/TEST0
@@ -51,7 +51,7 @@ EXE=../libpmempool_api/libpmempool_test
 
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST0
+++ b/src/test/libpmempool_bttdev/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ EXE=../libpmempool_api/libpmempool_test
 
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST1
+++ b/src/test/libpmempool_bttdev/TEST1
@@ -54,7 +54,7 @@ expect_normal_exit $BTTCREATE $POOL >> $LOG
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST1
+++ b/src/test/libpmempool_bttdev/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ expect_normal_exit $BTTCREATE $POOL >> $LOG
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST10
+++ b/src/test/libpmempool_bttdev/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +55,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.checksum=777"\
 	"bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST10
+++ b/src/test/libpmempool_bttdev/TEST10
@@ -55,7 +55,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.checksum=777"\
 	"bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST11
+++ b/src/test/libpmempool_bttdev/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(1).btt_info.checksum=777"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST11
+++ b/src/test/libpmempool_bttdev/TEST11
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(1).btt_info.checksum=777"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST2
+++ b/src/test/libpmempool_bttdev/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,11 +54,11 @@ EXE=../libpmempool_api/libpmempool_test
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info_backup.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 cat $LOG >> $LOG_TEMP
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 cat $LOG >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG

--- a/src/test/libpmempool_bttdev/TEST2
+++ b/src/test/libpmempool_bttdev/TEST2
@@ -54,11 +54,11 @@ EXE=../libpmempool_api/libpmempool_test
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info_backup.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 cat $LOG >> $LOG_TEMP
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 cat $LOG >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG

--- a/src/test/libpmempool_bttdev/TEST3
+++ b/src/test/libpmempool_bttdev/TEST3
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST3
+++ b/src/test/libpmempool_bttdev/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST4
+++ b/src/test/libpmempool_bttdev/TEST4
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST4
+++ b/src/test/libpmempool_bttdev/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST5
+++ b/src/test/libpmempool_bttdev/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -60,7 +60,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST5
+++ b/src/test/libpmempool_bttdev/TEST5
@@ -60,7 +60,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST6
+++ b/src/test/libpmempool_bttdev/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -63,7 +63,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(2).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(3).btt_info.checksum=13"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST6
+++ b/src/test/libpmempool_bttdev/TEST6
@@ -63,7 +63,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(2).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(3).btt_info.checksum=13"
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST7
+++ b/src/test/libpmempool_bttdev/TEST7
@@ -55,7 +55,7 @@ $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\
 		"bttdevice.arena(0).btt_info.major=0x0" >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
+expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST7
+++ b/src/test/libpmempool_bttdev/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -55,7 +55,7 @@ $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\
 		"bttdevice.arena(0).btt_info.major=0x0" >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST8
+++ b/src/test/libpmempool_bttdev/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -66,7 +66,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
+	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/TEST8
+++ b/src/test/libpmempool_bttdev/TEST8
@@ -66,7 +66,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
+	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/TEST9
+++ b/src/test/libpmempool_bttdev/TEST9
@@ -65,7 +65,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
+	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/TEST9
+++ b/src/test/libpmempool_bttdev/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
+	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/out0.log.match
+++ b/src/test/libpmempool_bttdev/out0.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST0: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 checking BTT Map and Flog

--- a/src/test/libpmempool_bttdev/out0.log.match
+++ b/src/test/libpmempool_bttdev/out0.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST0: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 checking BTT Map and Flog

--- a/src/test/libpmempool_bttdev/out1.log.match
+++ b/src/test/libpmempool_bttdev/out1.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST1: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out1.log.match
+++ b/src/test/libpmempool_bttdev/out1.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST1: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out10.log.match
+++ b/src/test/libpmempool_bttdev/out10.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST10: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out10.log.match
+++ b/src/test/libpmempool_bttdev/out10.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST10: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out11.log.match
+++ b/src/test/libpmempool_bttdev/out11.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST11: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 1: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?

--- a/src/test/libpmempool_bttdev/out11.log.match
+++ b/src/test/libpmempool_bttdev/out11.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST11: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 1: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?

--- a/src/test/libpmempool_bttdev/out2.log.match
+++ b/src/test/libpmempool_bttdev/out2.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 0: BTT Info backup checksum incorrect. Do you want to restore it from BTT Info header?
@@ -9,7 +9,7 @@ arena 0: checking BTT Map and Flog
 status = repaired
 libpmempool_bttdev/TEST2: DONE
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out2.log.match
+++ b/src/test/libpmempool_bttdev/out2.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 0: BTT Info backup checksum incorrect. Do you want to restore it from BTT Info header?
@@ -9,7 +9,7 @@ arena 0: checking BTT Map and Flog
 status = repaired
 libpmempool_bttdev/TEST2: DONE
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out3.log.match
+++ b/src/test/libpmempool_bttdev/out3.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST3: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out3.log.match
+++ b/src/test/libpmempool_bttdev/out3.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST3: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out4.log.match
+++ b/src/test/libpmempool_bttdev/out4.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST4: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out4.log.match
+++ b/src/test/libpmempool_bttdev/out4.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST4: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out5.log.match
+++ b/src/test/libpmempool_bttdev/out5.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST5: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out5.log.match
+++ b/src/test/libpmempool_bttdev/out5.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST5: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out6.log.match
+++ b/src/test/libpmempool_bttdev/out6.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST6: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out6.log.match
+++ b/src/test/libpmempool_bttdev/out6.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST6: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out7.log.match
+++ b/src/test/libpmempool_bttdev/out7.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST7: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out7.log.match
+++ b/src/test/libpmempool_bttdev/out7.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST7: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out8.log.match
+++ b/src/test/libpmempool_bttdev/out8.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -10,7 +10,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -20,7 +20,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -30,7 +30,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -40,7 +40,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -60,7 +60,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -70,7 +70,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -80,7 +80,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -90,7 +90,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.mapoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -100,7 +100,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -110,7 +110,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.parent_uuid=03-04
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -120,7 +120,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flogoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -130,7 +130,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out8.log.match
+++ b/src/test/libpmempool_bttdev/out8.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -10,7 +10,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -20,7 +20,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -30,7 +30,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -40,7 +40,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -60,7 +60,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -70,7 +70,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -80,7 +80,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -90,7 +90,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.mapoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -100,7 +100,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -110,7 +110,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.parent_uuid=03-04
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -120,7 +120,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flogoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -130,7 +130,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out9.log.match
+++ b/src/test/libpmempool_bttdev/out9.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -11,7 +11,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -23,7 +23,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -36,7 +36,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -65,7 +65,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -81,7 +81,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -98,7 +98,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -116,7 +116,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -135,7 +135,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -155,7 +155,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
+ ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out9.log.match
+++ b/src/test/libpmempool_bttdev/out9.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -11,7 +11,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -23,7 +23,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -36,7 +36,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -65,7 +65,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -81,7 +81,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -98,7 +98,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -116,7 +116,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -135,7 +135,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -155,7 +155,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_include/TEST0
+++ b/src/test/libpmempool_include/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_map_flog/TEST0
+++ b/src/test/libpmempool_map_flog/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_map_flog/TEST1
+++ b/src/test/libpmempool_map_flog/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_map_flog/TEST2
+++ b/src/test/libpmempool_map_flog/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_map_flog/TEST3
+++ b/src/test/libpmempool_map_flog/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST0
+++ b/src/test/libpmempool_rm/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST1
+++ b/src/test/libpmempool_rm/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST2
+++ b/src/test/libpmempool_rm/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/libpmempool_rm/TEST3
+++ b/src/test/libpmempool_rm/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST4
+++ b/src/test/libpmempool_rm/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST5
+++ b/src/test/libpmempool_rm/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm/TEST6
+++ b/src/test/libpmempool_rm/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm_remote/TEST0
+++ b/src/test/libpmempool_rm_remote/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm_remote/TEST1
+++ b/src/test/libpmempool_rm_remote/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm_remote/TEST2
+++ b/src/test/libpmempool_rm_remote/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm_remote/TEST3
+++ b/src/test/libpmempool_rm_remote/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_rm_remote/config.sh
+++ b/src/test/libpmempool_rm_remote/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/libpmempool_sync/TEST0
+++ b/src/test/libpmempool_sync/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -102,11 +102,11 @@ ROOT_ADDR="$(cat $TMP_FILE | grep "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/libpmempool_sync/TEST0
+++ b/src/test/libpmempool_sync/TEST0
@@ -102,11 +102,11 @@ ROOT_ADDR="$(cat $TMP_FILE | grep "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/libpmempool_sync/TEST1
+++ b/src/test/libpmempool_sync/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_sync/TEST2
+++ b/src/test/libpmempool_sync/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_transform/TEST0
+++ b/src/test/libpmempool_transform/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_transform/TEST1
+++ b/src/test/libpmempool_transform/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/libpmempool_transform/TEST2
+++ b/src/test/libpmempool_transform/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/log_basic/TEST0
+++ b/src/test/log_basic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_basic/TEST1
+++ b/src/test/log_basic/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_basic/TEST2
+++ b/src/test/log_basic/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_basic/TEST3
+++ b/src/test/log_basic/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_basic/TEST4
+++ b/src/test/log_basic/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_basic/TEST5
+++ b/src/test/log_basic/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_basic/TEST6
+++ b/src/test/log_basic/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_basic/TEST7
+++ b/src/test/log_basic/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/log_basic/TEST8
+++ b/src/test/log_basic/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/log_basic/TEST9
+++ b/src/test/log_basic/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/log_include/TEST0
+++ b/src/test/log_include/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST0
+++ b/src/test/log_pool/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST1
+++ b/src/test/log_pool/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST10
+++ b/src/test/log_pool/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST11
+++ b/src/test/log_pool/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST12
+++ b/src/test/log_pool/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST2
+++ b/src/test/log_pool/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST20
+++ b/src/test/log_pool/TEST20
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST21
+++ b/src/test/log_pool/TEST21
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST22
+++ b/src/test/log_pool/TEST22
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST23
+++ b/src/test/log_pool/TEST23
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST24
+++ b/src/test/log_pool/TEST24
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST25
+++ b/src/test/log_pool/TEST25
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST26
+++ b/src/test/log_pool/TEST26
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST27
+++ b/src/test/log_pool/TEST27
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST28
+++ b/src/test/log_pool/TEST28
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST3
+++ b/src/test/log_pool/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST4
+++ b/src/test/log_pool/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST5
+++ b/src/test/log_pool/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST6
+++ b/src/test/log_pool/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST7
+++ b/src/test/log_pool/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool/TEST8
+++ b/src/test/log_pool/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/log_pool/TEST9
+++ b/src/test/log_pool/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/log_pool_lock/TEST0
+++ b/src/test/log_pool_lock/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/log_recovery/TEST0
+++ b/src/test/log_recovery/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/log_recovery/TEST1
+++ b/src/test/log_recovery/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/log_walker/TEST0
+++ b/src/test/log_walker/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/magic/TEST0
+++ b/src/test/magic/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/obj_async_postcommit/TEST0
+++ b/src/test/obj_async_postcommit/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST0
+++ b/src/test/obj_basic_integration/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_basic_integration/TEST1
+++ b/src/test/obj_basic_integration/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -38,7 +38,7 @@ export UNITTEST_NUM=10
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_command $TRACE_CMD
+require_command strace
 require_dax_devices 1
 
 # covered by TEST5
@@ -48,7 +48,7 @@ setup
 
 dax_device_zero
 
-expect_normal_exit $TRACE_CMD -emsync -ostrace$UNITTEST_NUM.log \
+expect_normal_exit strace -emsync -ostrace$UNITTEST_NUM.log \
 	./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
 
 check

--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -38,7 +38,7 @@ export UNITTEST_NUM=10
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_command strace
+require_command $TRACE_CMD
 require_dax_devices 1
 
 # covered by TEST5
@@ -48,7 +48,7 @@ setup
 
 dax_device_zero
 
-expect_normal_exit strace -emsync -ostrace$UNITTEST_NUM.log \
+expect_normal_exit $TRACE_CMD -emsync -ostrace$UNITTEST_NUM.log \
 	./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
 
 check

--- a/src/test/obj_basic_integration/TEST11
+++ b/src/test/obj_basic_integration/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST2
+++ b/src/test/obj_basic_integration/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_basic_integration/TEST3
+++ b/src/test/obj_basic_integration/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST4
+++ b/src/test/obj_basic_integration/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST5
+++ b/src/test/obj_basic_integration/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_basic_integration/TEST6
+++ b/src/test/obj_basic_integration/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_basic_integration/TEST7
+++ b/src/test/obj_basic_integration/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST8
+++ b/src/test/obj_basic_integration/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/TEST9
+++ b/src/test/obj_basic_integration/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_basic_integration/config.sh
+++ b/src/test/obj_basic_integration/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_bucket/TEST0
+++ b/src/test/obj_bucket/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_check/TEST0
+++ b/src/test/obj_check/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_check/TEST1
+++ b/src/test/obj_check/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_check/TEST2
+++ b/src/test/obj_check/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_check/TEST3
+++ b/src/test/obj_check/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).list.redo_log(1).offset=0x1"
@@ -86,7 +86,7 @@ rm -f $DIR/testfile
 
 # Invalid obj_offset - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.obj_offset=$SIZE"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile

--- a/src/test/obj_check/TEST3
+++ b/src/test/obj_check/TEST3
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
+SIZE=$(stat -c%s $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).list.redo_log(1).offset=0x1"
@@ -86,7 +86,7 @@ rm -f $DIR/testfile
 
 # Invalid obj_offset - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
+SIZE=$(stat -c%s $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.obj_offset=$SIZE"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile

--- a/src/test/obj_check/TEST4
+++ b/src/test/obj_check/TEST4
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
+SIZE=$(stat -c%s $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).allocator.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).allocator.redo_log(1).offset=0x1"

--- a/src/test/obj_check/TEST4
+++ b/src/test/obj_check/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STATSIZE_OPT $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).allocator.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).allocator.redo_log(1).offset=0x1"

--- a/src/test/obj_constructor/TEST0
+++ b/src/test/obj_constructor/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_constructor/TEST1
+++ b/src/test/obj_constructor/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_constructor/TEST2
+++ b/src/test/obj_constructor/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_convert/TEST0
+++ b/src/test/obj_convert/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST1
+++ b/src/test/obj_convert/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST11
+++ b/src/test/obj_convert/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST12
+++ b/src/test/obj_convert/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST13
+++ b/src/test/obj_convert/TEST13
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST14
+++ b/src/test/obj_convert/TEST14
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST15
+++ b/src/test/obj_convert/TEST15
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST16
+++ b/src/test/obj_convert/TEST16
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST17
+++ b/src/test/obj_convert/TEST17
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST18
+++ b/src/test/obj_convert/TEST18
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST19
+++ b/src/test/obj_convert/TEST19
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST2
+++ b/src/test/obj_convert/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST3
+++ b/src/test/obj_convert/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/TEST4
+++ b/src/test/obj_convert/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_convert/common.sh
+++ b/src/test/obj_convert/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #
@@ -34,6 +34,7 @@
 #
 # src/test/obj_convert/common.sh -- common part of conversion tool tests
 #
+set -e
 
 # exits in the middle of transaction, so pool cannot be closed
 export MEMCHECK_DONT_CHECK_LEAKS=1

--- a/src/test/obj_cpp_allocator/TEST0
+++ b/src/test/obj_cpp_allocator/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_allocator/TEST1
+++ b/src/test/obj_cpp_allocator/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_cond_var/TEST0
+++ b/src/test/obj_cpp_cond_var/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_cond_var_posix/TEST0
+++ b/src/test/obj_cpp_cond_var_posix/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_cond_var_posix/TEST1
+++ b/src/test/obj_cpp_cond_var_posix/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_cond_var_posix/TEST2
+++ b/src/test/obj_cpp_cond_var_posix/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_deque/TEST0
+++ b/src/test/obj_cpp_deque/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_deque/TEST1
+++ b/src/test/obj_cpp_deque/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_list/TEST0
+++ b/src/test/obj_cpp_list/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_list/TEST1
+++ b/src/test/obj_cpp_list/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_make_persistent/TEST0
+++ b/src/test/obj_cpp_make_persistent/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent/TEST1
+++ b/src/test/obj_cpp_make_persistent/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_array/TEST0
+++ b/src/test/obj_cpp_make_persistent_array/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_array/TEST1
+++ b/src/test/obj_cpp_make_persistent_array/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_array_atomic/TEST0
+++ b/src/test/obj_cpp_make_persistent_array_atomic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_array_atomic/TEST1
+++ b/src/test/obj_cpp_make_persistent_array_atomic/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_atomic/TEST0
+++ b/src/test/obj_cpp_make_persistent_atomic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_make_persistent_atomic/TEST1
+++ b/src/test/obj_cpp_make_persistent_atomic/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_map/TEST0
+++ b/src/test/obj_cpp_map/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_map/TEST1
+++ b/src/test/obj_cpp_map/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_multimap/TEST0
+++ b/src/test/obj_cpp_multimap/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_multimap/TEST1
+++ b/src/test/obj_cpp_multimap/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_multiset/TEST0
+++ b/src/test/obj_cpp_multiset/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_multiset/TEST1
+++ b/src/test/obj_cpp_multiset/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_mutex/TEST0
+++ b/src/test/obj_cpp_mutex/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_mutex_posix/TEST0
+++ b/src/test/obj_cpp_mutex_posix/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_mutex_posix/TEST1
+++ b/src/test/obj_cpp_mutex_posix/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_mutex_posix/TEST2
+++ b/src/test/obj_cpp_mutex_posix/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_p_ext/TEST0
+++ b/src/test/obj_cpp_p_ext/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_p_ext/TEST1
+++ b/src/test/obj_cpp_p_ext/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_cpp_pool/TEST0
+++ b/src/test/obj_cpp_pool/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_pool/TEST1
+++ b/src/test/obj_cpp_pool/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_pool/TEST2
+++ b/src/test/obj_cpp_pool/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_pool/TEST3
+++ b/src/test/obj_cpp_pool/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_pool_primitives/TEST0
+++ b/src/test/obj_cpp_pool_primitives/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_pool_primitives/TEST1
+++ b/src/test/obj_cpp_pool_primitives/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_priority_queue/TEST0
+++ b/src/test/obj_cpp_priority_queue/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_priority_queue/TEST1
+++ b/src/test/obj_cpp_priority_queue/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_ptr/TEST0
+++ b/src/test/obj_cpp_ptr/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_ptr/TEST1
+++ b/src/test/obj_cpp_ptr/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_cpp_ptr_arith/TEST0
+++ b/src/test/obj_cpp_ptr_arith/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_ptr_arith/TEST1
+++ b/src/test/obj_cpp_ptr_arith/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_ptr_arith/TEST2
+++ b/src/test/obj_cpp_ptr_arith/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_queue/TEST0
+++ b/src/test/obj_cpp_queue/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_queue/TEST1
+++ b/src/test/obj_cpp_queue/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_set/TEST0
+++ b/src/test/obj_cpp_set/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_set/TEST1
+++ b/src/test/obj_cpp_set/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_shared_mutex/TEST0
+++ b/src/test/obj_cpp_shared_mutex/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_shared_mutex_posix/TEST0
+++ b/src/test/obj_cpp_shared_mutex_posix/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_shared_mutex_posix/TEST1
+++ b/src/test/obj_cpp_shared_mutex_posix/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_shared_mutex_posix/TEST2
+++ b/src/test/obj_cpp_shared_mutex_posix/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_stack/TEST0
+++ b/src/test/obj_cpp_stack/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_stack/TEST1
+++ b/src/test/obj_cpp_stack/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_timed_mtx/TEST0
+++ b/src/test/obj_cpp_timed_mtx/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_timed_mtx_posix/TEST0
+++ b/src/test/obj_cpp_timed_mtx_posix/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_timed_mtx_posix/TEST1
+++ b/src/test/obj_cpp_timed_mtx_posix/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_timed_mtx_posix/TEST2
+++ b/src/test/obj_cpp_timed_mtx_posix/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_transaction/TEST0
+++ b/src/test/obj_cpp_transaction/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_transaction/TEST1
+++ b/src/test/obj_cpp_transaction/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cpp_unordered_map/TEST0
+++ b/src/test/obj_cpp_unordered_map/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_map/TEST1
+++ b/src/test/obj_cpp_unordered_map/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_multimap/TEST0
+++ b/src/test/obj_cpp_unordered_multimap/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_multimap/TEST1
+++ b/src/test/obj_cpp_unordered_multimap/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_multiset/TEST0
+++ b/src/test/obj_cpp_unordered_multiset/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_multiset/TEST1
+++ b/src/test/obj_cpp_unordered_multiset/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_set/TEST0
+++ b/src/test/obj_cpp_unordered_set/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_unordered_set/TEST1
+++ b/src/test/obj_cpp_unordered_set/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_vector/TEST0
+++ b/src/test/obj_cpp_vector/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_cpp_vector/TEST1
+++ b/src/test/obj_cpp_vector/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_ctl/TEST0
+++ b/src/test/obj_ctl/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_ctl/TEST1
+++ b/src/test/obj_ctl/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_ctl_config/TEST0
+++ b/src/test/obj_ctl_config/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_ctl_config/TEST1
+++ b/src/test/obj_ctl_config/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_ctl_prefault/TEST0
+++ b/src/test/obj_ctl_prefault/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_ctree/TEST0
+++ b/src/test/obj_ctree/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_cuckoo/TEST0
+++ b/src/test/obj_cuckoo/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST0
+++ b/src/test/obj_debug/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST1
+++ b/src/test/obj_debug/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST2
+++ b/src/test/obj_debug/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST3
+++ b/src/test/obj_debug/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_debug/TEST4
+++ b/src/test/obj_debug/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_debug/TEST5
+++ b/src/test/obj_debug/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_direct/TEST0
+++ b/src/test/obj_direct/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_first_next/TEST0
+++ b/src/test/obj_first_next/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_first_next/TEST1
+++ b/src/test/obj_first_next/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_fragmentation/TEST0
+++ b/src/test/obj_fragmentation/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_fragmentation/TEST1
+++ b/src/test/obj_fragmentation/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_fragmentation/TEST2
+++ b/src/test/obj_fragmentation/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_heap/TEST0
+++ b/src/test/obj_heap/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_heap_interrupt/TEST0
+++ b/src/test/obj_heap_interrupt/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_heap_state/TEST0
+++ b/src/test/obj_heap_state/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_heap_state/TEST1
+++ b/src/test/obj_heap_state/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_heap_state/TEST2
+++ b/src/test/obj_heap_state/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_include/TEST0
+++ b/src/test/obj_include/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_lane/TEST0
+++ b/src/test/obj_lane/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_lane/TEST1
+++ b/src/test/obj_lane/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_layout/TEST0
+++ b/src/test/obj_layout/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_insert/TEST0
+++ b/src/test/obj_list_insert/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_insert/TEST1
+++ b/src/test/obj_list_insert/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_insert/TEST2
+++ b/src/test/obj_list_insert/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_insert/TEST3
+++ b/src/test/obj_list_insert/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_insert/TEST4
+++ b/src/test/obj_list_insert/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST0
+++ b/src/test/obj_list_macro/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST1
+++ b/src/test/obj_list_macro/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST2
+++ b/src/test/obj_list_macro/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST3
+++ b/src/test/obj_list_macro/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST4
+++ b/src/test/obj_list_macro/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST5
+++ b/src/test/obj_list_macro/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST6
+++ b/src/test/obj_list_macro/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_macro/TEST7
+++ b/src/test/obj_list_macro/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_move/TEST0
+++ b/src/test/obj_list_move/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_move/TEST1
+++ b/src/test/obj_list_move/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_move/TEST2
+++ b/src/test/obj_list_move/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_recovery/TEST0
+++ b/src/test/obj_list_recovery/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_list_recovery/TEST1
+++ b/src/test/obj_list_recovery/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_list_recovery/TEST2
+++ b/src/test/obj_list_recovery/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_list_remove/TEST0
+++ b/src/test/obj_list_remove/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_remove/TEST1
+++ b/src/test/obj_list_remove/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_remove/TEST2
+++ b/src/test/obj_list_remove/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_valgrind/TEST0
+++ b/src/test/obj_list_valgrind/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_valgrind/TEST1
+++ b/src/test/obj_list_valgrind/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_valgrind/TEST2
+++ b/src/test/obj_list_valgrind/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_valgrind/TEST3
+++ b/src/test/obj_list_valgrind/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_list_valgrind/TEST4
+++ b/src/test/obj_list_valgrind/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_list_valgrind/TEST5
+++ b/src/test/obj_list_valgrind/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_locks/TEST0
+++ b/src/test/obj_locks/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_locks/TEST1
+++ b/src/test/obj_locks/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_locks/TEST2
+++ b/src/test/obj_locks/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_many_size_allocs/TEST0
+++ b/src/test/obj_many_size_allocs/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_many_size_allocs/TEST1
+++ b/src/test/obj_many_size_allocs/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_many_size_allocs/TEST2
+++ b/src/test/obj_many_size_allocs/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_many_size_allocs/TEST3
+++ b/src/test/obj_many_size_allocs/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_memblock/TEST0
+++ b/src/test/obj_memblock/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_memcheck/TEST0
+++ b/src/test/obj_memcheck/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_oid/TEST0
+++ b/src/test/obj_oid/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_out_of_memory/TEST0
+++ b/src/test/obj_out_of_memory/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_out_of_memory/TEST1
+++ b/src/test/obj_out_of_memory/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_out_of_memory/TEST2
+++ b/src/test/obj_out_of_memory/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_persist_count/TEST0
+++ b/src/test/obj_persist_count/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_persist_count/TEST1
+++ b/src/test/obj_persist_count/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_pmalloc_basic/TEST0
+++ b/src/test/obj_pmalloc_basic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pmalloc_mt/TEST0
+++ b/src/test/obj_pmalloc_mt/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_pmalloc_mt/TEST1
+++ b/src/test/obj_pmalloc_mt/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pmalloc_oom_mt/TEST0
+++ b/src/test/obj_pmalloc_oom_mt/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pmalloc_rand_mt/TEST0
+++ b/src/test/obj_pmalloc_rand_mt/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_pmalloc_rand_mt/TEST1
+++ b/src/test/obj_pmalloc_rand_mt/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_pool/TEST0
+++ b/src/test/obj_pool/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST1
+++ b/src/test/obj_pool/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST10
+++ b/src/test/obj_pool/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST11
+++ b/src/test/obj_pool/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST12
+++ b/src/test/obj_pool/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST13
+++ b/src/test/obj_pool/TEST13
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST14
+++ b/src/test/obj_pool/TEST14
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST2
+++ b/src/test/obj_pool/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST20
+++ b/src/test/obj_pool/TEST20
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST21
+++ b/src/test/obj_pool/TEST21
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST22
+++ b/src/test/obj_pool/TEST22
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST23
+++ b/src/test/obj_pool/TEST23
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST24
+++ b/src/test/obj_pool/TEST24
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST25
+++ b/src/test/obj_pool/TEST25
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST26
+++ b/src/test/obj_pool/TEST26
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST27
+++ b/src/test/obj_pool/TEST27
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST28
+++ b/src/test/obj_pool/TEST28
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST29
+++ b/src/test/obj_pool/TEST29
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST3
+++ b/src/test/obj_pool/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST4
+++ b/src/test/obj_pool/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST5
+++ b/src/test/obj_pool/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST6
+++ b/src/test/obj_pool/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool/TEST7
+++ b/src/test/obj_pool/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST8
+++ b/src/test/obj_pool/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_pool/TEST9
+++ b/src/test/obj_pool/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pool_lock/TEST0
+++ b/src/test/obj_pool_lock/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_pool_lookup/TEST0
+++ b/src/test/obj_pool_lookup/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_pvector/TEST0
+++ b/src/test/obj_pvector/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_realloc/TEST0
+++ b/src/test/obj_realloc/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_realloc/TEST1
+++ b/src/test/obj_realloc/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_recovery/TEST0
+++ b/src/test/obj_recovery/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_recovery/TEST1
+++ b/src/test/obj_recovery/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_recovery/TEST2
+++ b/src/test/obj_recovery/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_recovery/TEST3
+++ b/src/test/obj_recovery/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_recovery/TEST4
+++ b/src/test/obj_recovery/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_recovery/TEST5
+++ b/src/test/obj_recovery/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_recovery/TEST6
+++ b/src/test/obj_recovery/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_recovery/TEST7
+++ b/src/test/obj_recovery/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_recovery/TEST8
+++ b/src/test/obj_recovery/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_recreate/TEST0
+++ b/src/test/obj_recreate/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_recreate/TEST1
+++ b/src/test/obj_recreate/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_redo_log/TEST0
+++ b/src/test/obj_redo_log/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_redo_log/TEST1
+++ b/src/test/obj_redo_log/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_redo_log/TEST2
+++ b/src/test/obj_redo_log/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_redo_log/TEST3
+++ b/src/test/obj_redo_log/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_redo_log/TEST4
+++ b/src/test/obj_redo_log/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_redo_log/TEST5
+++ b/src/test/obj_redo_log/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_redo_log/TEST6
+++ b/src/test/obj_redo_log/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_ringbuf/TEST0
+++ b/src/test/obj_ringbuf/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST0
+++ b/src/test/obj_rpmem_basic_integration/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST1
+++ b/src/test/obj_rpmem_basic_integration/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_rpmem_basic_integration/TEST10
+++ b/src/test/obj_rpmem_basic_integration/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST11
+++ b/src/test/obj_rpmem_basic_integration/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST12
+++ b/src/test/obj_rpmem_basic_integration/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST13
+++ b/src/test/obj_rpmem_basic_integration/TEST13
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST14
+++ b/src/test/obj_rpmem_basic_integration/TEST14
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST15
+++ b/src/test/obj_rpmem_basic_integration/TEST15
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST16
+++ b/src/test/obj_rpmem_basic_integration/TEST16
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST17
+++ b/src/test/obj_rpmem_basic_integration/TEST17
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST18
+++ b/src/test/obj_rpmem_basic_integration/TEST18
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST2
+++ b/src/test/obj_rpmem_basic_integration/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST3
+++ b/src/test/obj_rpmem_basic_integration/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST4
+++ b/src/test/obj_rpmem_basic_integration/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST5
+++ b/src/test/obj_rpmem_basic_integration/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST6
+++ b/src/test/obj_rpmem_basic_integration/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST7
+++ b/src/test/obj_rpmem_basic_integration/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_basic_integration/TEST8
+++ b/src/test/obj_rpmem_basic_integration/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/TEST9
+++ b/src/test/obj_rpmem_basic_integration/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_basic_integration/config.sh
+++ b/src/test/obj_rpmem_basic_integration/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_rpmem_heap_interrupt/TEST0
+++ b/src/test/obj_rpmem_heap_interrupt/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_rpmem_heap_interrupt/config.sh
+++ b/src/test/obj_rpmem_heap_interrupt/config.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_heap_state/TEST0
+++ b/src/test/obj_rpmem_heap_state/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_rpmem_heap_state/TEST1
+++ b/src/test/obj_rpmem_heap_state/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_heap_state/TEST2
+++ b/src/test/obj_rpmem_heap_state/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_rpmem_heap_state/config.sh
+++ b/src/test/obj_rpmem_heap_state/config.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_strdup/TEST0
+++ b/src/test/obj_strdup/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_sync/TEST0
+++ b/src/test/obj_sync/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST1
+++ b/src/test/obj_sync/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST2
+++ b/src/test/obj_sync/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST3
+++ b/src/test/obj_sync/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST4
+++ b/src/test/obj_sync/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST5
+++ b/src/test/obj_sync/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST6
+++ b/src/test/obj_sync/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST7
+++ b/src/test/obj_sync/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST8
+++ b/src/test/obj_sync/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017-2017, Intel Corporation
 #

--- a/src/test/obj_sync/TEST9
+++ b/src/test/obj_sync/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_toid/TEST0
+++ b/src/test/obj_toid/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_add_range/TEST0
+++ b/src/test/obj_tx_add_range/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_add_range/TEST1
+++ b/src/test/obj_tx_add_range/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_add_range/TEST2
+++ b/src/test/obj_tx_add_range/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_add_range/config.sh
+++ b/src/test/obj_tx_add_range/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_tx_add_range_direct/TEST0
+++ b/src/test/obj_tx_add_range_direct/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_add_range_direct/TEST1
+++ b/src/test/obj_tx_add_range_direct/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_alloc/TEST0
+++ b/src/test/obj_tx_alloc/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_tx_alloc/TEST1
+++ b/src/test/obj_tx_alloc/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.

--- a/src/test/obj_tx_callbacks/TEST0
+++ b/src/test/obj_tx_callbacks/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_flow/TEST0
+++ b/src/test/obj_tx_flow/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_free/TEST0
+++ b/src/test/obj_tx_free/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_free/TEST1
+++ b/src/test/obj_tx_free/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_invalid/TEST0
+++ b/src/test/obj_tx_invalid/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_lock/TEST0
+++ b/src/test/obj_tx_lock/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_locks/TEST0
+++ b/src/test/obj_tx_locks/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_locks/TEST1
+++ b/src/test/obj_tx_locks/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_locks/TEST2
+++ b/src/test/obj_tx_locks/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_locks_abort/TEST0
+++ b/src/test/obj_tx_locks_abort/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_locks_abort/TEST1
+++ b/src/test/obj_tx_locks_abort/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_locks_abort/TEST2
+++ b/src/test/obj_tx_locks_abort/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/obj_tx_mt/TEST0
+++ b/src/test/obj_tx_mt/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_mt/TEST1
+++ b/src/test/obj_tx_mt/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_mt/config.sh
+++ b/src/test/obj_tx_mt/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/obj_tx_realloc/TEST0
+++ b/src/test/obj_tx_realloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_tx_realloc/TEST1
+++ b/src/test/obj_tx_realloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/obj_tx_strdup/TEST0
+++ b/src/test/obj_tx_strdup/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/obj_tx_strdup/TEST1
+++ b/src/test/obj_tx_strdup/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/out_err/TEST0
+++ b/src/test/out_err/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/out_err_mt/TEST0
+++ b/src/test/out_err_mt/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/out_err_mt/TEST1
+++ b/src/test/out_err_mt/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/out_err_mt/TEST2
+++ b/src/test/out_err_mt/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmem_include/TEST0
+++ b/src/test/pmem_include/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_is_pmem/TEST0
+++ b/src/test/pmem_is_pmem/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem/TEST1
+++ b/src/test/pmem_is_pmem/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem/TEST2
+++ b/src/test/pmem_is_pmem/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem/TEST3
+++ b/src/test/pmem_is_pmem/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem/TEST4
+++ b/src/test/pmem_is_pmem/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem/TEST5
+++ b/src/test/pmem_is_pmem/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 # Copyright (c) 2016, Microsoft Corporation. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/test/pmem_is_pmem_linux/TEST0
+++ b/src/test/pmem_is_pmem_linux/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmem_is_pmem_linux/TEST1
+++ b/src/test/pmem_is_pmem_linux/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmem_is_pmem_linux/TEST2
+++ b/src/test/pmem_is_pmem_linux/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmem_is_pmem_linux/TEST3
+++ b/src/test/pmem_is_pmem_linux/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmem_is_pmem_linux/TEST4
+++ b/src/test/pmem_is_pmem_linux/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmem_map_file/TEST0
+++ b/src/test/pmem_map_file/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_map_file/TEST1
+++ b/src/test/pmem_map_file/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_map_file/TEST2
+++ b/src/test/pmem_map_file/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memcpy/TEST0
+++ b/src/test/pmem_memcpy/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memcpy/TEST1
+++ b/src/test/pmem_memcpy/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memcpy/TEST2
+++ b/src/test/pmem_memcpy/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memcpy/TEST3
+++ b/src/test/pmem_memcpy/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST0
+++ b/src/test/pmem_memmove/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST1
+++ b/src/test/pmem_memmove/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST10
+++ b/src/test/pmem_memmove/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST11
+++ b/src/test/pmem_memmove/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST12
+++ b/src/test/pmem_memmove/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST2
+++ b/src/test/pmem_memmove/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST3
+++ b/src/test/pmem_memmove/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST4
+++ b/src/test/pmem_memmove/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST5
+++ b/src/test/pmem_memmove/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST6
+++ b/src/test/pmem_memmove/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST7
+++ b/src/test/pmem_memmove/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST8
+++ b/src/test/pmem_memmove/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memmove/TEST9
+++ b/src/test/pmem_memmove/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memset/TEST0
+++ b/src/test/pmem_memset/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_memset/TEST1
+++ b/src/test/pmem_memset/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt/TEST0
+++ b/src/test/pmem_movnt/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmem_movnt/TEST1
+++ b/src/test/pmem_movnt/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmem_movnt/TEST2
+++ b/src/test/pmem_movnt/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmem_movnt/TEST3
+++ b/src/test/pmem_movnt/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmem_movnt_align/TEST0
+++ b/src/test/pmem_movnt_align/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST1
+++ b/src/test/pmem_movnt_align/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST2
+++ b/src/test/pmem_movnt_align/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST3
+++ b/src/test/pmem_movnt_align/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST4
+++ b/src/test/pmem_movnt_align/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST5
+++ b/src/test/pmem_movnt_align/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST6
+++ b/src/test/pmem_movnt_align/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_movnt_align/TEST7
+++ b/src/test/pmem_movnt_align/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmem_valgr_simple/TEST0
+++ b/src/test/pmem_valgr_simple/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmemobjcli/TEST0
+++ b/src/test/pmemobjcli/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmemobjcli/TEST1
+++ b/src/test/pmemobjcli/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST0
+++ b/src/test/pmempool_check/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST1
+++ b/src/test/pmempool_check/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST10
+++ b/src/test/pmempool_check/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST11
+++ b/src/test/pmempool_check/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST12
+++ b/src/test/pmempool_check/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST13
+++ b/src/test/pmempool_check/TEST13
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST14
+++ b/src/test/pmempool_check/TEST14
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST15
+++ b/src/test/pmempool_check/TEST15
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014-2017, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -53,10 +53,10 @@ rm -rf $LOG && touch $LOG
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 
-TIME=$($DATE_CMD +"%s")
+TIME=$(date +"%s")
 let "FUTURE_TIME=$TIME+60*60"
 let "PAST_TIME=$TIME-60*60"
-PAST_TIME=$($DATE_CMD -d @$PAST_TIME +"%y%m%d%H%M")
+PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
 $PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
 touch -mt $PAST_TIME $POOL_P1
 

--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #
@@ -53,10 +53,10 @@ rm -rf $LOG && touch $LOG
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 
-TIME=$(date +"%s")
+TIME=$($DATE_CMD +"%s")
 let "FUTURE_TIME=$TIME+60*60"
 let "PAST_TIME=$TIME-60*60"
-PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
+PAST_TIME=$($DATE_CMD -d @$PAST_TIME +"%y%m%d%H%M")
 $PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
 touch -mt $PAST_TIME $POOL_P1
 

--- a/src/test/pmempool_check/TEST17
+++ b/src/test/pmempool_check/TEST17
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST18
+++ b/src/test/pmempool_check/TEST18
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST19
+++ b/src/test/pmempool_check/TEST19
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST2
+++ b/src/test/pmempool_check/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST20
+++ b/src/test/pmempool_check/TEST20
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST21
+++ b/src/test/pmempool_check/TEST21
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST22
+++ b/src/test/pmempool_check/TEST22
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST23
+++ b/src/test/pmempool_check/TEST23
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST24
+++ b/src/test/pmempool_check/TEST24
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST25
+++ b/src/test/pmempool_check/TEST25
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST3
+++ b/src/test/pmempool_check/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST4
+++ b/src/test/pmempool_check/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST5
+++ b/src/test/pmempool_check/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_check/TEST6
+++ b/src/test/pmempool_check/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST7
+++ b/src/test/pmempool_check/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST8
+++ b/src/test/pmempool_check/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/TEST9
+++ b/src/test/pmempool_check/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_check/config.sh
+++ b/src/test/pmempool_check/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_create/TEST0
+++ b/src/test/pmempool_create/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_create/TEST1
+++ b/src/test/pmempool_create/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_create/TEST2
+++ b/src/test/pmempool_create/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_create/TEST3
+++ b/src/test/pmempool_create/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_create/TEST4
+++ b/src/test/pmempool_create/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_create/TEST5
+++ b/src/test/pmempool_create/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_create/TEST6
+++ b/src/test/pmempool_create/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_create/TEST7
+++ b/src/test/pmempool_create/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_dump/TEST0
+++ b/src/test/pmempool_dump/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST1
+++ b/src/test/pmempool_dump/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST2
+++ b/src/test/pmempool_dump/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST3
+++ b/src/test/pmempool_dump/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST4
+++ b/src/test/pmempool_dump/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST5
+++ b/src/test/pmempool_dump/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_dump/TEST6
+++ b/src/test/pmempool_dump/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_help/TEST0
+++ b/src/test/pmempool_help/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_help/TEST1
+++ b/src/test/pmempool_help/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST0
+++ b/src/test/pmempool_info/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST1
+++ b/src/test/pmempool_info/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST10
+++ b/src/test/pmempool_info/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST11
+++ b/src/test/pmempool_info/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST12
+++ b/src/test/pmempool_info/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST13
+++ b/src/test/pmempool_info/TEST13
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST14
+++ b/src/test/pmempool_info/TEST14
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST15
+++ b/src/test/pmempool_info/TEST15
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST16
+++ b/src/test/pmempool_info/TEST16
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST17
+++ b/src/test/pmempool_info/TEST17
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST18
+++ b/src/test/pmempool_info/TEST18
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST19
+++ b/src/test/pmempool_info/TEST19
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_info/TEST2
+++ b/src/test/pmempool_info/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST3
+++ b/src/test/pmempool_info/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST4
+++ b/src/test/pmempool_info/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST5
+++ b/src/test/pmempool_info/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST6
+++ b/src/test/pmempool_info/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST7
+++ b/src/test/pmempool_info/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_info/TEST8
+++ b/src/test/pmempool_info/TEST8
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,10 +52,10 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 1:e 2:w:TEST
 
 INFO_NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | grep 'External LBA count' | grep -o '[0-9]\+')
-NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
+NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
+NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
+NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
+NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
 
 echo "Number of LBAs: $INFO_NLBA" >> $LOG
 echo "Number of LBAs in map: $NLBA" >> $LOG

--- a/src/test/pmempool_info/TEST8
+++ b/src/test/pmempool_info/TEST8
@@ -52,10 +52,10 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 1:e 2:w:TEST
 
 INFO_NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | grep 'External LBA count' | grep -o '[0-9]\+')
-NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
-NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
-NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
-NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | grep -c '[0-9]\+: 0x[0-9]\+.*')
+NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
+NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
+NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
+NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | grep '[0-9]\+: 0x[0-9]\+.*' | wc -l)
 
 echo "Number of LBAs: $INFO_NLBA" >> $LOG
 echo "Number of LBAs in map: $NLBA" >> $LOG

--- a/src/test/pmempool_info/TEST9
+++ b/src/test/pmempool_info/TEST9
@@ -50,7 +50,7 @@ rm -rf $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 INFO_NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | grep 'Free blocks' | grep -o '[0-9]\+')
-NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | grep -co '^[0-9]\+:')
+NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | grep -o '^[0-9]\+:' | wc -l)
 
 [[ $INFO_NFLOG == $NFLOG ]] || exit 1
 

--- a/src/test/pmempool_info/TEST9
+++ b/src/test/pmempool_info/TEST9
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -50,7 +50,7 @@ rm -rf $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 INFO_NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | grep 'Free blocks' | grep -o '[0-9]\+')
-NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | grep -o '^[0-9]\+:' | wc -l)
+NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | grep -co '^[0-9]\+:')
 
 [[ $INFO_NFLOG == $NFLOG ]] || exit 1
 

--- a/src/test/pmempool_info_remote/TEST0
+++ b/src/test/pmempool_info_remote/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST0
+++ b/src/test/pmempool_rm/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST1
+++ b/src/test/pmempool_rm/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST2
+++ b/src/test/pmempool_rm/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST3
+++ b/src/test/pmempool_rm/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_rm/TEST4
+++ b/src/test/pmempool_rm/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST5
+++ b/src/test/pmempool_rm/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST6
+++ b/src/test/pmempool_rm/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/pmempool_rm/TEST7
+++ b/src/test/pmempool_rm/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST0
+++ b/src/test/pmempool_sync/TEST0
@@ -104,11 +104,11 @@ ROOT_ADDR="$(cat $TMP_FILE | grep "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/pmempool_sync/TEST0
+++ b/src/test/pmempool_sync/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -104,11 +104,11 @@ ROOT_ADDR="$(cat $TMP_FILE | grep "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat $STATSIZE_OPT "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/pmempool_sync/TEST1
+++ b/src/test/pmempool_sync/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST10
+++ b/src/test/pmempool_sync/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST11
+++ b/src/test/pmempool_sync/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST12
+++ b/src/test/pmempool_sync/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST2
+++ b/src/test/pmempool_sync/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST3
+++ b/src/test/pmempool_sync/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST4
+++ b/src/test/pmempool_sync/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST5
+++ b/src/test/pmempool_sync/TEST5
@@ -72,8 +72,8 @@ rm -f $DIR/testfile01
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat $STATPERM_OPT $DIR/testfile00 >> $LOG_TEMP
-stat $STATPERM_OPT $DIR/testfile01 >> $LOG_TEMP
+stat -c %A $DIR/testfile00 >> $LOG_TEMP
+stat -c %A $DIR/testfile01 >> $LOG_TEMP
 
 # Delete the first part in the second replica
 rm -f $DIR/testfile10
@@ -85,8 +85,8 @@ chmod 600 $DIR/testfile*
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat $STATPERM_OPT $DIR/testfile10 >> $LOG_TEMP
-stat $STATPERM_OPT $DIR/testfile11 >> $LOG_TEMP
+stat -c %A $DIR/testfile10 >> $LOG_TEMP
+stat -c %A $DIR/testfile11 >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG
 check

--- a/src/test/pmempool_sync/TEST5
+++ b/src/test/pmempool_sync/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -72,8 +72,8 @@ rm -f $DIR/testfile01
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat -c %A $DIR/testfile00 >> $LOG_TEMP
-stat -c %A $DIR/testfile01 >> $LOG_TEMP
+stat $STATPERM_OPT $DIR/testfile00 >> $LOG_TEMP
+stat $STATPERM_OPT $DIR/testfile01 >> $LOG_TEMP
 
 # Delete the first part in the second replica
 rm -f $DIR/testfile10
@@ -85,8 +85,8 @@ chmod 600 $DIR/testfile*
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat -c %A $DIR/testfile10 >> $LOG_TEMP
-stat -c %A $DIR/testfile11 >> $LOG_TEMP
+stat $STATPERM_OPT $DIR/testfile10 >> $LOG_TEMP
+stat $STATPERM_OPT $DIR/testfile11 >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG
 check

--- a/src/test/pmempool_sync/TEST6
+++ b/src/test/pmempool_sync/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST7
+++ b/src/test/pmempool_sync/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST8
+++ b/src/test/pmempool_sync/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync/TEST9
+++ b/src/test/pmempool_sync/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_sync_remote/TEST0
+++ b/src/test/pmempool_sync_remote/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync_remote/TEST1
+++ b/src/test/pmempool_sync_remote/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync_remote/TEST2
+++ b/src/test/pmempool_sync_remote/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync_remote/TEST3
+++ b/src/test/pmempool_sync_remote/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync_remote/TEST4
+++ b/src/test/pmempool_sync_remote/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/pmempool_sync_remote/TEST5
+++ b/src/test/pmempool_sync_remote/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_sync_remote/TEST6
+++ b/src/test/pmempool_sync_remote/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_sync_remote/TEST7
+++ b/src/test/pmempool_sync_remote/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_sync_remote/common.sh
+++ b/src/test/pmempool_sync_remote/common.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #
 # pmempool_sync_remote/common.sh -- pmempool sync with remote replication
 #
+set -e
 
 require_nodes 2
 

--- a/src/test/pmempool_sync_remote/config.sh
+++ b/src/test/pmempool_sync_remote/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST0
+++ b/src/test/pmempool_transform/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST1
+++ b/src/test/pmempool_transform/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST10
+++ b/src/test/pmempool_transform/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST2
+++ b/src/test/pmempool_transform/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST3
+++ b/src/test/pmempool_transform/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST4
+++ b/src/test/pmempool_transform/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST5
+++ b/src/test/pmempool_transform/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST6
+++ b/src/test/pmempool_transform/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST7
+++ b/src/test/pmempool_transform/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST8
+++ b/src/test/pmempool_transform/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform/TEST9
+++ b/src/test/pmempool_transform/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST0
+++ b/src/test/pmempool_transform_remote/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST1
+++ b/src/test/pmempool_transform_remote/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST2
+++ b/src/test/pmempool_transform_remote/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST3
+++ b/src/test/pmempool_transform_remote/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST4
+++ b/src/test/pmempool_transform_remote/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/TEST5
+++ b/src/test/pmempool_transform_remote/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmempool_transform_remote/common.sh
+++ b/src/test/pmempool_transform_remote/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -34,6 +34,7 @@
 # pmempool_transform_remote/common.sh -- commons for pmempool transform tests
 #                                        with remote replication
 #
+set -e
 
 require_nodes 2
 

--- a/src/test/pmempool_transform_remote/config.sh
+++ b/src/test/pmempool_transform_remote/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/pmemspoil/TEST0
+++ b/src/test/pmemspoil/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/remote_basic/TEST0
+++ b/src/test/remote_basic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/remote_basic/TEST1
+++ b/src/test/remote_basic/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/remote_obj_basic/TEST0
+++ b/src/test/remote_obj_basic/TEST0
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST0
+++ b/src/test/remote_obj_basic/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST1
+++ b/src/test/remote_obj_basic/TEST1
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST1
+++ b/src/test/remote_obj_basic/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST2
+++ b/src/test/remote_obj_basic/TEST2
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST2
+++ b/src/test/remote_obj_basic/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST3
+++ b/src/test/remote_obj_basic/TEST3
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST3
+++ b/src/test/remote_obj_basic/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE_CMD +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/rpmem_addr/TEST0
+++ b/src/test/rpmem_addr/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_basic/TEST0
+++ b/src/test/rpmem_basic/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST1
+++ b/src/test/rpmem_basic/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST10
+++ b/src/test/rpmem_basic/TEST10
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST11
+++ b/src/test/rpmem_basic/TEST11
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST2
+++ b/src/test/rpmem_basic/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST3
+++ b/src/test/rpmem_basic/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST4
+++ b/src/test/rpmem_basic/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST5
+++ b/src/test/rpmem_basic/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST6
+++ b/src/test/rpmem_basic/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_basic/TEST7
+++ b/src/test/rpmem_basic/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST8
+++ b/src/test/rpmem_basic/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/TEST9
+++ b/src/test/rpmem_basic/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/common_pm_policy.sh
+++ b/src/test/rpmem_basic/common_pm_policy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -34,6 +34,7 @@
 #
 # src/test/rpmem_basic/common_pm_policy.sh -- common part for TEST[10-11] scripts
 #
+set -e
 
 LOG=rpmemd$UNITTEST_NUM.log
 OUT=out$UNITTEST_NUM.log

--- a/src/test/rpmem_basic/config.sh
+++ b/src/test/rpmem_basic/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_basic/setup.sh
+++ b/src/test/rpmem_basic/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #
 # src/test/rpmem_basic/setup.sh -- common part for TEST* scripts
 #
+set -e
 
 require_nodes 2
 require_node_libfabric 0 $RPMEM_PROVIDER

--- a/src/test/rpmem_basic/setup2to1.sh
+++ b/src/test/rpmem_basic/setup2to1.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/TEST0
+++ b/src/test/rpmem_fip/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/TEST1
+++ b/src/test/rpmem_fip/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/TEST2
+++ b/src/test/rpmem_fip/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/TEST3
+++ b/src/test/rpmem_fip/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/TEST4
+++ b/src/test/rpmem_fip/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/config.sh
+++ b/src/test/rpmem_fip/config.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_fip/setup.sh
+++ b/src/test/rpmem_fip/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #
 # src/test/rpmem_fip/setup.sh -- common setup for rpmem_fip tests
 #
+set -e
 
 require_nodes 2
 require_node_libfabric 0 $RPMEM_PROVIDER

--- a/src/test/rpmem_obc/TEST0
+++ b/src/test/rpmem_obc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST1
+++ b/src/test/rpmem_obc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST2
+++ b/src/test/rpmem_obc/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST3
+++ b/src/test/rpmem_obc/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST4
+++ b/src/test/rpmem_obc/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST5
+++ b/src/test/rpmem_obc/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmem_obc/TEST6
+++ b/src/test/rpmem_obc/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmem_obc/setup.sh
+++ b/src/test/rpmem_obc/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #
 # src/test/rpmem_obc/setup.sh -- common setup for rpmem_obc tests
 #
+set -e
 
 require_nodes 2
 require_node_log_files 1 $RPMEM_LOG_FILE

--- a/src/test/rpmem_obc_int/TEST0
+++ b/src/test/rpmem_obc_int/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmem_proto/TEST0
+++ b/src/test/rpmem_proto/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_config/TEST0
+++ b/src/test/rpmemd_config/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmemd_config/TEST1
+++ b/src/test/rpmemd_config/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_config/TEST2
+++ b/src/test/rpmemd_config/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_config/TEST3
+++ b/src/test/rpmemd_config/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_config/TEST4
+++ b/src/test/rpmemd_config/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/test/rpmemd_db/TEST0
+++ b/src/test/rpmemd_db/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_db/TEST1
+++ b/src/test/rpmemd_db/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_dbg/TEST0
+++ b/src/test/rpmemd_dbg/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_dbg/TEST1
+++ b/src/test/rpmemd_dbg/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_dbg/TEST2
+++ b/src/test/rpmemd_dbg/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_log/TEST0
+++ b/src/test/rpmemd_log/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_log/TEST1
+++ b/src/test/rpmemd_log/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_log/TEST2
+++ b/src/test/rpmemd_log/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_obc/TEST0
+++ b/src/test/rpmemd_obc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_obc/TEST1
+++ b/src/test/rpmemd_obc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_obc/TEST2
+++ b/src/test/rpmemd_obc/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_obc/TEST3
+++ b/src/test/rpmemd_obc/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_obc/TEST4
+++ b/src/test/rpmemd_obc/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmemd_obc/setup.sh
+++ b/src/test/rpmemd_obc/setup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/rpmemd_util/TEST0
+++ b/src/test/rpmemd_util/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/rpmemd_util/TEST1
+++ b/src/test/rpmemd_util/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/scope/TEST0
+++ b/src/test/scope/TEST0
@@ -45,8 +45,6 @@ require_test_type medium
 require_fs_type none
 require_build_type debug
 
-require_vmem
-
 setup
 
 parse_lib() {

--- a/src/test/scope/TEST0
+++ b/src/test/scope/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,6 +44,8 @@ require_test_type medium
 
 require_fs_type none
 require_build_type debug
+
+require_vmem
 
 setup
 

--- a/src/test/scope/TEST1
+++ b/src/test/scope/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/scope/TEST2
+++ b/src/test/scope/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/scope/TEST3
+++ b/src/test/scope/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/scope/TEST4
+++ b/src/test/scope/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/scope/TEST5
+++ b/src/test/scope/TEST5
@@ -45,8 +45,6 @@ require_test_type medium
 require_fs_type none
 require_build_type debug
 
-require_vmem
-
 setup
 
 parse_lib() {

--- a/src/test/scope/TEST5
+++ b/src/test/scope/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,6 +44,8 @@ require_test_type medium
 
 require_fs_type none
 require_build_type debug
+
+require_vmem
 
 setup
 

--- a/src/test/scope/TEST6
+++ b/src/test/scope/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/set_funcs/TEST0
+++ b/src/test/set_funcs/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/sync-remotes/copy-to-remote-nodes.sh
+++ b/src/test/sync-remotes/copy-to-remote-nodes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -31,7 +31,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+#
 # copy-to-remote-nodes.sh -- helper script used to sync remote nodes
+#
+set -e
 
 if [ ! -f ../testconfig.sh ]; then
 	echo "SKIP: testconfig.sh does not exist"

--- a/src/test/traces/TEST0
+++ b/src/test/traces/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST1
+++ b/src/test/traces/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST2
+++ b/src/test/traces/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST3
+++ b/src/test/traces/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST4
+++ b/src/test/traces/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST5
+++ b/src/test/traces/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces/TEST6
+++ b/src/test/traces/TEST6
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces_custom_function/TEST0
+++ b/src/test/traces_custom_function/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces_custom_function/TEST1
+++ b/src/test/traces_custom_function/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/traces_pmem/TEST0
+++ b/src/test/traces_pmem/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/unicode_api/TEST0
+++ b/src/test/unicode_api/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -34,6 +34,7 @@
 #
 # src/test/unicode_api/TEST0 -- unicode C API check
 #
+
 export UNITTEST_NAME=unicode_api/TEST0
 export UNITTEST_NUM=0
 
@@ -70,7 +71,7 @@ function check_file {
 		grep "FunctionDecl.*\(vmem\|pmem\).*char \*" | cut -d " " -f $DEF_COL)
 	for func in $funcs
 	do
-		local good=0
+		local good=1	# Not starting at 0 allows set -e
 		to_check="$dir/*.h $file"
 		if [ -n "${pat:+x}" ] && [[ $func =~ $pat ]]; then
 			continue
@@ -80,8 +81,7 @@ function check_file {
 		do
 			let good+=$(grep -c "$func[UW][ ]*(" $f)
 		done
-
-		if [ $good -ne 2 ]; then
+		if [ $good -ne 3 ]; then
 			echo "Function $func in file $file does not have unicode U/W counterparts"
 			FAILED=1;
 		fi

--- a/src/test/unicode_match_script/TEST0
+++ b/src/test/unicode_match_script/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -30,6 +30,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+set -e
 
 # make sure we have a well defined locale for string operations here
 export LC_ALL="C"
@@ -77,6 +78,29 @@ $DIR_SRC/tools/rpmemd/rpmemd \
 $DIR_SRC/tools/pmempool/pmempool \
 $DIR_SRC/test/tools/ctrld/ctrld \
 $DIR_SRC/test/tools/fip/fip"
+
+# Portability
+if [ "$OSTYPE" = "FreeBSD" ]; then
+	DATE_CMD="gdate"
+	DD_CMD="gdd"
+	VM_OVERCOMMIT="sysctl vm.overcommit"
+	RM_ONEFS_OPT="-x"
+	STATMODE_OPT="-f%Lp"
+	STATPERM_OPT="-f%Sp"
+	STATSIZE_OPT="-f%z"
+	TRACE_CMD="truss"
+	INCLUDE_VMEM="no"
+else
+	DATE_CMD="date"
+	DD_CMD="dd"
+	VM_OVERCOMMIT="cat /proc/sys/vm/overcommit_memory"
+	RM_ONEFS_OPT="--one-file-system"
+	STATMODE_OPT="-c%a"
+	STATPERM_OPT="-c%A"
+	STATSIZE_OPT="-c%s"
+	TRACE_CMD="strace"
+	INCLUDE_VMEM="yes"
+fi
 
 # array of lists of PID files to be cleaned in case of an error
 NODE_PID_FILES[0]=""
@@ -202,28 +226,29 @@ fi
 # The default is to turn on library logging to level 3 and save it to local files.
 # Tests that don't want it on, should override these environment variables.
 #
-export VMEM_LOG_LEVEL=3
+LIBRARY_LOG_LEVEL=3
+export VMEM_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export VMEM_LOG_FILE=vmem$UNITTEST_NUM.log
-export PMEM_LOG_LEVEL=3
+export PMEM_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export PMEM_LOG_FILE=pmem$UNITTEST_NUM.log
-export PMEMBLK_LOG_LEVEL=3
+export PMEMBLK_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export PMEMBLK_LOG_FILE=pmemblk$UNITTEST_NUM.log
-export PMEMLOG_LOG_LEVEL=3
+export PMEMLOG_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export PMEMLOG_LOG_FILE=pmemlog$UNITTEST_NUM.log
-export PMEMOBJ_LOG_LEVEL=3
+export PMEMOBJ_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export PMEMOBJ_LOG_FILE=pmemobj$UNITTEST_NUM.log
-export PMEMPOOL_LOG_LEVEL=3
+export PMEMPOOL_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export PMEMPOOL_LOG_FILE=pmempool$UNITTEST_NUM.log
 
 export VMMALLOC_POOL_DIR="$DIR"
 export VMMALLOC_POOL_SIZE=$((16 * 1024 * 1024))
-export VMMALLOC_LOG_LEVEL=3
+export VMMALLOC_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export VMMALLOC_LOG_FILE=vmmalloc$UNITTEST_NUM.log
 
 export VALGRIND_LOG_FILE=${CHECK_TYPE}${UNITTEST_NUM}.log
 export VALIDATE_VALGRIND_LOG=1
 
-export RPMEM_LOG_LEVEL=3
+export RPMEM_LOG_LEVEL=$LIBRARY_LOG_LEVEL
 export RPMEM_LOG_FILE=rpmem$UNITTEST_NUM.log
 export RPMEMD_LOG_LEVEL=info
 export RPMEMD_LOG_FILE=rpmemd$UNITTEST_NUM.log
@@ -297,13 +322,7 @@ function get_executables() {
 	disable_exit_on_error
 	for c in *
 	do
-		local rights=$(stat -c "%a %F" "$c" 2>/dev/null)
-		if [ "$rights" == "" ]
-		then
-			continue
-		fi
-		local executable=$((${rights:0:1} % 2))
-		if [ "${rights#[0-7]* }" == "regular file" -a $executable -eq 1 ]
+		if [ -f $c -a -x $c ]
 		then
 			echo "$c"
 		fi
@@ -372,7 +391,7 @@ function create_file() {
 	shift
 	for file in $*
 	do
-		dd if=/dev/zero of=$file bs=1M count=$size iflag=count_bytes >> prep$UNITTEST_NUM.log
+		$DD_CMD if=/dev/zero of=$file bs=1M count=$size iflag=count_bytes >> prep$UNITTEST_NUM.log
 	done
 }
 
@@ -391,7 +410,7 @@ function create_nonzeroed_file() {
 	for file in $*
 	do
 		truncate -s ${offset} $file >> prep$UNITTEST_NUM.log
-		dd if=/dev/zero bs=1K count=${size} iflag=count_bytes 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $file
+		$DD_CMD if=/dev/zero bs=1K count=${size} iflag=count_bytes 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $file
 	done
 }
 
@@ -520,12 +539,12 @@ function create_poolset() {
 			;;
 		n)
 			# non-zeroed file
-			dd if=/dev/zero bs=$asize count=1 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $fpath
+			$DD_CMD if=/dev/zero bs=$asize count=1 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $fpath
 			;;
 		h)
 			# non-zeroed file, except 4K header
 			truncate -s 4K $fpath >> prep$UNITTEST_NUM.log
-			dd if=/dev/zero bs=$asize count=1 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $fpath
+			$DD_CMD if=/dev/zero bs=$asize count=1 2>>prep$UNITTEST_NUM.log | tr '\0' '\132' >> $fpath
 			truncate -s $asize $fpath >> prep$UNITTEST_NUM.log
 			;;
 		esac
@@ -809,7 +828,7 @@ function check_pools() {
 # - unlimited virtual memory (ulimit -v is unlimited)
 #
 function require_unlimited_vm() {
-	local overcommit=$(cat /proc/sys/vm/overcommit_memory)
+	local overcommit=$($VM_OVERCOMMIT)
 	local vm_limit=$(ulimit -v)
 	[ "$overcommit" != "2" ] && [ "$vm_limit" = "unlimited" ] && return
 	echo "$UNITTEST_NAME: SKIP required: overcommit_memory enabled and unlimited virtual memory"
@@ -1100,6 +1119,15 @@ function require_node_pkg() {
 	fi
 }
 
+
+#
+# require_vmem -- run test only if libvmem is present
+#
+function require_vmem() {
+	[ "$INCLUDE_VMEM" == "yes" ] && return
+	echo "$UNITTEST_NAME: SKIP no vmem"
+	exit 0
+}
 #
 # configure_valgrind -- only allow script to continue when settings match
 #
@@ -1936,13 +1964,13 @@ function setup() {
 
 	if [ "$FS" != "none" ]; then
 		if [ -d "$DIR" ]; then
-			rm --one-file-system -rf -- $DIR
+			rm $RM_ONEFS_OPT -rf -- $DIR
 		fi
 
 		mkdir -p $DIR
 	fi
 	if [ "$TM" = "1" ]; then
-		start_time=$(date +%s.%N)
+		start_time=$($DATE_CMD +%s.%N)
 	fi
 }
 
@@ -1997,8 +2025,8 @@ function check() {
 #
 function pass() {
 	if [ "$TM" = "1" ]; then
-		end_time=$(date +%s.%N)
-		tm=$(date -d "0 $end_time sec - $start_time sec" +%H:%M:%S.%N | \
+		end_time=$($DATE_CMD +%s.%N)
+		tm=$($DATE_CMD -d "0 $end_time sec - $start_time sec" +%H:%M:%S.%N | \
 			sed -e "s/^00://g" -e "s/^00://g" -e "s/\([0-9]*\)\.\([0-9][0-9][0-9]\).*/\1.\2/")
 		tm="\t\t\t[$tm s]"
 	else
@@ -2008,7 +2036,7 @@ function pass() {
 	[ -t 1 ] && command -v tput >/dev/null && msg="$(tput setaf 2)$msg$(tput sgr0)"
 	echo -e "$UNITTEST_NAME: $msg$tm"
 	if [ "$FS" != "none" ]; then
-		rm --one-file-system -rf -- $DIR
+		rm $RM_ONEFS_OPT -rf -- $DIR
 	fi
 }
 
@@ -2079,7 +2107,7 @@ check_no_files()
 #
 get_size()
 {
-	stat -c%s $1
+	stat $STATSIZE_OPT $1
 }
 
 #
@@ -2087,7 +2115,7 @@ get_size()
 #
 get_mode()
 {
-	stat -c%a $1
+	stat $STATMODE_OPT $1
 }
 
 #
@@ -2129,7 +2157,7 @@ check_signature()
 {
 	local sig=$1
 	local file=$2
-	local file_sig=$(dd if=$file bs=1 count=$SIG_LEN 2>/dev/null | tr -d \\0)
+	local file_sig=$($DD_CMD if=$file bs=1 count=$SIG_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $sig != $file_sig ]]
 	then
@@ -2158,7 +2186,7 @@ check_layout()
 {
 	local layout=$1
 	local file=$2
-	local file_layout=$(dd if=$file bs=1\
+	local file_layout=$($DD_CMD if=$file bs=1\
 		skip=$LAYOUT_OFFSET count=$LAYOUT_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $layout != $file_layout ]]
@@ -2174,7 +2202,7 @@ check_layout()
 check_arena()
 {
 	local file=$1
-	local sig=$(dd if=$file bs=1 skip=$ARENA_OFF count=$ARENA_SIG_LEN 2>/dev/null | tr -d \\0)
+	local sig=$($DD_CMD if=$file bs=1 skip=$ARENA_OFF count=$ARENA_SIG_LEN 2>/dev/null | tr -d \\0)
 
 	if [[ $sig != $ARENA_SIG ]]
 	then
@@ -2363,18 +2391,20 @@ function copy_common_to_remote_nodes() {
 	local NODES_ALL_SEQ=$(seq -s' ' 0 $NODES_ALL_MAX)
 
 	DIR_SYNC=$1
-	[ ! -d $DIR_SYNC ] \
+	if [ "$DIR_SYNC" != "" ]; then
+		[ ! -d $DIR_SYNC ] \
 		&& echo "error: $DIR_SYNC does not exist or is not a directory" >&2 \
 		&& exit 1
+	fi
 
 	# add all libraries to the 'to-copy' list
 	local LIBS_TAR=libs.tar
 	pack_all_libs $LIBS_TAR
 
-	if [ "$(ls $DIR_SYNC)" != "" ]; then
+	if [ "$DIR_SYNC" != "" -a "$(ls $DIR_SYNC)" != "" ]; then
 		FILES_COMMON_DIR="$DIR_SYNC/* $LIBS_TAR"
 	else
-		FILES_COMMON_DIR="$LIBS_TAR"
+		FILES_COMMON_DIR="$FILES_COMMON_DIR $LIBS_TAR"
 	fi
 
 	for N in $NODES_ALL_SEQ; do

--- a/src/test/util_cpuid/TEST0
+++ b/src/test/util_cpuid/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_file_create/TEST0
+++ b/src/test/util_file_create/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_file_create/TEST1
+++ b/src/test/util_file_create/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_file_create/TEST2
+++ b/src/test/util_file_create/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_file_open/TEST0
+++ b/src/test/util_file_open/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_file_open/TEST1
+++ b/src/test/util_file_open/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_is_absolute/TEST0
+++ b/src/test/util_is_absolute/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_is_poolset/TEST0
+++ b/src/test/util_is_poolset/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST0
+++ b/src/test/util_map_proc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST1
+++ b/src/test/util_map_proc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST2
+++ b/src/test/util_map_proc/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST3
+++ b/src/test/util_map_proc/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST4
+++ b/src/test/util_map_proc/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_map_proc/TEST5
+++ b/src/test/util_map_proc/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_parse_size/TEST0
+++ b/src/test/util_parse_size/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset/TEST0
+++ b/src/test/util_poolset/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset/TEST1
+++ b/src/test/util_poolset/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset/TEST2
+++ b/src/test/util_poolset/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset/TEST3
+++ b/src/test/util_poolset/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/util_poolset_foreach/TEST0
+++ b/src/test/util_poolset_foreach/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset_foreach/TEST1
+++ b/src/test/util_poolset_foreach/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset_parse/TEST0
+++ b/src/test/util_poolset_parse/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset_parse/TEST1
+++ b/src/test/util_poolset_parse/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_poolset_parse/TEST2
+++ b/src/test/util_poolset_parse/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/util_poolset_parse/TEST3
+++ b/src/test/util_poolset_parse/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/src/test/util_poolset_size/TEST0
+++ b/src/test/util_poolset_size/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_uuid_generate/TEST0
+++ b/src/test/util_uuid_generate/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_uuid_generate/TEST1
+++ b/src/test/util_uuid_generate/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/util_uuid_generate/TEST2
+++ b/src/test/util_uuid_generate/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_aligned_alloc/TEST0
+++ b/src/test/vmem_aligned_alloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_aligned_alloc/TEST1
+++ b/src/test/vmem_aligned_alloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_calloc/TEST0
+++ b/src/test/vmem_calloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_calloc/TEST1
+++ b/src/test/vmem_calloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_check/TEST0
+++ b/src/test/vmem_check/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_check/TEST1
+++ b/src/test/vmem_check/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_check_allocations/TEST0
+++ b/src/test/vmem_check_allocations/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_check_allocations/TEST1
+++ b/src/test/vmem_check_allocations/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_check_version/TEST0
+++ b/src/test/vmem_check_version/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_create/TEST0
+++ b/src/test/vmem_create/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_create_error/TEST0
+++ b/src/test/vmem_create_error/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_create_in_region/TEST0
+++ b/src/test/vmem_create_in_region/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST0
+++ b/src/test/vmem_custom_alloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST1
+++ b/src/test/vmem_custom_alloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST2
+++ b/src/test/vmem_custom_alloc/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST3
+++ b/src/test/vmem_custom_alloc/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST4
+++ b/src/test/vmem_custom_alloc/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_custom_alloc/TEST5
+++ b/src/test/vmem_custom_alloc/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_delete/TEST0
+++ b/src/test/vmem_delete/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_malloc/TEST0
+++ b/src/test/vmem_malloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_malloc/TEST1
+++ b/src/test/vmem_malloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_malloc/TEST2
+++ b/src/test/vmem_malloc/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_malloc_usable_size/TEST0
+++ b/src/test/vmem_malloc_usable_size/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_malloc_usable_size/TEST1
+++ b/src/test/vmem_malloc_usable_size/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_mix_allocations/TEST0
+++ b/src/test/vmem_mix_allocations/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_mix_allocations/TEST1
+++ b/src/test/vmem_mix_allocations/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_multiple_pools/TEST0
+++ b/src/test/vmem_multiple_pools/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_multiple_pools/TEST1
+++ b/src/test/vmem_multiple_pools/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_multiple_pools/TEST2
+++ b/src/test/vmem_multiple_pools/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_multiple_pools/TEST3
+++ b/src/test/vmem_multiple_pools/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_out_of_memory/TEST0
+++ b/src/test/vmem_out_of_memory/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_out_of_memory/TEST1
+++ b/src/test/vmem_out_of_memory/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_pages_purging/TEST0
+++ b/src/test/vmem_pages_purging/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_pages_purging/TEST1
+++ b/src/test/vmem_pages_purging/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_realloc/TEST0
+++ b/src/test/vmem_realloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_realloc/TEST1
+++ b/src/test/vmem_realloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_realloc_inplace/TEST0
+++ b/src/test/vmem_realloc_inplace/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_realloc_inplace/TEST1
+++ b/src/test/vmem_realloc_inplace/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_stats/TEST0
+++ b/src/test/vmem_stats/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST1
+++ b/src/test/vmem_stats/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST2
+++ b/src/test/vmem_stats/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST3
+++ b/src/test/vmem_stats/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST4
+++ b/src/test/vmem_stats/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST5
+++ b/src/test/vmem_stats/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST6
+++ b/src/test/vmem_stats/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST7
+++ b/src/test/vmem_stats/TEST7
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST8
+++ b/src/test/vmem_stats/TEST8
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_stats/TEST9
+++ b/src/test/vmem_stats/TEST9
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_strdup/TEST0
+++ b/src/test/vmem_strdup/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_strdup/TEST1
+++ b/src/test/vmem_strdup/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmem_valgrind/TEST0
+++ b/src/test/vmem_valgrind/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_valgrind/TEST1
+++ b/src/test/vmem_valgrind/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_valgrind/TEST2
+++ b/src/test/vmem_valgrind/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_valgrind/TEST3
+++ b/src/test/vmem_valgrind/TEST3
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_valgrind/TEST4
+++ b/src/test/vmem_valgrind/TEST4
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmem_valgrind/TEST5
+++ b/src/test/vmem_valgrind/TEST5
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_calloc/TEST0
+++ b/src/test/vmmalloc_calloc/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_check_allocations/TEST0
+++ b/src/test/vmmalloc_check_allocations/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_fork/TEST0
+++ b/src/test/vmmalloc_fork/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_fork/TEST1
+++ b/src/test/vmmalloc_fork/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_fork/TEST2
+++ b/src/test/vmmalloc_fork/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_fork/TEST3
+++ b/src/test/vmmalloc_fork/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_fork/TEST4
+++ b/src/test/vmmalloc_fork/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST0
+++ b/src/test/vmmalloc_init/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST1
+++ b/src/test/vmmalloc_init/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST10
+++ b/src/test/vmmalloc_init/TEST10
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST11
+++ b/src/test/vmmalloc_init/TEST11
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST12
+++ b/src/test/vmmalloc_init/TEST12
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST13
+++ b/src/test/vmmalloc_init/TEST13
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST14
+++ b/src/test/vmmalloc_init/TEST14
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST15
+++ b/src/test/vmmalloc_init/TEST15
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST16
+++ b/src/test/vmmalloc_init/TEST16
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2015-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_init/TEST17
+++ b/src/test/vmmalloc_init/TEST17
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST18
+++ b/src/test/vmmalloc_init/TEST18
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST2
+++ b/src/test/vmmalloc_init/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST3
+++ b/src/test/vmmalloc_init/TEST3
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST4
+++ b/src/test/vmmalloc_init/TEST4
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST5
+++ b/src/test/vmmalloc_init/TEST5
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_init/TEST6
+++ b/src/test/vmmalloc_init/TEST6
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_init/TEST7
+++ b/src/test/vmmalloc_init/TEST7
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_malloc/TEST0
+++ b/src/test/vmmalloc_malloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_malloc_hooks/TEST0
+++ b/src/test/vmmalloc_malloc_hooks/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_malloc_hooks/TEST1
+++ b/src/test/vmmalloc_malloc_hooks/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2015-2016, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_malloc_usable_size/TEST0
+++ b/src/test/vmmalloc_malloc_usable_size/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_memalign/TEST0
+++ b/src/test/vmmalloc_memalign/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_memalign/TEST1
+++ b/src/test/vmmalloc_memalign/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_memalign/TEST2
+++ b/src/test/vmmalloc_memalign/TEST2
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_out_of_memory/TEST0
+++ b/src/test/vmmalloc_out_of_memory/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_realloc/TEST0
+++ b/src/test/vmmalloc_realloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_valgrind/TEST0
+++ b/src/test/vmmalloc_valgrind/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_valgrind/TEST1
+++ b/src/test/vmmalloc_valgrind/TEST1
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_valgrind/TEST2
+++ b/src/test/vmmalloc_valgrind/TEST2
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/src/test/vmmalloc_valloc/TEST0
+++ b/src/test/vmmalloc_valloc/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/vmmalloc_valloc/TEST1
+++ b/src/test/vmmalloc_valloc/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/win_getopt/TEST0
+++ b/src/test/win_getopt/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/win_getopt/TEST1
+++ b/src/test/win_getopt/TEST1
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/win_mmap/TEST0
+++ b/src/test/win_mmap/TEST0
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/test/win_mmap_fixed/TEST0
+++ b/src/test/win_mmap_fixed/TEST0
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/src/tools/pmempool/pmempool.sh
+++ b/src/tools/pmempool/pmempool.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/utils/check-commit.sh
+++ b/utils/check-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/utils/check-doc.sh
+++ b/utils/check-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #

--- a/utils/check-os.sh
+++ b/utils/check-os.sh
@@ -42,7 +42,7 @@ if [[ $2 =~ $EXCLUDE ]]; then
 	exit 0
 fi
 
-symbols=$(nm --demangle --undefined-only --format=posix $2 | sed 's/ U *//g')
+symbols=$(nm -Cuf posix $2 | sed 's/ U *//g')
 functions=$(cat $1 | tr '\n' '|')
 out=$(
 	for sym in $symbols

--- a/utils/check-os.sh
+++ b/utils/check-os.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -42,7 +42,7 @@ if [[ $2 =~ $EXCLUDE ]]; then
 	exit 0
 fi
 
-symbols=$(nm -Cuf posix $2 | sed 's/ U *//g')
+symbols=$(nm --demangle --undefined-only --format=posix $2 | sed 's/ U *//g')
 functions=$(cat $1 | tr '\n' '|')
 out=$(
 	for sym in $symbols

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -145,7 +145,7 @@ for file in $FILES ; do
 	[ ! -f $file ] && continue
 	# ensure that file is UTF-8 encoded
 	ENCODING=`file -b --mime-encoding $file`
-	iconv -f $ENCODING -t "UTF-8" -o $TEMPFILE $file
+	iconv -f $ENCODING -t "UTF-8" $file > $TEMPFILE
 
 	YEARS=`$CHECK_LICENSE check-pattern $PATTERN $TEMPFILE $file`
 	if [ $? -ne 0 ]; then

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -145,7 +145,7 @@ for file in $FILES ; do
 	[ ! -f $file ] && continue
 	# ensure that file is UTF-8 encoded
 	ENCODING=`file -b --mime-encoding $file`
-	iconv -f $ENCODING -t "UTF-8" $file > $TEMPFILE
+	iconv -f $ENCODING -t "UTF-8" -o $TEMPFILE $file
 
 	YEARS=`$CHECK_LICENSE check-pattern $PATTERN $TEMPFILE $file`
 	if [ $? -ne 0 ]; then

--- a/utils/cstyle
+++ b/utils/cstyle
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # CDDL HEADER START
 #
@@ -22,6 +22,8 @@
 #
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
+#
+# Portions copyright 2017, Intel Corporation.
 #
 # @(#)cstyle 1.58 98/09/09 (from shannon)
 #ident	"%Z%%M%	%I%	%E% SMI"
@@ -54,6 +56,7 @@ require 5.0;
 use IO::File;
 use Getopt::Std;
 use strict;
+use warnings;
 
 my $usage =
 "usage: cstyle [-chpvCP] [-o constructs] file ...

--- a/utils/magic-install.sh
+++ b/utils/magic-install.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,6 +32,8 @@
 #
 # magic-install.sh -- Script for installing magic script
 #
+set -e
+
 if ! grep -q "File: nvml" /etc/magic
 then
 	echo "Appending NVML magic to /etc/magic"

--- a/utils/magic-uninstall.sh
+++ b/utils/magic-uninstall.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,6 +32,8 @@
 #
 # magic-uninstall.sh -- Script for uninstalling magic script
 #
+set -e
+
 HDR_LOCAL=$(grep "File: nvml" /etc/magic)
 HDR_PKG=$(grep "File: nvml" /usr/share/nvml/nvml.magic)
 

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-# Copyright 2016, Intel Corporation
+#!/usr/bin/env bash
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,6 +31,8 @@
 #
 # utils/style_check.sh -- common style checking script
 #
+set -e
+
 ARGS=("$@")
 CSTYLE_ARGS=()
 CLANG_ARGS=()


### PR DESCRIPTION
Shell scripts must start with #!/usr/bin/env bash.
Add set -e to top-level scripts.
Use canonical argument/option ordering in command lines.

unittest.sh:
Add LIBRARY_LOG_LEVEL to allow setting of all log levels
at once (can still change individually). Add variables for
commands/options that differ between Linux and FreeBSD. Use
standard test options in get_executables(). Add require_vmem()
function. Fixes in copy_common_to_remote_nodes().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2133)
<!-- Reviewable:end -->
