### PR TITLE
benchmark: add memcpy operation to blk

### DIFF
--- a/src/benchmarks/perf.cfg
+++ b/src/benchmarks/perf.cfg
@@ -110,7 +110,7 @@ file-size = 1073741824
 ops-per-thread = 1000000
 threads = 1:+1:32
 data-size = 512
-random = true
+mode = rand
 
 # pmemblk_read(size = 512, random) vs threads
 [blk_read_v_threads]
@@ -120,7 +120,7 @@ file-size = 1073741824
 ops-per-thread = 1000000
 threads = 1:+1:32
 data-size = 512
-random = true
+mode = rand
 
 # log_append vs data-size
 [log_append_v_data_size]

--- a/src/benchmarks/pmembench_blk.cfg
+++ b/src/benchmarks/pmembench_blk.cfg
@@ -8,8 +8,8 @@ ops-per-thread=1000
 # from 1 to 32
 [blk_blk_read_threads]
 bench = blk_read
-random = true
-file-io = false
+mode = rand
+operation = blk
 file-size = 536870912
 threads = 1:+1:32
 data-size = 512
@@ -18,8 +18,8 @@ data-size = 512
 # from 1 to 32
 [blk_non_blk_read_threads]
 bench = blk_read
-random = true
-file-io = true
+mode = rand
+operation = file
 file-size = 536870912
 threads = 1:+1:32
 data-size = 512
@@ -28,8 +28,8 @@ data-size = 512
 # from 512 to 1048576 bytes
 [blk_blk_read_data_size]
 bench = blk_read
-random = true
-file-io = false
+mode = rand
+operation = blk
 threads = 1
 data-size = 512:*2:524288
 file-size = 536870912
@@ -38,8 +38,8 @@ file-size = 536870912
 # from 512 to 1048576 bytes
 [blk_non_blk_read_data_size]
 bench = blk_read
-random = true
-file-io = true
+mode = rand
+operation = file
 threads = 1
 data-size = 512:*2:524288
 file-size = 536870912
@@ -48,8 +48,8 @@ file-size = 536870912
 # from 1 to 32
 [blk_blk_write_threads]
 bench = blk_write
-random = true
-file-io = false
+mode = rand
+operation = blk
 file-size = 536870912
 threads = 1:+1:32
 data-size = 512
@@ -58,8 +58,8 @@ data-size = 512
 # from 1 to 32
 [blk_non_blk_write_threads]
 bench = blk_write
-random = true
-file-io = true
+mode = rand
+operation = file
 file-size = 536870912
 threads = 1:+1:32
 data-size = 512
@@ -68,8 +68,8 @@ data-size = 512
 # from 512 to 1048576 bytes
 [blk_blk_write_data_size]
 bench = blk_write
-random = false
-file-io = false
+mode = seq
+operation = blk
 threads = 1
 data-size = 512:*2:524288
 file-size = 536870912
@@ -78,8 +78,8 @@ file-size = 536870912
 # from 512 to 1048576 bytes
 [blk_non_blk_write_data_size]
 bench = blk_write
-random = false
-file-io = true
+mode = seq
+operation = file
 threads = 1
 data-size = 512:*2:524288
 file-size = 536870912


### PR DESCRIPTION
Adds an additional operation type that allows to compare performance
of pmemblk_read/write vs. pmem_memcpy.  Replaces 'file-io' argument
with 'operation', which can be 'blk', 'file' or 'memcpy'.

Replaces 'random' flag with 'mode' argument, which controls
the read/write pattern amd culd be 'stat', 'seq' or 'rand'.

For tests run on Device DAX, 'files-size' argument can be used
to limit the size of the device that is actually used for the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2216)
<!-- Reviewable:end -->
