### PR TITLE
common: FreeBSD portability #4

### DIFF
--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -44,9 +44,7 @@
 #include <dirent.h>
 #include <err.h>
 #include <getopt.h>
-#ifndef __FreeBSD__
 #include <linux/limits.h>
-#endif
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -44,7 +44,9 @@
 #include <dirent.h>
 #include <err.h>
 #include <getopt.h>
+#ifndef __FreeBSD__
 #include <linux/limits.h>
+#endif
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/src/common/file.c
+++ b/src/common/file.c
@@ -44,7 +44,7 @@
 #include <sys/file.h>
 #include <sys/mman.h>
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__FreeBSD__)
 #include <sys/sysmacros.h>
 #endif
 

--- a/src/common/file.h
+++ b/src/common/file.h
@@ -43,6 +43,7 @@ extern "C" {
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #define NAME_MAX _MAX_FNAME

--- a/src/examples/libpmemobj/libart/arttree.c
+++ b/src/examples/libpmemobj/libart/arttree.c
@@ -52,6 +52,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <strings.h>
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/src/examples/libpmemobj/libart/arttree_structures.c
+++ b/src/examples/libpmemobj/libart/arttree_structures.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2016, FUJITSU TECHNOLOGY SOLUTIONS GMBH
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,6 +48,9 @@
  * ===========================================================================
  */
 
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <fcntl.h>
 #include <libgen.h>

--- a/src/examples/libpmemobj/panaconda/panaconda.cpp
+++ b/src/examples/libpmemobj/panaconda/panaconda.cpp
@@ -33,12 +33,19 @@
 /*
  * panaconda.cpp -- example of usage c++ bindings in nvml
  */
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <cstdlib>
 #include <ctime>
 #include <getopt.h>
 #include <iostream>
-#include <ncurses.h>
 #include <stdio.h>
+#ifdef __FreeBSD__
+#include <ncurses/ncurses.h> /* Need pkg, not system, version */
+#else
+#include <ncurses.h>
+#endif
 #include <stdlib.h>
 
 #include "panaconda.hpp"

--- a/src/examples/libpmemobj/pman/pman.cpp
+++ b/src/examples/libpmemobj/pman/pman.cpp
@@ -40,7 +40,11 @@
 #include <libpmemobj++/make_persistent_array.hpp>
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
+#ifdef __FreeBSD__
+#include <ncurses/ncurses.h> /* Need pkg, not system, version */
+#else
 #include <ncurses.h>
+#endif
 
 #define LAYOUT_NAME "pman"
 #define SIZE 40

--- a/src/examples/libpmemobj/pminvaders/pminvaders.c
+++ b/src/examples/libpmemobj/pminvaders/pminvaders.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,11 @@
  */
 
 #include <stddef.h>
+#ifdef __FreeBSD__
+#include <ncurses/ncurses.h>	/* Need pkg, not system, version */
+#else
 #include <ncurses.h>
+#endif
 #include <unistd.h>
 #include <time.h>
 #include <stdlib.h>

--- a/src/examples/libpmemobj/pminvaders/pminvaders2.c
+++ b/src/examples/libpmemobj/pminvaders/pminvaders2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016, Intel Corporation
+ * Copyright 2015-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,11 @@
  */
 
 #include <stddef.h>
+#ifdef __FreeBSD__
+#include <ncurses/ncurses.h>	/* Need pkg, not system, version */
+#else
 #include <ncurses.h>
+#endif
 #include <unistd.h>
 #include <time.h>
 #include <stdlib.h>

--- a/src/examples/libvmem/libart/arttree.c
+++ b/src/examples/libvmem/libart/arttree.c
@@ -55,6 +55,9 @@
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>

--- a/src/include/libpmemobj++/pool.hpp
+++ b/src/include/libpmemobj++/pool.hpp
@@ -39,6 +39,7 @@
 #define PMEMOBJ_POOL_HPP
 
 #include <stddef.h>
+#include <string>
 #include <sys/stat.h>
 
 #include "libpmemobj++/detail/pexceptions.hpp"

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -128,11 +128,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdint.h>
-#ifdef __FreeBSD__
-#include <sys/endian.h>
-#else
 #include <endian.h>
-#endif
 
 #include "out.h"
 #include "uuid.h"

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -43,7 +43,12 @@
 
 #ifndef _WIN32
 #include <sys/ioctl.h>
+#ifdef __FreeBSD__
+#include <sys/disk.h>
+#define BLKGETSIZE64 DIOCGMEDIASIZE
+#else
 #include <linux/fs.h>
+#endif
 #endif
 
 #include "libpmem.h"

--- a/src/librpmem/rpmem_cmd.c
+++ b/src/librpmem/rpmem_cmd.c
@@ -42,6 +42,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#include <signal.h>
 
 #include "util.h"
 #include "out.h"

--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -40,6 +40,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #include "util.h"
 #include "os.h"

--- a/src/rpmem_common/rpmem_common.h
+++ b/src/rpmem_common/rpmem_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@
 #define RPMEM_ACCEPT_TIMEOUT 30000
 #define RPMEM_CONNECT_TIMEOUT 30000
 
+#include <stdint.h>
 #include <sys/socket.h>
 #include <netdb.h>
 

--- a/src/test/blk_recovery/blk_recovery.c
+++ b/src/test/blk_recovery/blk_recovery.c
@@ -44,7 +44,7 @@
 
 #include "blk.h"
 #include "btt_layout.h"
-#include "endian.h"
+#include <endian.h>
 
 static size_t Bsize;
 

--- a/src/test/bttdevice/TEST0
+++ b/src/test/bttdevice/TEST0
@@ -49,15 +49,15 @@ LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
 echo "Create btt device - uuid defined by the user" >> $LOG
-expect_normal_exit $BTTCREATE $POOL -s 20M -b 1K -l 256\
-		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v >> $LOG
+expect_normal_exit $BTTCREATE -s 20M -b 1K -l 256 \
+		-u "9047cad6-53e1-4ba8-bcdd-a9fb411f7392" -v $POOL >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL
 rm -rf $POOL
 
 echo -e "\nCreate btt device - automatic uuid generation" >> $LOG
-expect_normal_exit $BTTCREATE $POOL -s 40M -b 2K -l 256 -v >> $LOG
+expect_normal_exit $BTTCREATE -s 40M -b 2K -l 256 -v $POOL >> $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL >> $LOG
 check_file $POOL

--- a/src/test/bttdevice/TEST1
+++ b/src/test/bttdevice/TEST1
@@ -48,7 +48,7 @@ POOL=$DIR/file.pool
 LOG=out${UNITTEST_NUM}.log
 rm -rf $LOG && touch $LOG
 
-expect_normal_exit $BTTCREATE $POOL -v >> $LOG
+expect_normal_exit $BTTCREATE -v $POOL >> $LOG
 
 $PMEMSPOIL -v $POOL "bttdevice.arena(0).btt_info.sig=BADSIGNATURE"\
 		"bttdevice.arena(0).btt_info.external_lbasize=10"\

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -34,7 +34,9 @@
  * spoil.c -- pmempool spoil command source file
  */
 #include <features.h>
+#ifndef __FreeBSD__
 #define __USE_UNIX98
+#endif
 #include <unistd.h>
 #include <stdio.h>
 #include <getopt.h>

--- a/src/tools/pmempool/info.c
+++ b/src/tools/pmempool/info.c
@@ -45,7 +45,9 @@
 #include <inttypes.h>
 #include <assert.h>
 #include <sys/param.h>
+#ifndef __FreeBSD__
 #define __USE_UNIX98
+#endif
 #include <unistd.h>
 #include <sys/mman.h>
 

--- a/src/tools/rpmemd/rpmemd_log.c
+++ b/src/tools/rpmemd/rpmemd_log.c
@@ -34,7 +34,12 @@
  * rpmemd_log.c -- rpmemd logging functions definitions
  */
 /* for GNU version of basename */
+/* XXX Consider changing to Posix basename for consistency */
+#ifdef __FreeBSD__
+#include <libgen.h>
+#else
 #define _GNU_SOURCE
+#endif
 #include <errno.h>
 #include <stdio.h>
 #include <syslog.h>

--- a/utils/check-os.sh
+++ b/utils/check-os.sh
@@ -42,7 +42,7 @@ if [[ $2 =~ $EXCLUDE ]]; then
 	exit 0
 fi
 
-symbols=$(nm -Cuf posix $2 | sed 's/ U *//g')
+symbols=$(nm --demangle --undefined-only --format=posix $2 | sed 's/ U *//g')
 functions=$(cat $1 | tr '\n' '|')
 out=$(
 	for sym in $symbols

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -145,7 +145,7 @@ for file in $FILES ; do
 	[ ! -f $file ] && continue
 	# ensure that file is UTF-8 encoded
 	ENCODING=`file -b --mime-encoding $file`
-	iconv -f $ENCODING -t "UTF-8" -o $TEMPFILE $file
+	iconv -f $ENCODING -t "UTF-8" $file > $TEMPFILE
 
 	YEARS=`$CHECK_LICENSE check-pattern $PATTERN $TEMPFILE $file`
 	if [ $? -ne 0 ]; then

--- a/utils/check_license/check-license.c
+++ b/utils/check_license/check-license.c
@@ -45,6 +45,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #define LICENSE_MAX_LEN		2048
 #define COPYRIGHT		"Copyright "


### PR DESCRIPTION
These non-invasive changes are intended to reduce the
size of the main FreeBSD port commit.

Change #includes and add #ifdefs for FreeBSD, for files
where there are otherwise no code changes.
Canonicalize arguments for test/bttdevice.
Use common options in utils/check-os.sh.
Use redirect rather than unsupported -o option in
utils/check_license/check-headers.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2208)
<!-- Reviewable:end -->
