### PR TITLE
pmem: Use clflushopt and clwb intrinsics

### DIFF
--- a/src/libpmem/Makefile
+++ b/src/libpmem/Makefile
@@ -50,6 +50,11 @@ SOURCE =\
 	pmem.c\
 	pmem_linux.c
 
+# The corresponding intrinsics are only exposed in the headers
+# when (cross) compiling for a target CPU where the instructions are available.
+CFLAGS += -mclflushopt
+CFLAGS += -mclwb
+
 include ../Makefile.inc
 
 LIBS += -pthread

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -170,7 +170,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <emmintrin.h>
+#include <x86intrin.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -191,15 +191,6 @@
 #include "valgrind_internal.h"
 
 #ifndef _MSC_VER
-/*
- * The x86 memory instructions are new enough that the compiler
- * intrinsic functions are not always available.  The intrinsic
- * functions are defined here in terms of asm statements for now.
- */
-#define _mm_clflushopt(addr)\
-	asm volatile(".byte 0x66; clflush %0" : "+m" (*(volatile char *)addr));
-#define _mm_clwb(addr)\
-	asm volatile(".byte 0x66; xsaveopt %0" : "+m" (*(volatile char *)addr));
 
 #endif /* _MSC_VER */
 


### PR DESCRIPTION
Also, include x86intrin.h header, to get all x86 intrinsics,
instead of using only some of the multimedia intrinsics.

I don't recall exactly how old toolchains must be supported, I just see header files `clflushoptintrin.h` and `clwbintrin.h` on my machine, containing copyright dates "2013-2016". And 2013 was 4 years ago.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2207)
<!-- Reviewable:end -->
