### PR TITLE
benchmark: fix buffer overflow in rpmem_persist

### DIFF
--- a/src/benchmarks/rpmem_persist.cpp
+++ b/src/benchmarks/rpmem_persist.cpp
@@ -284,11 +284,7 @@ rpmem_poolset_init(const char *path, struct rpmem_bench *mb,
 
 	struct rpmem_pool_attr attr;
 	memset(&attr, 0, sizeof(attr));
-	int ret = snprintf(attr.signature, sizeof(attr.signature), "PMEMBENCH");
-	if (ret < 0) {
-		perror("snprintf");
-		return -1;
-	}
+	memcpy(attr.signature, "PMEMBNCH", sizeof(attr.signature));
 
 	/* read and validate poolset */
 	if (util_poolset_read(&set, path)) {


### PR DESCRIPTION
Ref: pmem/issues#600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2134)
<!-- Reviewable:end -->
