### PR TITLE
common: (win) add support for TLS dtors

### DIFF
--- a/src/common/os_thread.h
+++ b/src/common/os_thread.h
@@ -95,6 +95,12 @@ int os_tls_key_delete(os_tls_key_t key);
 int os_tls_set(os_tls_key_t key, const void *value);
 void *os_tls_get(os_tls_key_t key);
 
+#ifdef _WIN32
+void os_tls_init(void);
+void os_tls_fini(void);
+void os_tls_thread_fini(void);
+#endif
+
 int os_mutex_init(os_mutex_t *__restrict mutex);
 int os_mutex_destroy(os_mutex_t *__restrict mutex);
 _When_(return == 0, _Acquires_lock_(mutex->lock))

--- a/src/common/pmemcommon.h
+++ b/src/common/pmemcommon.h
@@ -40,12 +40,17 @@
 #include "util.h"
 #include "out.h"
 #include "mmap.h"
+#include "os_thread.h"
 
 static inline void
 common_init(const char *log_prefix, const char *log_level_var,
 		const char *log_file_var, int major_version,
 		int minor_version)
 {
+#ifdef _WIN32
+	os_tls_init();
+#endif
+
 	util_init();
 	out_init(log_prefix, log_level_var, log_file_var, major_version,
 		minor_version);
@@ -57,5 +62,10 @@ common_fini(void)
 {
 	util_mmap_fini();
 	out_fini();
+
+#ifdef _WIN32
+	os_tls_thread_fini();
+	os_tls_fini();
+#endif
 }
 #endif

--- a/src/libpmem/libpmem_main.c
+++ b/src/libpmem/libpmem_main.c
@@ -32,11 +32,9 @@
 
 /*
  * libpmem_main.c -- entry point for libpmem.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
+
+#include "os_thread.h"
 
 void libpmem_init(void);
 void libpmem_fini(void);
@@ -50,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/libpmemblk/libpmemblk_main.c
+++ b/src/libpmemblk/libpmemblk_main.c
@@ -32,11 +32,9 @@
 
 /*
  * libpmemblk_main.c -- entry point for libpmemblk.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
+
+#include "os_thread.h"
 
 void libpmemblk_init(void);
 void libpmemblk_fini(void);
@@ -50,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/libpmemlog/libpmemlog_main.c
+++ b/src/libpmemlog/libpmemlog_main.c
@@ -32,11 +32,9 @@
 
 /*
  * libpmemlog_main.c -- entry point for libpmemlog.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
+
+#include "os_thread.h"
 
 void libpmemlog_init(void);
 void libpmemlog_fini(void);
@@ -50,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/libpmemobj/libpmemobj_main.c
+++ b/src/libpmemobj/libpmemobj_main.c
@@ -32,11 +32,9 @@
 
 /*
  * libpmemobj_main.c -- entry point for libpmemobj.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
+
+#include "os_thread.h"
 
 void libpmemobj_init(void);
 void libpmemobj_fini(void);
@@ -50,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/libpmempool/libpmempool_main.c
+++ b/src/libpmempool/libpmempool_main.c
@@ -32,13 +32,9 @@
 
 /*
  * libpmempool_main.c -- entry point for libpmempool.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
 
-#include <stdio.h>
+#include "os_thread.h"
 
 void libpmempool_init(void);
 void libpmempool_fini(void);
@@ -52,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/libvmem/libvmem_main.c
+++ b/src/libvmem/libvmem_main.c
@@ -32,11 +32,9 @@
 
 /*
  * libvmem_main.c -- entry point for libvmem.dll
- *
- * XXX - This is a placeholder.  All the library initialization/cleanup
- * that is done in library ctors/dtors, as well as TLS initialization
- * should be moved here.
  */
+
+#include "os_thread.h"
 
 void vmem_init(void);
 void vmem_fini(void);
@@ -50,7 +48,10 @@ DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 		break;
 
 	case DLL_THREAD_ATTACH:
+		break;
+
 	case DLL_THREAD_DETACH:
+		os_tls_thread_fini();
 		break;
 
 	case DLL_PROCESS_DETACH:

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -332,7 +332,8 @@ int
 main(int argc, char *argv[])
 {
 	START(argc, argv, "obj_sync");
-	util_init();
+
+	util_init(); /* initialize On_valgrind */
 
 	if (argc < 4)
 		FATAL_USAGE();
@@ -418,5 +419,6 @@ main(int argc, char *argv[])
 	FREE(check_threads);
 	FREE(write_threads);
 	FREE(Test_obj);
+
 	DONE(NULL);
 }

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -40,6 +40,7 @@
  */
 
 #include "unittest.h"
+#include "os_thread.h"
 
 #ifndef _WIN32
 int
@@ -643,6 +644,9 @@ static void
 ut_start_common(const char *file, int line, const char *func,
     const char *fmt, va_list ap)
 {
+#ifdef _WIN32
+	os_tls_init();
+#endif
 
 	int saveerrno = errno;
 	char logname[MAXLOGNAME];
@@ -793,6 +797,11 @@ ut_done(const char *file, int line, const char *func,
 
 	if (Tracefp != NULL)
 		fclose(Tracefp);
+
+#ifdef _WIN32
+	os_tls_thread_fini();
+	os_tls_fini();
+#endif
 
 	exit(0);
 }

--- a/src/test/util_file_create/util_file_create.c
+++ b/src/test/util_file_create/util_file_create.c
@@ -37,7 +37,6 @@
  */
 
 #include "unittest.h"
-
 #include "file.h"
 
 int

--- a/src/test/util_file_open/util_file_open.c
+++ b/src/test/util_file_open/util_file_open.c
@@ -37,7 +37,6 @@
  */
 
 #include "unittest.h"
-
 #include "file.h"
 
 int

--- a/src/test/util_is_poolset/util_is_poolset.c
+++ b/src/test/util_is_poolset/util_is_poolset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,19 +41,11 @@
 #include "pmemcommon.h"
 #include <errno.h>
 
-#define LOG_PREFIX "ut"
-#define LOG_LEVEL_VAR "TEST_LOG_LEVEL"
-#define LOG_FILE_VAR "TEST_LOG_FILE"
-#define MAJOR_VERSION 1
-#define MINOR_VERSION 0
 
 int
 main(int argc, char *argv[])
 {
 	START(argc, argv, "util_is_poolset");
-
-	common_init(LOG_PREFIX, LOG_LEVEL_VAR, LOG_FILE_VAR,
-			MAJOR_VERSION, MINOR_VERSION);
 
 	if (argc < 2)
 		UT_FATAL("usage: %s file...",
@@ -65,7 +57,6 @@ main(int argc, char *argv[])
 
 		UT_OUT("util_is_poolset(%s): %d", fname, is_poolset);
 	}
-	common_fini();
 
 	DONE(NULL);
 }

--- a/src/test/vmem_check_allocations/vmem_check_allocations.vcxproj
+++ b/src/test/vmem_check_allocations/vmem_check_allocations.vcxproj
@@ -20,7 +20,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="TEST0.PS1" />
-    <None Include="TEST1.PS1" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="vmem_check_allocations.c" />

--- a/src/test/vmem_check_allocations/vmem_check_allocations.vcxproj.filters
+++ b/src/test/vmem_check_allocations/vmem_check_allocations.vcxproj.filters
@@ -16,9 +16,6 @@
     <None Include="TEST0.PS1">
       <Filter>Test Scripts</Filter>
     </None>
-    <None Include="TEST1.PS1">
-      <Filter>Test Scripts</Filter>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="vmem_check_allocations.c">

--- a/src/tools/pmempool/pmempool.c
+++ b/src/tools/pmempool/pmempool.c
@@ -243,6 +243,8 @@ main(int argc, char *argv[])
 	int option_index;
 	int ret = 0;
 #ifdef _WIN32
+	os_tls_init();
+
 	wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
 	for (int i = 0; i < argc; i++) {
 		argv[i] = util_toUTF8(wargv[i]);
@@ -301,6 +303,7 @@ end:
 #ifdef _WIN32
 	for (int i = argc; i > 0; i--)
 		free(argv[i - 1]);
+	os_tls_fini();
 #endif
 	if (ret)
 		return 1;


### PR DESCRIPTION
Reverts the patch that introduced fiber APIs (FlsAlloc/FlsFree/...)
and implements our own mechnism for TLS destructors.

Ref: pmem/issues#631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2219)
<!-- Reviewable:end -->
