### PR TITLE
make: allow the objcopy and pkg-config to be overridden

### DIFF
--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -214,6 +214,6 @@ sparse:
 PMEMOBJ_SYMBOLS=pmalloc pfree lane_hold lane_release
 
 pmemobj.o: $(LIBS_PATH)/libpmemobj/libpmemobj_unscoped.o
-	objcopy --localize-hidden $(addprefix -G, $(PMEMOBJ_SYMBOLS)) $< $@
+	$(OBJCOPY) --localize-hidden $(addprefix -G, $(PMEMOBJ_SYMBOLS)) $< $@
 
 -include .deps/*.P

--- a/src/common.inc
+++ b/src/common.inc
@@ -34,7 +34,7 @@
 TOP := $(dir $(lastword $(MAKEFILE_LIST)))..
 
 LN = ln
-OBJCOPY = objcopy
+OBJCOPY ?= objcopy
 MKDIR = mkdir
 INSTALL = install
 CP = cp
@@ -45,7 +45,7 @@ CHECK_OS = $(TOP)/utils/check-os.sh
 OS_BANNED = $(TOP)/utils/os-banned
 COVERAGE = 0
 
-PKG_CONFIG = pkg-config
+PKG_CONFIG ?= pkg-config
 CLANG_FORMAT ?= clang-format
 HEADERS = $(wildcard *.h) $(wildcard *.hpp)
 


### PR DESCRIPTION
When building nvml under different environments (ie. buildroot),
the objcopy and pkg-config need to be settable thru the environment
since the gcc, binutils, etc might not match the host during this
build.

This prevents errors on relocation symbols not being understood
by link specically discovered when working on Ubuntu 14.04 and
build 2017.02 to add an nvml package support.

Signed-off-by: Charles Hardin <ckhardin@exablox.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2137)
<!-- Reviewable:end -->
