### PR TITLE
rpmem: limit max lanes

### DIFF
--- a/src/rpmem_common/rpmem_fip_common.c
+++ b/src/rpmem_common/rpmem_fip_common.c
@@ -310,8 +310,9 @@ rpmem_fip_rx_size(enum rpmem_persist_method pm, enum rpmem_fip_node node)
 size_t
 rpmem_fip_max_nlanes(struct fi_info *fi)
 {
-	return min(fi->domain_attr->max_ep_tx_ctx,
-			fi->domain_attr->max_ep_rx_ctx);
+	return min(min(fi->domain_attr->tx_ctx_cnt,
+			fi->domain_attr->rx_ctx_cnt),
+			fi->domain_attr->cq_cnt);
 }
 
 /*


### PR DESCRIPTION
Limit maximum number of lanes to the optimal number of resources which
includes tx and rx contexts and number of CQ.

Ref: pmem/issues#609

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2181)
<!-- Reviewable:end -->
