### PR TITLE
libpmemobj/obj.c: chmod for the memory pool

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1261,6 +1261,9 @@ pmemobj_createU(const char *path, const char *layout,
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
+	if (os_chmod(path, mode))
+		goto err;
+
 	util_poolset_fdclose(set);
 
 	LOG(3, "pop %p", pop);


### PR DESCRIPTION
In function pmemobj_creatU, only chmod for the poolset but not for
the pool itself.

Signed-off-by: Xiaodong Jia <jiaxd-fnst@cn.fujitsu.com>
Signed-off-by: Hailin Gu <hailinx.gu@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2151)
<!-- Reviewable:end -->
