### PR TITLE
test: fix RUNTESTS.PS1 with '-f any'

### DIFF
--- a/src/test/RUNTESTLIB.PS1
+++ b/src/test/RUNTESTLIB.PS1
@@ -176,7 +176,7 @@ Write-Host "Usage: $name [ -hnv ] [ -b build-type ] [ -t test-type ] [ -f fs-typ
 
 function get_build_dir() {
     param(
-        [ValidateSet(”debug”,”nondebug”)]
+        [ValidateSet("debug", "nondebug")]
         [string]$build
     )
 
@@ -242,15 +242,16 @@ function restore_env_variables {
 #
 function runtest {
     param (
-    [Parameter(ValueFromPipeline = $true, Mandatory=$true)]
+    [Parameter(ValueFromPipeline = $true, Mandatory = $true)]
     [string] $testName,
 
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory = $true)]
     [Config] $config
     )
+
     $Env:UNITTEST_QUIET = 1
 
-    if($config.forcefs) {
+    if ($config.forcefs) {
         $Env:FORCE_FS= 1
     } else {
         $Env:FORCE_FS= 0
@@ -269,7 +270,7 @@ function runtest {
 
     $runscripts = $runscripts.trim()
 
-    if(-not $runscripts) {
+    if (-not $runscripts) {
         return
     }
 
@@ -321,6 +322,6 @@ To create one:
     Copy-Item testconfig.ps1.example testconfig.ps1
 and edit testconfig.ps1 to describe the local machine configuration.
 "
-
 }
+
 . .\testconfig.ps1

--- a/src/test/RUNTESTS.PS1
+++ b/src/test/RUNTESTS.PS1
@@ -187,8 +187,8 @@ try {
         # control loop for receiving job outputs and starting new jobs
         while ($threads -ne 0) {
             if ($Global:stopwatch.Elapsed.TotalSeconds -ge $config.timeout.TotalSeconds) {
-                    Get-Job -name $name | Remove-Job -Force
-                    throw "RUNTESTS: stopping: TIMED OUT"
+                Get-Job -name $name | Remove-Job -Force
+                throw "RUNTESTS: stopping: TIMED OUT"
             }
             Get-Job -name $name | Receive-Job
             Get-Job -name $name | % {
@@ -215,33 +215,33 @@ try {
         }
     } else {
         # if there is no timeout don't run tests in separate thread - usefull for script debugging
-        if($config.timeout.TotalSeconds -eq 0) {
+        if ($config.timeout.TotalSeconds -eq 0) {
             & $sb_ST $PSScriptRoot $config
         } else {
             $job = Start-Job -Name $name -Args $PSScriptRoot, $config -ScriptBlock $sb_ST -Verbose
             $threads++
             while ($Global:stopwatch.Elapsed.TotalSeconds -lt $config.timeout.TotalSeconds -and  $(Get-Job).ChildJobs.Count -ne 0) {
-                    Receive-Job -Job $job
+                Receive-Job -Job $job
 
-                    if ($job.State -eq "Running" -or $job.State -eq "NotStarted") {
-                        sleep -Milliseconds 100
-                        continue
-                    }
-                    if ($job.State -eq "Failed") {
-                        Remove-Job -job $job -Force | out-null
-                        $threads--
-                        throw "one of the tests failed"
-                    }
-
-                    Receive-Job $job
-                    Remove-Job $job -Force
+                if ($job.State -eq "Running" -or $job.State -eq "NotStarted") {
+                    sleep -Milliseconds 100
+                    continue
+                }
+                if ($job.State -eq "Failed") {
+                    Remove-Job -job $job -Force | out-null
                     $threads--
-                    return
+                    throw "one of the tests failed"
+                }
+
+                Receive-Job $job
+                Remove-Job $job -Force
+                $threads--
+                return
             }
 
             if ($Global:stopwatch.Elapsed.TotalSeconds -ge $config.timeout.TotalSeconds) {
-                    Receive-Job -Job $job
-                    throw "TIMED OUT"
+                Receive-Job -Job $job
+                throw "TIMED OUT"
             }
         }
     }

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -714,6 +714,7 @@ function expect_normal_exit() {
 			dump_last_n_lines $PMEMOBJ_LOG_FILE
 			dump_last_n_lines $PMEMLOG_LOG_FILE
 			dump_last_n_lines $PMEMBLK_LOG_FILE
+			dump_last_n_lines $PMEMPOOL_LOG_FILE
 			dump_last_n_lines $VMEM_LOG_FILE
 			dump_last_n_lines $VMMALLOC_LOG_FILE
 			dump_last_n_lines $RPMEM_LOG_FILE


### PR DESCRIPTION
Treat '-f any' as '-f pmem' if $Env:PMEM_FS_DIR is specified.

Plus some minor code cleanup and formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2147)
<!-- Reviewable:end -->
