### PR TITLE
test: get rid of error messages in obj_lane

### DIFF
--- a/src/test/obj_lane/TEST0.PS1
+++ b/src/test/obj_lane/TEST0.PS1
@@ -49,7 +49,8 @@ $Env:UNITTEST_NUM = "0"
 require_test_type medium
 
 setup
-expect_normal_exit $Env:EXE_DIR\obj_lane$Env:EXESUFFIX s
+
+expect_normal_exit $Env:EXE_DIR\obj_lane$Env:EXESUFFIX s 2>$null
 
 check
 

--- a/src/test/obj_lane/TEST1.PS1
+++ b/src/test/obj_lane/TEST1.PS1
@@ -49,7 +49,8 @@ $Env:UNITTEST_NUM = "1"
 require_test_type medium
 
 setup
-expect_normal_exit $Env:EXE_DIR\obj_lane$Env:EXESUFFIX m
+
+expect_normal_exit $Env:EXE_DIR\obj_lane$Env:EXESUFFIX m 2>$null
 
 check
 


### PR DESCRIPTION
There is an expected exception (abort) in this test, handled
by the test program.  However, on Windows the error message
is still printed on stderr, so it must be redirected to $null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2174)
<!-- Reviewable:end -->
