### PR TITLE
common: allow inline structs in cstlye

### DIFF
--- a/utils/cstyle
+++ b/utils/cstyle
@@ -668,7 +668,7 @@ line: while (<$filehandle>) {
 	if (/^\s*\(void\)[^ ]/) {
 		err("missing space after (void) cast");
 	}
-	if (/\S\{/ && !/\{\{/) {
+	if (/\S\{/ && !/\{\{/ && !/\(struct \w+\)\{/) {
 		err("missing space before left brace");
 	}
 	if ($in_function && /^\s+{/ &&


### PR DESCRIPTION
The cstyle script (usually) does not allow spaces after
casts. As a side effect, it does not accept the following line:

`return (struct x) {.a = 0, .b = 1};` -> space after cast

At the same time, it did not accept the following line:

`return (struct x){.a = 0, .b = 1};` -> missing space before left brace

This patch resolves the "space after cast/space before left brace" paradox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2183)
<!-- Reviewable:end -->
