### PR TITLE
benchmark: fix perf.cfg script

### DIFF
--- a/src/benchmarks/perf.cfg
+++ b/src/benchmarks/perf.cfg
@@ -2,8 +2,8 @@
 file = testfile
 repeats = 5
 
-# pmemobj_tx_alloc(size = 256, type_num per thread) vs threads
-[obj_tx_alloc_small_v_thread_type_num_per_thread]
+# pmemobj_tx_alloc(size = 256) vs threads
+[obj_tx_alloc_small_v_thread]
 bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 200000
@@ -11,31 +11,13 @@ threads = 1:+1:32
 type-number = per-thread
 data-size = 256
 
-# pmemobj_tx_alloc(size = 128k, type_num per thread) vs threads
-[obj_tx_alloc_huge_v_threads_type_num_per_thread]
+# pmemobj_tx_alloc(size = 128k) vs threads
+[obj_tx_alloc_huge_v_threads]
 bench = obj_tx_alloc
 group = pmemobj
 ops-per-thread = 500
 threads = 1:+1:32
 type-number = per-thread
-data-size = 131072
-
-# pmemobj_tx_alloc(size = 256, type_num per thread) vs threads
-[obj_tx_alloc_small_v_thread_type_num_one]
-bench = obj_tx_alloc
-group = pmemobj
-ops-per-thread = 200000
-threads = 1:+1:32
-type-number = one
-data-size = 256
-
-# pmemobj_tx_alloc(size = 128k, type_num per thread) vs threads
-[obj_tx_alloc_huge_v_threads_type_num_one]
-bench = obj_tx_alloc
-group = pmemobj
-ops-per-thread = 500
-threads = 1:+1:32
-type-number = one
 data-size = 131072
 
 # pmemobj_tx_alloc vs data-size
@@ -72,47 +54,47 @@ threads = 1
 type-number = one
 data-size = 1:*2:32768
 
-# btree_map_insert vs threads
-[obj_btree_map_insert_v_threads]
+# btree_map_insert
+[obj_btree_map_insert]
 bench = map_insert
 group = pmemobj
 ops-per-thread = 10000000
 type = btree
 threads = 1
 
-# ctree_map_insert vs threads
-[obj_ctree_map_insert_v_threads]
+# ctree_map_insert
+[obj_ctree_map_insert]
 bench = map_insert
 group = pmemobj
 ops-per-thread = 10000000
 type = ctree
 threads = 1
 
-# rtree_map_insert vs threads
-[obj_rtree_map_insert_v_threads]
+# rtree_map_insert
+[obj_rtree_map_insert]
 bench = map_insert
 group = pmemobj
-ops-per-thread = 10000000
+ops-per-thread = 1000000
 type = rtree
 threads = 1
 
-# rbtree_map_insert vs threads
-[obj_rbtree_map_insert_v_threads]
+# rbtree_map_insert
+[obj_rbtree_map_insert]
 bench = map_insert
 group = pmemobj
 ops-per-thread = 10000000
 type = rbtree
 threads = 1
 
-# hashmap_tx_map_insert vs threads
-[obj_hashmap_tx_map_insert_v_threads]
+# hashmap_tx_map_insert
+[obj_hashmap_tx_map_insert]
 bench = map_insert
 group = pmemobj
 ops-per-thread = 10000000
 type = hashmap_tx
 threads = 1
 
-# hashmap_atomic_map_insert vs threads
+# hashmap_atomic_map_insert
 [obj_hashmap_atomic_map_insert_v_threads]
 bench = map_insert
 group = pmemobj
@@ -120,7 +102,7 @@ ops-per-thread = 10000000
 type = hashmap_atomic
 threads = 1
 
-#ct pmemblk_write(size = 512, random) vs threads
+# pmemblk_write(size = 512, random) vs threads
 [blk_write_v_threads]
 bench = blk_write
 group = pmemblk


### PR DESCRIPTION
 * removed obsolete benchmarks
 * fixed misleading tests name
 * reduced rtree ops-per-thread (this tree is quite slow)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2180)
<!-- Reviewable:end -->
