### PR TITLE
test: FreeBSD portability #3

### DIFF
--- a/src/test/libpmempool_bttdev/TEST0
+++ b/src/test/libpmempool_bttdev/TEST0
@@ -51,7 +51,7 @@ EXE=../libpmempool_api/libpmempool_test
 
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST1
+++ b/src/test/libpmempool_bttdev/TEST1
@@ -54,7 +54,7 @@ expect_normal_exit $BTTCREATE $POOL >> $LOG
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST10
+++ b/src/test/libpmempool_bttdev/TEST10
@@ -55,7 +55,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.checksum=777"\
 	"bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST11
+++ b/src/test/libpmempool_bttdev/TEST11
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(1).btt_info.checksum=777"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.checksum=777"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST2
+++ b/src/test/libpmempool_bttdev/TEST2
@@ -54,11 +54,11 @@ EXE=../libpmempool_api/libpmempool_test
 expect_normal_exit $BTTCREATE $POOL >> $LOG
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info_backup.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 cat $LOG >> $LOG_TEMP
 
 $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 cat $LOG >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG

--- a/src/test/libpmempool_bttdev/TEST3
+++ b/src/test/libpmempool_bttdev/TEST3
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST4
+++ b/src/test/libpmempool_bttdev/TEST4
@@ -59,7 +59,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(0).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST5
+++ b/src/test/libpmempool_bttdev/TEST5
@@ -60,7 +60,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info.sig=ERROR"\
 	"bttdevice.arena(1).btt_info_backup.sig=ERROR"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST6
+++ b/src/test/libpmempool_bttdev/TEST6
@@ -63,7 +63,7 @@ $PMEMSPOIL $POOL "bttdevice.arena(0).btt_info.sig=ERROR"\
 	"bttdevice.arena(2).btt_info_backup.sig=ERROR"\
 	"bttdevice.arena(3).btt_info.checksum=13"
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST7
+++ b/src/test/libpmempool_bttdev/TEST7
@@ -55,7 +55,7 @@ $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\
 		"bttdevice.arena(0).btt_info.major=0x0" >> $LOG
 
-expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt >> $LOG
+expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL >> $LOG
 
 check_file $POOL
 

--- a/src/test/libpmempool_bttdev/TEST8
+++ b/src/test/libpmempool_bttdev/TEST8
@@ -66,7 +66,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
+	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/TEST9
+++ b/src/test/libpmempool_bttdev/TEST9
@@ -65,7 +65,7 @@ do
 	expect_normal_exit $BTTCREATE $POOL
 	$PMEMSPOIL -v $POOL $spcmd >> $LOG_TEMP
 
-	expect_normal_exit $EXE$EXESUFFIX $POOL -r 1 -t btt
+	expect_normal_exit $EXE$EXESUFFIX -r 1 -t btt $POOL
 	cat $LOG >> $LOG_TEMP
 	rm -f POOL
 

--- a/src/test/libpmempool_bttdev/out0.log.match
+++ b/src/test/libpmempool_bttdev/out0.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST0: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 checking BTT Map and Flog

--- a/src/test/libpmempool_bttdev/out1.log.match
+++ b/src/test/libpmempool_bttdev/out1.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST1: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out10.log.match
+++ b/src/test/libpmempool_bttdev/out10.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST10: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out11.log.match
+++ b/src/test/libpmempool_bttdev/out11.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST11: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 1: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?

--- a/src/test/libpmempool_bttdev/out2.log.match
+++ b/src/test/libpmempool_bttdev/out2.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum correct
 arena 0: BTT Info backup checksum incorrect. Do you want to restore it from BTT Info header?
@@ -9,7 +9,7 @@ arena 0: checking BTT Map and Flog
 status = repaired
 libpmempool_bttdev/TEST2: DONE
 libpmempool_bttdev/TEST2: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out3.log.match
+++ b/src/test/libpmempool_bttdev/out3.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST3: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out4.log.match
+++ b/src/test/libpmempool_bttdev/out4.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST4: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out5.log.match
+++ b/src/test/libpmempool_bttdev/out5.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST5: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 can not find any valid BTT Info
 status = not consistent

--- a/src/test/libpmempool_bttdev/out6.log.match
+++ b/src/test/libpmempool_bttdev/out6.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST6: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Do you want to regenerate BTT Info?
 arena 0: regenerating BTT Info header

--- a/src/test/libpmempool_bttdev/out7.log.match
+++ b/src/test/libpmempool_bttdev/out7.log.match
@@ -1,5 +1,5 @@
 libpmempool_bttdev/TEST7: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out8.log.match
+++ b/src/test/libpmempool_bttdev/out8.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -10,7 +10,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -20,7 +20,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -30,7 +30,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -40,7 +40,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -60,7 +60,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -70,7 +70,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -80,7 +80,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -90,7 +90,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.mapoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -100,7 +100,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -110,7 +110,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.parent_uuid=03-04
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -120,7 +120,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flogoff=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -130,7 +130,7 @@ status = repaired
 libpmempool_bttdev/TEST8: DONE
 /$(nW)/test_libpmempool_bttdev8$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST8: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup

--- a/src/test/libpmempool_bttdev/out9.log.match
+++ b/src/test/libpmempool_bttdev/out9.log.match
@@ -1,6 +1,6 @@
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -11,7 +11,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.flags=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -23,7 +23,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.unused=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -36,7 +36,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.major=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -50,7 +50,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.sig=ERROR
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -65,7 +65,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nextoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -81,7 +81,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infosize=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -98,7 +98,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.infooff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -116,7 +116,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.dataoff=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -135,7 +135,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.nfree=7
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup
@@ -155,7 +155,7 @@ libpmempool_bttdev/TEST9: DONE
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.uuid=01-02
 /$(nW)/test_libpmempool_bttdev9$(nW)/file.pool: spoil: bttdevice.arena(0).btt_info.minor=7
 libpmempool_bttdev/TEST9: START: libpmempool_test
- ../libpmempool_api/libpmempool_test$(nW) $(nW) -r 1 -t btt
+ ../libpmempool_api/libpmempool_test$(nW) -r 1 -t btt $(nW)
 checking BTT Info headers
 arena 0: BTT Info header checksum incorrect. Restore BTT Info from backup?
 arena 0: restoring BTT Info header from backup


### PR DESCRIPTION
Use canonical argument ordering in libpmempool_bttdev tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2203)
<!-- Reviewable:end -->
