### PR TITLE
vmem: fix valgrind instrumentation

### DIFF
--- a/src/test/vmem_valgrind_region/.gitignore
+++ b/src/test/vmem_valgrind_region/.gitignore
@@ -1,0 +1,1 @@
+vmem_valgrind_region

--- a/src/test/vmem_valgrind_region/Makefile
+++ b/src/test/vmem_valgrind_region/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/Makefile -- build vmem_valgrind_region
+# unit test
+#
+TARGET = vmem_valgrind_region
+OBJS =vmem_valgrind_region.o
+
+LIBVMEM=y
+
+include ../Makefile.inc

--- a/src/test/vmem_valgrind_region/TEST0
+++ b/src/test/vmem_valgrind_region/TEST0
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/TEST0 -- unit test for vmem_valgrind_region
+#
+export UNITTEST_NAME=vmem_valgrind_region/TEST0
+export UNITTEST_NUM=0
+
+export VALGRIND_OPTS="--suppressions=excluded-errors.supp --leak-check=full\
+	--show-reachable=yes"
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_build_type debug nondebug
+require_valgrind_dev_version 3.7
+configure_valgrind memcheck force-enable
+
+setup
+
+unset VMEM_LOG_LEVEL
+unset VMEM_LOG_FILE
+
+expect_normal_exit ./vmem_valgrind_region$EXESUFFIX 0
+
+check
+
+pass

--- a/src/test/vmem_valgrind_region/TEST1
+++ b/src/test/vmem_valgrind_region/TEST1
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/TEST1 -- unit test for vmem_valgrind_region
+#
+export UNITTEST_NAME=vmem_valgrind_region/TEST1
+export UNITTEST_NUM=1
+
+export VALGRIND_OPTS="--suppressions=excluded-errors.supp --leak-check=full\
+	--show-reachable=yes"
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_build_type debug nondebug
+require_valgrind_dev_version 3.7
+configure_valgrind memcheck force-enable
+
+setup
+
+unset VMEM_LOG_LEVEL
+unset VMEM_LOG_FILE
+
+expect_normal_exit ./vmem_valgrind_region$EXESUFFIX 1
+
+check
+
+pass

--- a/src/test/vmem_valgrind_region/TEST2
+++ b/src/test/vmem_valgrind_region/TEST2
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/TEST2 -- unit test for vmem_valgrind_region
+#
+export UNITTEST_NAME=vmem_valgrind_region/TEST2
+export UNITTEST_NUM=2
+
+export VALGRIND_OPTS="--suppressions=excluded-errors.supp --leak-check=full\
+	--show-reachable=yes"
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_build_type debug nondebug
+require_valgrind_dev_version 3.7
+configure_valgrind memcheck force-enable
+
+setup
+
+unset VMEM_LOG_LEVEL
+unset VMEM_LOG_FILE
+
+expect_normal_exit ./vmem_valgrind_region$EXESUFFIX 2
+
+check
+
+pass

--- a/src/test/vmem_valgrind_region/TEST3
+++ b/src/test/vmem_valgrind_region/TEST3
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/TEST3 -- unit test for vmem_valgrind_region
+#
+export UNITTEST_NAME=vmem_valgrind_region/TEST3
+export UNITTEST_NUM=3
+
+export VALGRIND_OPTS="--suppressions=excluded-errors.supp --leak-check=full\
+	--show-reachable=yes"
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_build_type debug nondebug
+require_valgrind_dev_version 3.7
+configure_valgrind memcheck force-enable
+
+setup
+
+unset VMEM_LOG_LEVEL
+unset VMEM_LOG_FILE
+
+expect_normal_exit ./vmem_valgrind_region$EXESUFFIX 3
+
+check
+
+pass

--- a/src/test/vmem_valgrind_region/TEST4
+++ b/src/test/vmem_valgrind_region/TEST4
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/vmem_valgrind_region/TEST4 -- unit test for vmem_valgrind_region
+#
+export UNITTEST_NAME=vmem_valgrind_region/TEST4
+export UNITTEST_NUM=4
+
+export VALGRIND_OPTS="--suppressions=excluded-errors.supp --leak-check=full\
+	--show-reachable=yes"
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_build_type debug nondebug
+require_valgrind_dev_version 3.7
+configure_valgrind memcheck force-enable
+
+setup
+
+unset VMEM_LOG_LEVEL
+unset VMEM_LOG_FILE
+
+expect_normal_exit ./vmem_valgrind_region$EXESUFFIX 4
+
+check
+
+pass

--- a/src/test/vmem_valgrind_region/excluded-errors.supp
+++ b/src/test/vmem_valgrind_region/excluded-errors.supp
@@ -1,0 +1,14 @@
+{
+   Bullseye Coverage - Memory leaks
+   Memcheck:Leak
+   ...
+   fun:cov_probe_v12
+   ...
+}
+{
+   vmem_valgrind_region - Ignore uninitialised cond jumps
+   Memcheck:Cond
+   ...
+   fun:do_iterate
+   ...
+}

