### PR TITLE
obj: improve performance of palloc on windows

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -199,8 +199,9 @@ palloc_operation(struct palloc_heap *heap,
 		new_block.size_idx = CALC_SIZE_IDX(c->unit_size,
 			size + header_type_to_size[c->header_type]);
 
-		errno = heap_get_bestfit_block(heap, new_bucket, &new_block);
-		if (errno != 0) {
+		int err = heap_get_bestfit_block(heap, new_bucket, &new_block);
+		if (err != 0) {
+			errno = err;
 			ret = -1;
 			goto out;
 		}

--- a/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
+++ b/src/test/obj_tx_add_range_direct/obj_tx_add_range_direct.c
@@ -549,6 +549,7 @@ do_tx_add_range_too_large(PMEMobjpool *pop)
 	} TX_END
 
 	UT_ASSERTne(errno, 0);
+	errno = 0;
 }
 
 static void
@@ -603,6 +604,7 @@ do_tx_add_cache_overflowing_range(PMEMobjpool *pop)
 	UT_ASSERT(util_is_zeroed(pmemobj_direct(obj), s));
 
 	UT_ASSERTne(errno, 0);
+	errno = 0;
 	pmemobj_free(&obj);
 }
 


### PR DESCRIPTION
this patch improves performance of palloc_operation by ~8% on windows

on windows errno is a function call which is surprisingly heavy....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2156)
<!-- Reviewable:end -->
