### PR TITLE
test/obj_pool: add the umask in TEST30

### DIFF
--- a/src/test/obj_pool/TEST30
+++ b/src/test/obj_pool/TEST30
@@ -44,6 +44,7 @@ export UNITTEST_NUM=30
 require_test_type medium
 
 setup
+umask 0
 
 # create poolset file
 CMD="$DIR/testset"

--- a/src/test/obj_pool/out30.log.match
+++ b/src/test/obj_pool/out30.log.match
@@ -1,4 +1,4 @@
 obj_pool$(nW)TEST30: START: obj_pool$(nW)
  $(nW)obj_pool$(nW) c $(nW)testset test 0 0640
-$(nW)testset: file size $(nW) mode 0644
+$(nW)testset: file size $(nW) mode 0666
 obj_pool$(nW)TEST30: DONE


### PR DESCRIPTION
Testset will be created by the default umask. And it will cause a
fail during match. Setting the umask, and modified the log for
comparison.

Signed-off-by: Xiaodong Jia <jiaxd-fnst@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2155)
<!-- Reviewable:end -->
