### PR TITLE
common: workaround AppVeyor issues with nuget.org

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
-version: 1.2.{build}
+version: 1.3.{build}
 os: Visual Studio 2015
 platform: x64
 
 init:
+- ps: '[System.IO.File]::AppendAllText("C:\Windows\System32\drivers\etc\hosts", "`n93.184.221.200  api.nuget.org")'
 - ps: write-host "Uninstalling 4014507..."; cmd /c wusa /uninstall /kb:4014507 /quiet /forcerestart
 
 install:


### PR DESCRIPTION
Temporarily redirects nuget to European CDN edge server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2135)
<!-- Reviewable:end -->
