### PR TITLE
benchmark: perf.cfg script adjustments

### DIFF
--- a/src/benchmarks/perf.cfg
+++ b/src/benchmarks/perf.cfg
@@ -1,6 +1,6 @@
 [global]
 file = testfile
-repeats = 5
+repeats = 3
 
 # pmemobj_tx_alloc(size = 256) vs threads
 [obj_tx_alloc_small_v_thread]
@@ -90,15 +90,15 @@ threads = 1
 [obj_hashmap_tx_map_insert]
 bench = map_insert
 group = pmemobj
-ops-per-thread = 10000000
+ops-per-thread = 5000000
 type = hashmap_tx
 threads = 1
 
 # hashmap_atomic_map_insert
-[obj_hashmap_atomic_map_insert_v_threads]
+[obj_hashmap_atomic_map_insert]
 bench = map_insert
 group = pmemobj
-ops-per-thread = 10000000
+ops-per-thread = 5000000
 type = hashmap_atomic
 threads = 1
 
@@ -107,7 +107,7 @@ threads = 1
 bench = blk_write
 group = pmemblk
 file-size = 1073741824
-ops-per-thread = 10000000
+ops-per-thread = 1000000
 threads = 1:+1:32
 data-size = 512
 random = true
@@ -117,7 +117,7 @@ random = true
 bench = blk_read
 group = pmemblk
 file-size = 1073741824
-ops-per-thread = 10000000
+ops-per-thread = 1000000
 threads = 1:+1:32
 data-size = 512
 random = true


### PR DESCRIPTION
- reduce ops-per-thread in obj_hashmap_atomic_map_insert to match
  other map benchmarks

- fix misleading name of obj_hashmap_atomic_map_insert

- reduce ops-per-thread in blk-test to decrase run time of these
  benchmarks(was ~3h per blk benchmarks)

- reduce repeat number to limit benchmarks execution time to ~1h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2195)
<!-- Reviewable:end -->