--- a/src/test/vmem_valgrind_region/memcheck0.log.match
+++ b/src/test/vmem_valgrind_region/memcheck0.log.match
@@ -1,0 +1,15 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 0 bytes in 0 blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)== 
+==$(N)== All heap blocks were freed -- no leaks are possible
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

--- a/src/test/vmem_valgrind_region/memcheck1.log.match
+++ b/src/test/vmem_valgrind_region/memcheck1.log.match
@@ -1,0 +1,26 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 9,807,424 bytes in 8 blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)== 
+==$(N)== 9,807,424 bytes in 8 blocks are definitely lost in loss record 1 of 1
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== LEAK SUMMARY:
+==$(N)==    definitely lost: 9,807,424 bytes in 8 blocks
+==$(N)==    indirectly lost: 0 bytes in 0 blocks
+==$(N)==      possibly lost: 0 bytes in 0 blocks
+==$(N)==    still reachable: 0 bytes in 0 blocks
+==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind_region/memcheck2.log.match
+++ b/src/test/vmem_valgrind_region/memcheck2.log.match
@@ -1,0 +1,36 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== Use of uninitialised value of size 8
+==$(N)==    at 0x$(X): _itoa_word (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vfprintf (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vsnprintf (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vout (ut.c:$(N))
+==$(N)==    by 0x$(X): ut_out (ut.c:$(N))
+==$(N)==    by 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 9,807,424 bytes in 8 blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)== 
+==$(N)== 9,807,424 bytes in 8 blocks are definitely lost in loss record 1 of 1
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== LEAK SUMMARY:
+==$(N)==    definitely lost: 9,807,424 bytes in 8 blocks
+==$(N)==    indirectly lost: 0 bytes in 0 blocks
+==$(N)==      possibly lost: 0 bytes in 0 blocks
+==$(N)==    still reachable: 0 bytes in 0 blocks
+==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+==$(N)== Use --track-origins=yes to see where uninitialised values come from
+==$(N)== ERROR SUMMARY: 42 errors from 2 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind_region/memcheck3.log.match
+++ b/src/test/vmem_valgrind_region/memcheck3.log.match
@@ -1,0 +1,36 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== Invalid read of size 8
+==$(N)==    at 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)==  Address 0x$(X) is 0 bytes inside a block of size $(*) alloc'd
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc (vmem.c:$(N))
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 9,807,424 bytes in 8 blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)== 
+==$(N)== 9,807,424 bytes in 8 blocks are definitely lost in loss record 1 of 1
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== LEAK SUMMARY:
+==$(N)==    definitely lost: 9,807,424 bytes in 8 blocks
+==$(N)==    indirectly lost: 0 bytes in 0 blocks
+==$(N)==      possibly lost: 0 bytes in 0 blocks
+==$(N)==    still reachable: 0 bytes in 0 blocks
+==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --track-origins=yes to see where uninitialised values come from
+==$(N)== ERROR SUMMARY: 9 errors from 2 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind_region/memcheck4.log.match
+++ b/src/test/vmem_valgrind_region/memcheck4.log.match
@@ -1,0 +1,45 @@
+==$(N)== Memcheck, a memory error detector
+==$(N)== Copyright $(*)
+==$(N)== Using $(*)
+==$(N)== Command:$(*)
+==$(N)== Parent PID: $(N)
+==$(N)== 
+==$(N)== Use of uninitialised value of size 8
+==$(N)==    at 0x$(X): _itoa_word (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vfprintf (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vsnprintf (in /usr/lib64/libc-2.24.so)
+==$(N)==    by 0x$(X): vout (ut.c:$(N))
+==$(N)==    by 0x$(X): ut_out (ut.c:$(N))
+==$(N)==    by 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== Invalid read of size 8
+==$(N)==    at 0x$(X): do_iterate (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)==  Address 0x$(X) is 0 bytes inside a block of size $(*) alloc'd
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc (vmem.c:$(N))
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== 
+==$(N)== HEAP SUMMARY:
+==$(N)==     in use at exit: 9,807,424 bytes in 8 blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)== 
+==$(N)== 9,807,424 bytes in 8 blocks are definitely lost in loss record 1 of 1
+==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
+$(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
+==$(N)==    by 0x$(X): do_alloc (vmem_valgrind_region.c:$(N))
+==$(N)==    by 0x$(X): main (vmem_valgrind_region.c:$(N))
+==$(N)== 
+==$(N)== LEAK SUMMARY:
+==$(N)==    definitely lost: 9,807,424 bytes in 8 blocks
+==$(N)==    indirectly lost: 0 bytes in 0 blocks
+==$(N)==      possibly lost: 0 bytes in 0 blocks
+==$(N)==    still reachable: 0 bytes in 0 blocks
+==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)== 
+==$(N)== For counts of detected and suppressed errors, rerun with: -v
+$(OPT)==$(N)== Use --track-origins=yes to see where uninitialised values come from
+==$(N)== ERROR SUMMARY: $(N) errors from 3 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind_region/vmem_valgrind_region.c
+++ b/src/test/vmem_valgrind_region/vmem_valgrind_region.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * vmem_valgrind_region.c -- unit test for vmem_valgrind_region
+ */
+
+#include "unittest.h"
+
+#define POOLSIZE (16 << 20)
+#define CHUNKSIZE (4 << 20)
+#define NOBJS 8
+
+struct foo {
+	size_t size;
+	char data[1]; /* dynamically sized */
+};
+
+static struct foo *objs[NOBJS];
+
+static void
+do_alloc(VMEM *vmp)
+{
+	size_t size = 256;
+	/* allocate objects */
+	for (int i = 0; i < NOBJS; i++) {
+		objs[i] = vmem_malloc(vmp, size + sizeof(size_t));
+		UT_ASSERTne(objs[i], NULL);
+		objs[i]->size = size;
+		memset(objs[i]->data, '0' + i, size - 1);
+		objs[i]->data[size] = '\0';
+		size *= 4;
+	}
+}
+
+static void
+do_iterate(void)
+{
+	/* dump selected objects */
+	for (int i = 0; i < NOBJS; i++)
+		UT_OUT("%p size %zu", objs[i], objs[i]->size);
+}
+
+static void
+do_free(VMEM *vmp)
+{
+	/* free objects */
+	for (int i = 0; i < NOBJS; i++)
+		vmem_free(vmp, objs[i]);
+}
+
+int
+main(int argc, char *argv[])
+{
+	VMEM *vmp;
+
+	START(argc, argv, "vmem_valgrind_region");
+
+	if (argc < 2)
+		UT_FATAL("usage: %s <0..4>", argv[0]);
+
+	int test = atoi(argv[1]);
+
+	/*
+	 * Allocate memory for vmem_create_in_region().
+	 * Reserve more space for test case #4.
+	 */
+	char *addr = MMAP_ANON_ALIGNED(VMEM_MIN_POOL + CHUNKSIZE,
+			CHUNKSIZE);
+
+	vmp = vmem_create_in_region(addr, POOLSIZE);
+	if (vmp == NULL)
+		UT_FATAL("!vmem_create_in_region");
+
+	do_alloc(vmp);
+
+	switch (test) {
+	case 0:
+		/* free objects and delete pool */
+		do_free(vmp);
+		vmem_delete(vmp);
+		break;
+
+	case 1:
+		/* delete pool without freeing objects */
+		vmem_delete(vmp);
+		break;
+
+	case 2:
+		/*
+		 * delete pool without freeing objects
+		 * try to access objects
+		 * expected: use of uninitialized value
+		 */
+		vmem_delete(vmp);
+		do_iterate();
+		break;
+
+	case 3:
+		/*
+		 * delete pool without freeing objects
+		 * re-create pool in the same region
+		 * try to access objects
+		 * expected: invalid read
+		 */
+		vmem_delete(vmp);
+		vmp = vmem_create_in_region(addr, POOLSIZE);
+		if (vmp == NULL)
+			UT_FATAL("!vmem_create_in_region");
+		do_iterate();
+		vmem_delete(vmp);
+		break;
+
+	case 4:
+		/*
+		 * delete pool without freeing objects
+		 * re-create pool in the overlapping region
+		 * try to access objects
+		 * expected: use of uninitialized value & invalid read
+		 */
+		vmem_delete(vmp);
+		vmp = vmem_create_in_region(addr + CHUNKSIZE, POOLSIZE);
+		if (vmp == NULL)
+			UT_FATAL("!vmem_create_in_region");
+		do_iterate();
+		vmem_delete(vmp);
+		break;
+
+	default:
+		UT_FATAL("wrong test case %d", test);
+	}
+
+	MUNMAP(addr, VMEM_MIN_POOL + CHUNKSIZE);
+
+	DONE(NULL);
+}


### PR DESCRIPTION
In case the program creates the pool using vmem_create_in_region(),
the memory region passed to je_vmem_pool_create() should be treated
as addressable, but undefined, even though the program has ininitialized
this memory region before creating the pool.
Once the pool is created, jemalloc will also mark registered free chunks
(usable heap space) as unaddressable.
This hels memcheck to detect accesses to vmem pool memory regions
that were not explicitly allocated via libvmem APIs.

Also, the application cannot do any assumptions about the content
of such memory region after the pool has been destroyed.
So, in vmem_delete() it must be marked as undefined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2175)
<!-- Reviewable:end -->
