### PR TITLE
common: allow to run style_check.sh from cmdline

### DIFF
--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -38,6 +38,8 @@ CSTYLE_ARGS=()
 CLANG_ARGS=()
 CHECK_TYPE=$1
 
+[ -z "$clang_format_bin" ] && clang_format_bin=clang-format
+
 #
 # print script usage
 #


### PR DESCRIPTION
Configures $clang_format_bin variable to default value, in case it
was not set by the caller (Makefile).  This allows to run the
style checker script from the command line.

Ref: pmem/issues#618

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2170)
<!-- Reviewable:end -->
