### PR TITLE
doc: sockets provider does not support IPv6

### DIFF
--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -513,7 +513,12 @@ be required normally.
 + **RPMEM_ENABLE_SOCKETS**=0\|1
 
 Setting this variable to 1 enables using **fi_sockets**(7) provider for
-in-band RDMA connection. By default the *sockets* provider is disabled.
+in-band RDMA connection. The *sockets* provider does not support IPv6.
+It is required to disable IPv6 system wide if **RPMEM_ENABLE_SOCKETS** == 1 and
+*target* == localhost (or any other loopback interface address) and
+**SSH_CONNECTION** variable (see **ssh**(1) for more details) contains IPv6
+address after ssh to loopback interface. By default the *sockets* provider is
+disabled.
 
 * **RPMEM_ENABLE_VERBS**=0\|1
 


### PR DESCRIPTION
We are using **SSH_CONNECTION** variable (see **ssh**(1)). It happens IPv6 address pop out there when ssh to loopback interface (even if other loopback interface address is used explicitly). I wrote about this because it took a bit to debug the issue. Maybe it will save somebody few minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2210)
<!-- Reviewable:end -->
