### PR TITLE
common: gcc sanitize fixes

### DIFF
--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -870,7 +870,7 @@ ut_checksum(uint8_t *addr, size_t len)
 		sum2 = (uint16_t)(sum2 + sum1) % 255;
 	}
 
-	return (uint16_t)(sum2 << 8) | sum1;
+	return (uint16_t)((sum2 << 8) | sum1);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Fix two false positive -Wconversion warnings.

In libpmemblk/btt.c, refactor with internal inline function get_map_lock_num()
that casts multiply/divide result to avoid warning.

In test/unittest/ut.c, apply cast to entire expression to avoid warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2150)
<!-- Reviewable:end -->
