### PR TITLE
obj: stop populating buckets at heap init

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -1087,8 +1087,6 @@ heap_buckets_init(struct palloc_heap *heap)
 	if (h->default_bucket == NULL)
 		goto error_bucket_create;
 
-	heap_populate_bucket(heap, h->default_bucket);
-
 	return 0;
 
 error_bucket_create:

--- a/src/test/obj_persist_count/out0.log.match
+++ b/src/test/obj_persist_count/out0.log.match
@@ -1,7 +1,7 @@
 obj_persist_count$(nW)TEST0: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 persist	;msync	;flush	;drain	;task
-0	;15	;0	;0	;pool_create
+0	;13	;0	;0	;pool_create
 0	;8	;0	;0	;root_alloc
 0	;2	;0	;0	;atomic_alloc
 0	;1	;0	;0	;atomic_free

--- a/src/test/obj_persist_count/out1.log.match
+++ b/src/test/obj_persist_count/out1.log.match
@@ -1,7 +1,7 @@
 obj_persist_count$(nW)TEST1: START: obj_persist_count
  $(nW)obj_persist_count$(nW) $(nW)testfile
 persist	;msync	;flush	;drain	;task
-11	;0	;0	;0	;pool_create
+9	;0	;0	;0	;pool_create
 5	;0	;2	;0	;root_alloc
 2	;0	;0	;0	;atomic_alloc
 1	;0	;0	;0	;atomic_free


### PR DESCRIPTION
This makes the first heap zone traversal to happen at the time
of the first allocation. This means that if you want to open the
pool only for reading, you won't ever have to pay this cost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2166)
<!-- Reviewable:end -->
