### PR TITLE
pool: avoid static linking of log.c

### DIFF
--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -790,27 +790,6 @@ pmemlog_checkW(const wchar_t *path)
 }
 #endif
 
-/*
- * log_convert2h -- convert pmemlog structure to host byte order
- */
-void
-log_convert2h(struct pmemlog *plp)
-{
-	plp->start_offset = le64toh(plp->start_offset);
-	plp->end_offset = le64toh(plp->end_offset);
-	plp->write_offset = le64toh(plp->write_offset);
-}
-
-/*
- * log_convert2le -- convert pmemlog structure to LE byte order
- */
-void
-log_convert2le(struct pmemlog *plp)
-{
-	plp->start_offset = htole64(plp->start_offset);
-	plp->end_offset = htole64(plp->end_offset);
-	plp->write_offset = htole64(plp->write_offset);
-}
 
 #ifdef _MSC_VER
 /*

--- a/src/libpmemlog/log.h
+++ b/src/libpmemlog/log.h
@@ -36,6 +36,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <endian.h>
 
 #include "util.h"
 #include "os_thread.h"
@@ -74,5 +75,24 @@ struct pmemlog {
 /* data area starts at this alignment after the struct pmemlog above */
 #define LOG_FORMAT_DATA_ALIGN ((uintptr_t)4096)
 
-void log_convert2h(struct pmemlog *plp);
-void log_convert2le(struct pmemlog *plp);
+/*
+ * log_convert2h -- convert pmemlog structure to host byte order
+ */
+static inline void
+log_convert2h(struct pmemlog *plp)
+{
+	plp->start_offset = le64toh(plp->start_offset);
+	plp->end_offset = le64toh(plp->end_offset);
+	plp->write_offset = le64toh(plp->write_offset);
+}
+
+/*
+ * log_convert2le -- convert pmemlog structure to LE byte order
+ */
+static inline void
+log_convert2le(struct pmemlog *plp)
+{
+	plp->start_offset = htole64(plp->start_offset);
+	plp->end_offset = htole64(plp->end_offset);
+	plp->write_offset = htole64(plp->write_offset);
+}

--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -82,8 +82,6 @@ LIBPMEMBLK_PRIV_FUNCS=btt_info_set btt_arena_datasize btt_flog_size\
 	btt_map_size btt_flog_get_valid map_entry_is_initial btt_info_convert2h\
 	btt_info_convert2le btt_flog_convert2h btt_flog_convert2le
 
-LIBPMEMLOG_PRIV_FUNCS=log_convert2h log_convert2le
-
 include ../Makefile.inc
 
 LIBS += -lpmem -ldl
@@ -92,8 +90,4 @@ CFLAGS += -DUSE_RPMEM
 
 pmemblk_priv_funcs.o: $(PMEMBLK_PRIV_OBJ)
 	$(OBJCOPY) --localize-hidden $(addprefix -G, $(LIBPMEMBLK_PRIV_FUNCS)) \
-	$< $@
-
-pmemlog_priv_funcs.o: $(PMEMLOG_PRIV_OBJ)
-	$(OBJCOPY) --localize-hidden $(addprefix -G, $(LIBPMEMLOG_PRIV_FUNCS)) \
 	$< $@

--- a/src/libpmempool/libpmempool.c
+++ b/src/libpmempool/libpmempool.c
@@ -59,8 +59,8 @@
  *
  * Called automatically by the run-time loader.
  */
-__attribute__((constructor))
-static void
+ATTR_CONSTRUCTOR
+void
 libpmempool_init(void)
 {
 	common_init(PMEMPOOL_LOG_PREFIX, PMEMPOOL_LOG_LEVEL_VAR,
@@ -78,8 +78,8 @@ libpmempool_init(void)
  *
  * Called automatically when the process terminates.
  */
-__attribute__((destructor))
-static void
+ATTR_DESTRUCTOR
+void
 libpmempool_fini(void)
 {
 	LOG(3, NULL);
@@ -436,3 +436,12 @@ pmempool_check_end(PMEMpoolcheck *ppc)
 			return PMEMPOOL_CHECK_RESULT_ERROR;
 	}
 }
+
+
+#ifdef _MSC_VER
+/*
+ * libpmem constructor/destructor functions
+ */
+MSVC_CONSTR(libpmempool_init)
+MSVC_DESTR(libpmempool_fini)
+#endif

--- a/src/libpmempool/libpmempool.vcxproj
+++ b/src/libpmempool/libpmempool.vcxproj
@@ -46,7 +46,6 @@
     <ClCompile Include="..\common\uuid_windows.c" />
     <ClCompile Include="..\libpmemblk\btt.c" />
     <ClCompile Include="..\libpmemlog\libpmemlog.c" />
-    <ClCompile Include="..\libpmemlog\log.c" />
     <ClCompile Include="check.c" />
     <ClCompile Include="check_backup.c" />
     <ClCompile Include="check_btt_info.c" />

--- a/src/libpmempool/libpmempool.vcxproj.filters
+++ b/src/libpmempool/libpmempool.vcxproj.filters
@@ -43,9 +43,6 @@
     <ClCompile Include="libpmempool_main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\libpmemlog\log.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\common\mmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/tools/pmempool/Makefile
+++ b/src/tools/pmempool/Makefile
@@ -50,12 +50,13 @@ LIBPMEMOBJ=y
 LIBPMEMLOG=y
 LIBPMEMPOOL=y
 TOOLS_COMMON=y
-LIBPMEMLOG_PRIV=log_convert2h log_convert2le
+
 LIBPMEMOBJ_PRIV=pvector_new pvector_nvalues pvector_first pvector_next\
 	pvector_delete memblock_from_offset alloc_class_by_id\
 	memblock_rebuild_state alloc_class_get_create_by_unit_size\
 	heap_run_foreach_object alloc_class_collection_new\
 	alloc_class_by_unit_size alloc_class_collection_delete
+
 LIBPMEMBLK_PRIV=btt_init btt_write btt_fini btt_info_convert2h\
 	btt_info_convert2le btt_flog_convert2h btt_flog_convert2le
 


### PR DESCRIPTION
Changes functions required by pmempool to static inline functions
and moves them to log.h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2198)
<!-- Reviewable:end -->
