### PR TITLE
common: fix dependencies for Debian's dev packages

### DIFF
--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -149,7 +149,7 @@ Description: NVML librpmem library
 Package: librpmem-dev
 Section: libdevel
 Architecture: any
-Depends: librpmem (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
+Depends: librpmem (=\${binary:Version}), libpmem-dev, \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for librpmem
  Development files for librpmem library.
 
@@ -250,7 +250,7 @@ Description: NVML libpmemblk library
 Package: libpmemblk-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemblk (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemblk (=\${binary:Version}), libpmem-dev, \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemblk
  Development files for libpmemblk library.
 
@@ -263,7 +263,7 @@ Description: NVML libpmemlog library
 Package: libpmemlog-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemlog (=\${binary:Version}),  \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemlog (=\${binary:Version}), libpmem-dev,  \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemlog
  Development files for libpmemlog library.
 
@@ -276,7 +276,7 @@ Description: NVML libpmemobj library
 Package: libpmemobj-dev
 Section: libdevel
 Architecture: any
-Depends: libpmemobj (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmemobj (=\${binary:Version}), libpmem-dev, \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmemobj
  Development files for libpmemobj library.
 
@@ -289,7 +289,7 @@ Description: NVML libpmempool library
 Package: libpmempool-dev
 Section: libdevel
 Architecture: any
-Depends: libpmempool (=\${binary:Version}), \${shlibs:Depends}, \${misc:Depends}
+Depends: libpmempool (=\${binary:Version}), libpmem-dev, \${shlibs:Depends}, \${misc:Depends}
 Description: Development files for libpmempool
  Development files for libpmempool library.
 


### PR DESCRIPTION
Development packages for libraries that depend on libpmem need to depend
on libpmem-dev.

Without that pkg-config can't find those libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2215)
<!-- Reviewable:end -->
