### PR TITLE
rpmem: fix cleanup if fork() failed

### DIFF
--- a/src/librpmem/rpmem_cmd.c
+++ b/src/librpmem/rpmem_cmd.c
@@ -239,7 +239,7 @@ err_pipe_in:
 int
 rpmem_cmd_wait(struct rpmem_cmd *cmd, int *status)
 {
-	if (!cmd->pid)
+	if (cmd->pid <= 0)
 		return -1;
 
 	if (waitpid(cmd->pid, status, 0) != cmd->pid)
@@ -258,5 +258,6 @@ rpmem_cmd_term(struct rpmem_cmd *cmd)
 	os_close(cmd->fd_out);
 	os_close(cmd->fd_err);
 
+	RPMEM_ASSERT(cmd->pid > 0);
 	return kill(cmd->pid, SIGINT);
 }

--- a/src/librpmem/rpmem_ssh.c
+++ b/src/librpmem/rpmem_ssh.c
@@ -248,8 +248,6 @@ rpmem_ssh_execv(const struct rpmem_target_info *info, const char **argv)
 
 	return rps;
 err_run:
-	rpmem_cmd_term(rps->cmd);
-	rpmem_cmd_wait(rps->cmd, NULL);
 err_push:
 	free(cmd);
 err_cmd:


### PR DESCRIPTION
If fork() failed in rpmem_{open,create} there is a call to kill() with
pid equals -1, which sends a signal to all processes which the current
process has permissions to send to.

Ref: pmem/issues634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2222)
<!-- Reviewable:end -->
