### PR TITLE
common: Makefile updates for FreeBSD port

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -90,6 +90,8 @@ SCOPEFILES = $(SCOPE_SRC_FILES) $(SCOPE_HDR_FILES)
 # include/lib*.h - skip include/pmemcompat.h
 HEADERS =\
 	$(foreach f, $(wildcard\
+		freebsd/include/*.h\
+		freebsd/include/*/*.h\
 		include/lib*.h\
 		include/libpmemobj/*.h\
 		include/libpmemobj++/*.hpp\
@@ -167,9 +169,11 @@ check-remote: test
 	$(MAKE) -C test $@
 
 jemalloc jemalloc-clean jemalloc-clobber jemalloc-test jemalloc-check:
-	$(MAKE) -C jemalloc -f Makefile.nvml $@
+	$(MAKE) -C jemalloc -f Makefile.libvmem $@
+	$(MAKE) -C jemalloc -f Makefile.libvmmalloc $@
 ifeq ($(custom_build),)
-	$(MAKE) -C jemalloc -f Makefile.nvml $@ DEBUG=1
+	$(MAKE) -C jemalloc -f Makefile.libvmem $@ DEBUG=1
+	$(MAKE) -C jemalloc -f Makefile.libvmmalloc $@ DEBUG=1
 endif
 
 install-cpp:

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,10 +78,14 @@ SCOPE_SRC_DIRS = $(SCOPE_DIRS) include jemalloc/src
 SCOPE_HDR_DIRS = $(SCOPE_DIRS) include jemalloc/src\
 		jemalloc/include/jemalloc\
 		jemalloc/include/jemalloc/internal\
-		debug/jemalloc/include/jemalloc\
-		debug/jemalloc/include/jemalloc/internal\
-		nondebug/jemalloc/include/jemalloc\
-		nondebug/jemalloc/include/jemalloc/internal
+		debug/libvmem/jemalloc/include/jemalloc\
+		debug/libvmmalloc/jemalloc/include/jemalloc\
+		debug/libvmem/jemalloc/include/jemalloc/internal\
+		debug/libvmmalloc/jemalloc/include/jemalloc/internal\
+		nondebug/libvmem/jemalloc/include/jemalloc\
+		nondebug/libvmmalloc/jemalloc/include/jemalloc\
+		nondebug/libvmem/jemalloc/include/jemalloc/internal\
+		nondebug/libvmmalloc/jemalloc/include/jemalloc/internal
 
 SCOPE_SRC_FILES = $(foreach d, $(SCOPE_SRC_DIRS), $(wildcard $(d)/*.c))
 SCOPE_HDR_FILES = $(foreach d, $(SCOPE_HDR_DIRS), $(wildcard $(D)/*.h))

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -87,7 +87,7 @@ endif
 
 ifneq ($(SANITIZE),)
 # On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
-ifneq ($(NVMLDIR),libvmmalloc)
+ifneq ($(JEMALLOC_NVMLDIR),libvmmalloc)
 CFLAGS += -fsanitize=$(SANITIZE)
 LDFLAGS += -fsanitize=$(SANITIZE)
 else ifneq ($(OSTYPE),FreeBSD)

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -43,7 +43,7 @@ vpath %.c $(RPMEM_COMMON)
 COMMON = $(TOP)/src/common
 vpath %.c $(COMMON)
 
-INCS += -I../include -I../common/
+INCS += -I../include -I../common/ $(OS_INCS)
 
 CFLAGS += -std=gnu99
 CFLAGS += -Wall
@@ -83,6 +83,19 @@ ifeq ($(COVERAGE),1)
 CFLAGS += $(GCOV_CFLAGS)
 LDFLAGS += $(GCOV_LDFLAGS)
 LIBS += $(GCOV_LIBS)
+endif
+
+ifneq ($(SANITIZE),)
+# On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
+ifneq ($(NVMLDIR),libvmmalloc)
+CFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+else ifneq ($(OSTYPE),FreeBSD)
+CFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+else
+$(info SANITIZE not supported for libvmmalloc, ignored)
+endif
 endif
 
 CFLAGS += $(EXTRA_CFLAGS)

--- a/src/benchmarks/Makefile
+++ b/src/benchmarks/Makefile
@@ -101,7 +101,7 @@ OBJS=$(SRC:.cpp=.o)
 ifneq ($(filter 1 2, $(CSTYLEON)),)
 TMP_HEADERS := $(addsuffix tmp, $(HEADERS))
 endif
-LDFLAGS = -L$(LIBS_PATH)
+LDFLAGS = -L$(LIBS_PATH) $(OS_LIBS)
 LDFLAGS += -L../examples/libpmemobj/map
 LDFLAGS += $(EXTRA_LDFLAGS)
 ifeq ($(DEBUG),)
@@ -109,7 +109,8 @@ LIBS += ../nondebug/libpmemcommon.a
 else
 LIBS += ../debug/libpmemcommon.a
 endif
-LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm -ldl
+LIBS += -lpmemobj -lpmemlog -lpmemblk -lpmem -lvmem -pthread -lm\
+	$(LIBDL) $(LIBUUID)
 ifeq ($(call check_librt), n)
 LIBS += -lrt
 endif
@@ -127,12 +128,18 @@ CXXFLAGS += -I../common
 CXXFLAGS += -I../examples/libpmemobj/map
 CXXFLAGS += -I../rpmem_common
 CXXFLAGS += -I../librpmem
+CXXFLAGS += $(OS_INCS)
 CXXFLAGS += -DSRCVERSION='"$(SRCVERSION)"'
 
 ifeq ($(COVERAGE),1)
 CXXFLAGS += $(GCOV_CFLAGS)
 LDFLAGS += $(GCOV_LDFLAGS)
 LIBS += $(GCOV_LIBS)
+endif
+
+ifneq ($(SANITIZE),)
+CXXFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
 endif
 
 ifeq ($(BUILD_RPMEM),y)

--- a/src/common.inc
+++ b/src/common.inc
@@ -223,3 +223,17 @@ see src/librpmem/README for details.
 endif
 
 sparse-c = $(shell for c in *.c; do sparse -Wsparse-all -Wno-declaration-after-statement $(CFLAGS) $(INCS) $$c || true; done)
+
+ifeq ($(OSTYPE),FreeBSD)
+OS_INCS = -I$(TOP)/src/freebsd/include -I/usr/local/include
+OS_LIBS = -L/usr/local/lib
+LIBDL=
+LIBUTIL=-lutil
+LIBUUID=-luuid
+else
+OS_INCS=
+OS_LIBS=
+LIBDL=-ldl
+LIBUTIL=
+LIBUUID=
+endif

--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -47,7 +47,7 @@ SOURCE =\
 	set.c\
 	util.c\
 	uuid.c\
-	uuid_linux.c\
+	uuid_$(shell uname -s | tr "[:upper:]" "[:lower:]").c\
 	util_linux.c
 
 include ../Makefile.inc

--- a/src/common/uuid_freebsd.c
+++ b/src/common/uuid_freebsd.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015-2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * uuid_freebsd.c -- FreeBSD-specific implementation for UUID generation
+ */
+
+#include "uuid.h"
+
+/* XXX Can't include <uuid/uuid.h> because it also defines uuid_t */
+void uuid_generate(uuid_t);
+
+/*
+ * util_uuid_generate -- generate a uuid
+ *
+ * Uses the available FreeBSD uuid_generate library function.
+ */
+int
+util_uuid_generate(uuid_t uuid)
+{
+	uuid_generate(uuid);
+
+	return 0;
+}

--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -42,10 +42,20 @@ LIBDIR = $(TOP_SRC)/debug
 
 include $(TOP)/src/common.inc
 
-CXXFLAGS = -std=c++11 -ggdb -Wall -Werror $(EXTRA_CXXFLAGS)
+CXXFLAGS = -std=c++11 -ggdb -Wall -Werror
+ifeq ($(OSTYPE),FreeBSD)
+CXXFLAGS += -D_GLIBCXX_USE_C99
+endif
+CXXFLAGS +=  $(EXTRA_CXXFLAGS)
 CFLAGS = -std=gnu99 -ggdb -Wall -Werror -Wmissing-prototypes $(EXTRA_CFLAGS)
 LDFLAGS = -Wl,-rpath=$(LIBDIR) -L$(LIBDIR) $(EXTRA_LDFLAGS)
-INCS = -I$(INCDIR) -I. -I$(TOP_SRC)/examples
+ifneq ($(SANITIZE),)
+CFLAGS += -fsanitize=$(SANITIZE)
+CXXFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+endif
+INCS = -I$(INCDIR) -I. -I$(TOP_SRC)/examples $(OS_INCS)
+LIBS += $(OS_LIBS) $(LIBUUID)
 
 LINKER=$(CC)
 ifeq ($(COMPILE_LANG), cpp)

--- a/src/examples/libpmemobj/libart/Makefile
+++ b/src/examples/libpmemobj/libart/Makefile
@@ -50,9 +50,9 @@
 PROGS = arttree arttree_structures
 LIBRARIES = art
 
-include ../../Makefile.inc
-
 LIBS = -lpmemobj
+
+include ../../Makefile.inc
 
 $(PROGS): | $(DYNAMIC_LIBRARIES)
 $(PROGS): LDFLAGS += -Wl,-rpath=. -L. -lart

--- a/src/examples/libpmemobj/panaconda/Makefile
+++ b/src/examples/libpmemobj/panaconda/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,6 +45,9 @@ $(info NOTE: Skipping panaconda because ncurses is missing \
 endif
 
 LIBS = -lpmemobj -lpmem -pthread
+ifeq ($(OSTYPE),FreeBSD)
+LIBS += -lc
+endif
 
 ifeq ($(NCURSES),y)
 LIBS += $(shell $(PKG_CONFIG) --libs ncurses)

--- a/src/examples/libpmemobj/pmpong/Makefile
+++ b/src/examples/libpmemobj/pmpong/Makefile
@@ -34,7 +34,12 @@ include $(TOP)/src/common.inc
 
 SFML := $(call check_package, sfml-all --atleast-version 2.4)
 ifeq ($(SFML),y)
-PROGS = pmpong $(shell find /usr/share/fonts -name *.ttf | head -n 1 >| fontConf $<)
+ifeq ($(OSTYPE),FreeBSD)
+FONTDIR=/usr/local/share/fonts
+else
+FONTDIR=/usr/share/fonts
+endif
+PROGS = pmpong $(shell find $(FONTDIR) -name *.ttf | head -n 1 >| fontConf $<)
 else
 $(info NOTE: Skipping pmpong because sfml is missing \
 -- see src/examples/libpmemobj/pmpong/README for details.)

--- a/src/freebsd/README
+++ b/src/freebsd/README
@@ -1,0 +1,13 @@
+Non-Volatile Memory Library
+
+This is src/freebsd/README.
+
+This directory contains FreeBSD-specific files for the NVM Library.
+
+The subdirectory "include" contains header files that have no equivalents
+on FreeBSD. Most of these files are empty, which is a cheap trick to avoid
+preprocessor errors when including non-existing files. Others are redirects
+for files that are in different locations on FreeBSD. This way we don't
+need a lot of preprocessor conditionals in all the source code files, although
+it does require conditionals in the Makefiles (which could be addressed by
+using autoconf).

--- a/src/freebsd/include/endian.h
+++ b/src/freebsd/include/endian.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * endian.h -- redirect for FreeBSD <sys/endian.h>
+ */
+
+#include <sys/endian.h>

--- a/src/freebsd/include/features.h
+++ b/src/freebsd/include/features.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * features.h -- Empty file redirect
+ */

--- a/src/freebsd/include/linux/kdev_t.h
+++ b/src/freebsd/include/linux/kdev_t.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * linux/kdev_t.h -- Empty file redirect
+ */

--- a/src/freebsd/include/linux/limits.h
+++ b/src/freebsd/include/linux/limits.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * linux/limits.h -- Empty file redirect
+ */

--- a/src/freebsd/include/sys/sysmacros.h
+++ b/src/freebsd/include/sys/sysmacros.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * sys/sysmacros.h -- Empty file redirect
+ */

--- a/src/jemalloc/Makefile.libvmem
+++ b/src/jemalloc/Makefile.libvmem
@@ -37,7 +37,7 @@ EXTRA_TARGETS = jemalloc
 
 default: all
 
-NVMLDIR=libvmem
+JEMALLOC_NVMLDIR=libvmem
 include ./jemalloc.mk
 
 JEMALLOC_CONFIG += --disable-bsd-malloc-hooks

--- a/src/jemalloc/Makefile.libvmem
+++ b/src/jemalloc/Makefile.libvmem
@@ -29,31 +29,23 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# src/libvmmalloc/Makefile -- Makefile for libvmmalloc
+# src/jemalloc/Makefile.libvmem -- Makefile for building jemalloc
+# for libvmem
 #
 
-LIBRARY_NAME = vmmalloc
-LIBRARY_SO_VERSION = 1
-LIBRARY_VERSION = 0.0
-SOURCE = libvmmalloc.c\
-	$(COMMON)/file_linux.c\
-	$(COMMON)/mmap.c\
-	$(COMMON)/mmap_linux.c\
-	$(COMMON)/out.c\
-	$(COMMON)/os_linux.c\
-	$(COMMON)/os_thread_linux.c\
-	$(COMMON)/util.c\
-	$(COMMON)/util_linux.c
+EXTRA_TARGETS = jemalloc
 
 default: all
 
-NVMLDIR=libvmmalloc
-include ../jemalloc/jemalloc.mk
+NVMLDIR=libvmem
+include ./jemalloc.mk
 
-INCS += -I$(JEMALLOC_DIR)/include/jemalloc
-INCS += -I$(JEMALLOC_OBJDIR)/include/jemalloc
-INCS += -I../libvmem
-EXTRA_OBJS += $(JEMALLOC_LIB)
-LIBS += -pthread
+JEMALLOC_CONFIG += --disable-bsd-malloc-hooks
+
+ifeq ($(DEBUG),1)
+JEMALLOC_CONFIG += --enable-debug
+endif
+
+LIB_OUTDIR =
 
 include ../Makefile.inc

--- a/src/jemalloc/Makefile.libvmmalloc
+++ b/src/jemalloc/Makefile.libvmmalloc
@@ -37,7 +37,7 @@ EXTRA_TARGETS = jemalloc
 
 default: all
 
-NVMLDIR=libvmmalloc
+JEMALLOC_NVMLDIR=libvmmalloc
 include ./jemalloc.mk
 
 ifeq ($(DEBUG),1)

--- a/src/jemalloc/Makefile.libvmmalloc
+++ b/src/jemalloc/Makefile.libvmmalloc
@@ -29,14 +29,15 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# src/jemalloc/Makefile.nvml -- Makefile for building jemalloc
-# inside NVML tree
+# src/jemalloc/Makefile.libvmmalloc -- Makefile for building jemalloc
+# for libvmmalloc
 #
 
 EXTRA_TARGETS = jemalloc
 
 default: all
 
+NVMLDIR=libvmmalloc
 include ./jemalloc.mk
 
 ifeq ($(DEBUG),1)

--- a/src/jemalloc/configure.ac
+++ b/src/jemalloc/configure.ac
@@ -254,6 +254,7 @@ EXTRA_LDFLAGS=
 ARFLAGS='crus'
 AROUT=' $@'
 CC_MM=1
+MALLOCINC="malloc.h"
 
 AN_MAKEVAR([AR], [AC_PROG_AR])
 AN_PROGRAM([ar], [AC_PROG_AR])
@@ -287,6 +288,7 @@ case "${host}" in
 	abi="elf"
 	AC_DEFINE([JEMALLOC_PURGE_MADVISE_FREE], [ ])
 	force_lazy_lock="1"
+	MALLOCINC="stdlib.h"
 	;;
   *-*-linux*)
 	CFLAGS="$CFLAGS"
@@ -362,10 +364,10 @@ case "${host}" in
 esac
 
 JEMALLOC_USABLE_SIZE_CONST=const
-AC_CHECK_HEADERS([malloc.h], [
+AC_CHECK_HEADERS([${MALLOCINC}], [
   AC_MSG_CHECKING([whether malloc_usable_size definition can use const argument])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-    [#include <malloc.h>
+    [#include <${MALLOCINC}>
      #include <stddef.h>
     size_t malloc_usable_size(const void *ptr);
     ],
@@ -1064,28 +1066,49 @@ fi
 
 CPPFLAGS="$CPPFLAGS -D_REENTRANT"
 
+dnl The force_lazy_lock, _malloc_thread_cleanup and _pthread_mutex_init_calloc_cb
+dnl checks for FreeBSD assume that jemalloc is being built as a libc malloc
+dnl replacement. If jemalloc is being built for a different purpose, these checks
+dnl can be ovverridden with --disable-bsd-malloc-hooks.
+AC_ARG_ENABLE([bsd-malloc-hooks], [AS_HELP_STRING([--disable-bsd-malloc-hooks],
+  [Disable force_lazy_lock, _malloc_thread_cleanup and _pthread_mutex_init_calloc_cb checks])],
+[if test "x$enable_bsd_malloc_hooks" = "xno" ; then
+    AC_DEFINE([JEMALLOC_DISABLE_BSD_MALLOC_HOOKS], [ ])
+  enable_bsd_malloc_hooks="0"
+  force_lazy_lock="0"
+else
+  enable_bsd_malloc_hooks="1"
+fi
+],
+[enable_bsd_malloc_hooks="1"]
+)
+
 dnl Check whether the BSD-specific _malloc_thread_cleanup() exists.  If so, use
 dnl it rather than pthreads TSD cleanup functions to support cleanup during
 dnl thread exit, in order to avoid pthreads library recursion during
 dnl bootstrapping.
-AC_CHECK_FUNC([_malloc_thread_cleanup],
-              [have__malloc_thread_cleanup="1"],
-              [have__malloc_thread_cleanup="0"]
-             )
-if test "x$have__malloc_thread_cleanup" = "x1" ; then
-  AC_DEFINE([JEMALLOC_MALLOC_THREAD_CLEANUP], [ ])
-  force_tls="1"
+if test "x$enable_bsd_malloc_hooks" = "x1" ; then
+  AC_CHECK_FUNC([_malloc_thread_cleanup],
+                [have__malloc_thread_cleanup="1"],
+                [have__malloc_thread_cleanup="0"]
+               )
+  if test "x$have__malloc_thread_cleanup" = "x1" ; then
+    AC_DEFINE([JEMALLOC_MALLOC_THREAD_CLEANUP], [ ])
+    force_tls="1"
+  fi
 fi
 
 dnl Check whether the BSD-specific _pthread_mutex_init_calloc_cb() exists.  If
 dnl so, mutex initialization causes allocation, and we need to implement this
 dnl callback function in order to prevent recursive allocation.
-AC_CHECK_FUNC([_pthread_mutex_init_calloc_cb],
-              [have__pthread_mutex_init_calloc_cb="1"],
-              [have__pthread_mutex_init_calloc_cb="0"]
-             )
-if test "x$have__pthread_mutex_init_calloc_cb" = "x1" ; then
-  AC_DEFINE([JEMALLOC_MUTEX_INIT_CB])
+if test "x$enable_bsd_malloc_hooks" = "x1" ; then
+  AC_CHECK_FUNC([_pthread_mutex_init_calloc_cb],
+                [have__pthread_mutex_init_calloc_cb="1"],
+                 [have__pthread_mutex_init_calloc_cb="0"]
+              )
+  if test "x$have__pthread_mutex_init_calloc_cb" = "x1" ; then
+    AC_DEFINE([JEMALLOC_MUTEX_INIT_CB])
+  fi
 fi
 
 dnl Disable lazy locking by default.

--- a/src/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/src/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -86,6 +86,12 @@
  */
 #undef JEMALLOC_MUTEX_INIT_CB
 
+/*
+ * Defined if --disable_bsd_malloc_hooks is set. This overrides the
+ * JEMALLOC_MUTEX_INIT_CB checks for prefork/postfork.
+ */
+#undef JEMALLOC_DISABLE_BSD_MALLOC_HOOKS
+
 /* Non-empty if the tls_model attribute is supported. */
 #undef JEMALLOC_TLS_MODEL
 

--- a/src/jemalloc/jemalloc.cfg
+++ b/src/jemalloc/jemalloc.cfg
@@ -3,5 +3,3 @@
 --with-private-namespace=je_vmem_
 --disable-xmalloc
 --disable-munmap
-EXTRA_CFLAGS="-DJEMALLOC_LIBVMEM"
-

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -42,7 +42,7 @@ JEMALLOC_DIR = $(realpath ../jemalloc)
 ifeq ($(OBJDIR),$(abspath $(OBJDIR)))
 JEMALLOC_OBJDIR = $(OBJDIR)/jemalloc
 else
-JEMALLOC_OBJDIR = ../$(OBJDIR)/$(NVMLDIR)/jemalloc
+JEMALLOC_OBJDIR = ../$(OBJDIR)/$(JEMALLOC_NVMLDIR)/jemalloc
 endif
 JEMALLOC_MAKEFILE = $(JEMALLOC_OBJDIR)/Makefile
 JEMALLOC_CFG = $(JEMALLOC_DIR)/configure

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -1,4 +1,4 @@
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@ JEMALLOC_DIR = $(realpath ../jemalloc)
 ifeq ($(OBJDIR),$(abspath $(OBJDIR)))
 JEMALLOC_OBJDIR = $(OBJDIR)/jemalloc
 else
-JEMALLOC_OBJDIR = ../$(OBJDIR)/jemalloc
+JEMALLOC_OBJDIR = ../$(OBJDIR)/$(NVMLDIR)/jemalloc
 endif
 JEMALLOC_MAKEFILE = $(JEMALLOC_OBJDIR)/Makefile
 JEMALLOC_CFG = $(JEMALLOC_DIR)/configure
@@ -55,6 +55,11 @@ JEMALLOC_CFG_OUT_FILES = $(patsubst $(JEMALLOC_DIR)/%, $(JEMALLOC_OBJDIR)/%, $(J
 JEMALLOC_AUTOM4TE_CACHE=autom4te.cache
 JEMALLOC_CONFIG_FILE = $(JEMALLOC_DIR)/jemalloc.cfg
 JEMALLOC_CONFIG = $(shell cat $(JEMALLOC_CONFIG_FILE))
+ifeq ($(OSTYPE), FreeBSD)
+ifndef $(CC)
+JEMALLOC_CONFIG += CC=$(CC) # Default to system compiler (not gcc) on FreeBSD
+endif
+endif
 CFLAGS_FILTER += -fno-common
 CFLAGS_FILTER += -Wmissing-prototypes
 CFLAGS_FILTER += -Wpointer-arith
@@ -76,6 +81,9 @@ CFLAGS_FILTER += -Wshadow
 CFLAGS_FILTER += -Wdisabled-macro-expansion
 CFLAGS_FILTER += -Wlanguage-extension-token
 JEMALLOC_CFLAGS=$(filter-out $(CFLAGS_FILTER), $(CFLAGS))
+ifeq ($(OSTYPE), FreeBSD)
+JEMALLOC_CFLAGS += -I/usr/local/include
+endif
 JEMALLOC_REMOVE_LDFLAGS_TMP = -Wl,--warn-common
 JEMALLOC_LDFLAGS=$(filter-out $(JEMALLOC_REMOVE_LDFLAGS_TMP), $(LDFLAGS))
 JEMALLOC_CFG_OUT_FILES_FIRST=$(firstword $(JEMALLOC_CFG_OUT_FILES))

--- a/src/libpmemblk/Makefile
+++ b/src/libpmemblk/Makefile
@@ -48,7 +48,7 @@ SOURCE =\
 	$(COMMON)/set.c\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
-	$(COMMON)/uuid_linux.c\
+	$(COMMON)/uuid_$(shell uname -s | tr "[:upper:]" "[:lower:]").c\
 	$(COMMON)/util_linux.c\
 	blk.c\
 	btt.c\

--- a/src/libpmemlog/Makefile
+++ b/src/libpmemlog/Makefile
@@ -48,7 +48,7 @@ SOURCE =\
 	$(COMMON)/set.c\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
-	$(COMMON)/uuid_linux.c\
+	$(COMMON)/uuid_$(shell uname -s | tr "[:upper:]" "[:lower:]").c\
 	$(COMMON)/util_linux.c\
 	libpmemlog.c\
 	log.c

--- a/src/libpmemobj/Makefile
+++ b/src/libpmemobj/Makefile
@@ -48,7 +48,7 @@ SOURCE =\
 	$(COMMON)/set.c\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
-	$(COMMON)/uuid_linux.c\
+	$(COMMON)/uuid_$(shell uname -s | tr "[:upper:]" "[:lower:]").c\
 	$(COMMON)/util_linux.c\
 	alloc_class.c\
 	bucket.c\
@@ -78,4 +78,4 @@ include ../Makefile.inc
 
 CFLAGS += -DUSE_LIBDL -D_PMEMOBJ_INTRNL
 
-LIBS += -pthread -lpmem -ldl
+LIBS += -pthread -lpmem $(LIBDL)

--- a/src/libpmempool/Makefile
+++ b/src/libpmempool/Makefile
@@ -57,7 +57,7 @@ SOURCE =\
 	$(COMMON)/set.c\
 	$(COMMON)/util.c\
 	$(COMMON)/uuid.c\
-	$(COMMON)/uuid_linux.c\
+	$(COMMON)/uuid_$(shell uname -s | tr "[:upper:]" "[:lower:]").c\
 	$(COMMON)/util_linux.c\
 	libpmempool.c\
 	check.c\
@@ -84,7 +84,7 @@ LIBPMEMBLK_PRIV_FUNCS=btt_info_set btt_arena_datasize btt_flog_size\
 
 include ../Makefile.inc
 
-LIBS += -lpmem -ldl
+LIBS += -lpmem $(LIBDL)
 CFLAGS += -DUSE_LIBDL
 CFLAGS += -DUSE_RPMEM
 

--- a/src/libvmem/Makefile
+++ b/src/libvmem/Makefile
@@ -48,11 +48,8 @@ SOURCE = libvmem.c vmem.c\
 
 default: all
 
+NVMLDIR = libvmem
 include ../jemalloc/jemalloc.mk
-
-ifeq ($(DEBUG),1)
-JEMALLOC_CONFIG += --enable-debug
-endif
 
 INCS += -I$(JEMALLOC_DIR)/include/jemalloc
 INCS += -I$(JEMALLOC_OBJDIR)/include/jemalloc

--- a/src/libvmem/Makefile
+++ b/src/libvmem/Makefile
@@ -48,7 +48,7 @@ SOURCE = libvmem.c vmem.c\
 
 default: all
 
-NVMLDIR = libvmem
+JEMALLOC_NVMLDIR = libvmem
 include ../jemalloc/jemalloc.mk
 
 INCS += -I$(JEMALLOC_DIR)/include/jemalloc

--- a/src/libvmmalloc/Makefile
+++ b/src/libvmmalloc/Makefile
@@ -47,7 +47,7 @@ SOURCE = libvmmalloc.c\
 
 default: all
 
-NVMLDIR=libvmmalloc
+JEMALLOC_NVMLDIR=libvmmalloc
 include ../jemalloc/jemalloc.mk
 
 INCS += -I$(JEMALLOC_DIR)/include/jemalloc

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -268,13 +268,15 @@ VMMALLOC_TESTS = \
 	vmmalloc_fork\
 	vmmalloc_init\
 	vmmalloc_malloc\
-	vmmalloc_malloc_hooks\
 	vmmalloc_malloc_usable_size\
 	vmmalloc_memalign\
 	vmmalloc_out_of_memory\
 	vmmalloc_realloc\
 	vmmalloc_valgrind\
 	vmmalloc_valloc
+ifneq ($(OSTYPE),FreeBSD)
+	VMMALLOC_TESTS += vmmalloc_malloc_hooks	# No malloc hooks in FreeBSD
+endif
 
 EXAMPLES_TESTS = \
 	ex_libpmem\

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -41,6 +41,8 @@ TOP := $(dir $(lastword $(MAKEFILE_LIST)))../..
 
 include $(TOP)/src/common.inc
 
+INCS += $(OS_INCS)
+LDFLAGS += $(OS_LIBS)
 LIBS_DIR=$(TOP)/src
 
 EXAMPLES_DIR=$(TOP)/src/examples
@@ -50,21 +52,21 @@ EX_LIBPMEMLOG=$(EXAMPLES_DIR)/libpmemlog
 EX_LIBPMEMOBJ=$(EXAMPLES_DIR)/libpmemobj
 
 UT = ../unittest/libut.a
-LIBS += $(UT)
+LIBS += $(UT) $(LIBUUID)
 
 ifeq ($(USE_LIBUNWIND),1)
-LIBS += -ldl -lunwind
+LIBS += $(LIBDL) -lunwind
 else
 ifneq ($(USE_LIBUNWIND),0)
 UNWIND := $(call check_package, libunwind)
 ifeq ($(UNWIND),y)
-LIBS += -ldl $(shell $(PKG_CONFIG) --libs libunwind)
+LIBS += $(LIBDL) $(shell $(PKG_CONFIG) --libs libunwind)
 endif
 endif
 endif
 
 LIBS += -L$(LIBS_DIR)/debug
-LIBS += -pthread
+LIBS += -pthread $(LIBUTIL)
 
 # XXX: required by clock_gettime(), if glibc version < 2.17
 # The os_clock_gettime() function is now in OS abstraction layer,
@@ -77,7 +79,7 @@ ifeq ($(LIBPMEMPOOL), y)
 DYNAMIC_LIBS += -lpmempool
 STATIC_DEBUG_LIBS += $(LIBS_DIR)/debug/libpmempool.a
 STATIC_NONDEBUG_LIBS += $(LIBS_DIR)/nondebug/libpmempool.a
-LIBS += -ldl
+LIBS += $(LIBDL)
 CFLAGS += -DUSE_LIBDL
 endif
 
@@ -94,7 +96,7 @@ STATIC_NONDEBUG_LIBS += $(LIBS_DIR)/nondebug/libpmemlog.a
 endif
 
 ifeq ($(LIBPMEMOBJ), y)
-LIBS += -ldl
+LIBS += $(LIBDL)
 DYNAMIC_LIBS += -lpmemobj
 STATIC_DEBUG_LIBS += $(LIBS_DIR)/debug/libpmemobj.a
 STATIC_NONDEBUG_LIBS += $(LIBS_DIR)/nondebug/libpmemobj.a
@@ -125,7 +127,7 @@ OBJS += $(TOP)/src/debug/libpmemobj/alloc_class.o\
 	$(TOP)/src/debug/libpmemobj/sync.o\
 	$(TOP)/src/debug/libpmemobj/tx.o
 
-LIBS += -ldl
+LIBS += $(LIBDL)
 INCS += -I$(TOP)/src/libpmemobj
 LIBPMEM=y
 LIBPMEMCOMMON=y
@@ -164,7 +166,7 @@ endif
 ifeq ($(LIBPMEMCOMMON), y)
 OBJS += $(LIBS_DIR)/debug/libpmemcommon.a
 INCS += -I$(TOP)/src/common
-LIBS += -ldl
+LIBS += $(LIBDL)
 LIBPMEM=y
 endif
 
@@ -210,6 +212,9 @@ endif
 COMMON_FLAGS += -fno-common
 
 CXXFLAGS  = -std=c++11
+ifeq ($(OSTYPE),FreeBSD)
+CXXFLAGS += -D_GLIBCXX_USE_C99
+endif
 CXXFLAGS += -ggdb
 CXXFLAGS += $(COMMON_FLAGS)
 CXXFLAGS += $(EXTRA_CXXFLAGS)
@@ -226,6 +231,21 @@ CFLAGS += $(GCOV_CFLAGS)
 CXXFLAGS += $(GCOV_CFLAGS)
 LDFLAGS += $(GCOV_LDFLAGS)
 LIBS += $(GCOV_LIBS)
+endif
+
+ifneq ($(SANITIZE),)
+# On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
+ifeq (,$(filter vmmalloc_%,$(TARGET)))
+CFLAGS += -fsanitize=$(SANITIZE)
+CXXFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+else ifneq ($(OSTYPE),FreeBSD)
+CFLAGS += -fsanitize=$(SANITIZE)
+CXXFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+else
+$(info SANITIZE not supported for libvmmalloc, ignored)
+endif
 endif
 
 LINKER=$(CC)
@@ -339,6 +359,7 @@ else
 ifeq ($(SCP_SRC_DIR),)
 $(error SCP_SRC_DIR is not set)
 endif
+	$(SCP) common
 	$(SCP) test $(SCP_SRC_DIR)/$(SCP_TARGET) $(SCP_TARGET_STATIC_DEBUG) $(SCP_TARGET_STATIC_NONDEBUG)
 endif
 	@touch $(SYNC_FILE)

--- a/src/test/libpmempool_sync/TEST0
+++ b/src/test/libpmempool_sync/TEST0
@@ -102,11 +102,11 @@ ROOT_ADDR="$(cat $TMP_FILE | $GREP "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat $STAT_SIZE "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat $STAT_SIZE "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -38,7 +38,7 @@ export UNITTEST_NUM=10
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_command strace
+require_command $STRACE
 require_dax_devices 1
 
 # covered by TEST5
@@ -48,7 +48,7 @@ setup
 
 dax_device_zero
 
-expect_normal_exit strace -emsync -ostrace$UNITTEST_NUM.log \
+expect_normal_exit $STRACE -emsync -ostrace$UNITTEST_NUM.log \
 	./obj_basic_integration$EXESUFFIX $DEVICE_DAX_PATH
 
 check

--- a/src/test/obj_check/TEST3
+++ b/src/test/obj_check/TEST3
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STAT_SIZE $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).list.redo_log(1).offset=0x1"
@@ -86,7 +86,7 @@ rm -f $DIR/testfile
 
 # Invalid obj_offset - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STAT_SIZE $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).list.obj_offset=$SIZE"
 expect_normal_exit ./obj_check$EXESUFFIX $DIR/testfile

--- a/src/test/obj_check/TEST4
+++ b/src/test/obj_check/TEST4
@@ -68,7 +68,7 @@ rm -f $DIR/testfile
 
 # Invalid offset in redo log - <file size>
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $DIR/testfile
-SIZE=$(stat -c%s $DIR/testfile)
+SIZE=$(stat $STAT_SIZE $DIR/testfile)
 $PMEMSPOIL $DIR/testfile\
 	"pmemobj.lane(0).allocator.redo_log(0).offset=$SIZE"\
 	"pmemobj.lane(0).allocator.redo_log(1).offset=0x1"

--- a/src/test/pmem_map_file/Makefile
+++ b/src/test/pmem_map_file/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,4 +40,4 @@ LIBPMEM=y
 
 include ../Makefile.inc
 
-LIBS += -ldl
+LIBS += $(LIBDL)

--- a/src/test/pmempool_check/TEST16
+++ b/src/test/pmempool_check/TEST16
@@ -53,10 +53,10 @@ rm -rf $LOG && touch $LOG
 create_poolset $POOLSET 20M:$POOL_P1:z 20M:$POOL_P2:z
 expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
 
-TIME=$(date +"%s")
+TIME=$($DATE +"%s")
 let "FUTURE_TIME=$TIME+60*60"
 let "PAST_TIME=$TIME-60*60"
-PAST_TIME=$(date -d @$PAST_TIME +"%y%m%d%H%M")
+PAST_TIME=$($DATE -d @$PAST_TIME +"%y%m%d%H%M")
 $PMEMSPOIL -v $POOL_P1 pool_hdr.crtime=$FUTURE_TIME >> $LOG
 touch -mt $PAST_TIME $POOL_P1
 

--- a/src/test/pmempool_info/TEST8
+++ b/src/test/pmempool_info/TEST8
@@ -52,10 +52,10 @@ expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOL
 expect_normal_exit $PMEMWRITE$EXESUFFIX $POOL 1:e 2:w:TEST
 
 INFO_NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | $GREP 'External LBA count' | grep -o '[0-9]\+')
-NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | $GREP '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | $GREP '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | $GREP '[0-9]\+: 0x[0-9]\+.*' | wc -l)
-NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | $GREP '[0-9]\+: 0x[0-9]\+.*' | wc -l)
+NLBA=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -m $POOL | $GREP -c '[0-9]\+: 0x[0-9]\+.*')
+NZER=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mue $POOL | $GREP -c '[0-9]\+: 0x[0-9]\+.*')
+NERR=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -muz $POOL | $GREP -c '[0-9]\+: 0x[0-9]\+.*')
+NNON=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -mez $POOL | $GREP -c '[0-9]\+: 0x[0-9]\+.*')
 
 echo "Number of LBAs: $INFO_NLBA" >> $LOG
 echo "Number of LBAs in map: $NLBA" >> $LOG

--- a/src/test/pmempool_info/TEST9
+++ b/src/test/pmempool_info/TEST9
@@ -50,7 +50,7 @@ rm -rf $LOG && touch $LOG
 
 expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOL
 INFO_NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL | $GREP 'Free blocks' | $GREP -o '[0-9]\+')
-NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | $GREP -o '^[0-9]\+:' | wc -l)
+NFLOG=$(expect_normal_exit $PMEMPOOL$EXESUFFIX info -g $POOL | $GREP -co '^[0-9]\+:')
 
 [[ $INFO_NFLOG == $NFLOG ]] || exit 1
 

--- a/src/test/pmempool_sync/TEST0
+++ b/src/test/pmempool_sync/TEST0
@@ -104,11 +104,11 @@ ROOT_ADDR="$(cat $TMP_FILE | $GREP "Root offset" | \
 ROOT_ADDR=$((16#$ROOT_ADDR))
 
 # Calculate offsets from the root object start to hit each part file
-PART1_FILE_SIZE=$(stat -c%s "$DIR/testfile1")
+PART1_FILE_SIZE=$(stat $STAT_SIZE "$DIR/testfile1")
 PART1_SIZE=$(( ($PART1_FILE_SIZE & $ADDR_MASK) - $ROOT_ADDR ))
 PART2_OFFSET=$(( $M20 - $PART1_SIZE + $POOL_HEADER_OFFSET ))
 
-PART2_FILE_SIZE=$(stat -c%s "$DIR/testfile2")
+PART2_FILE_SIZE=$(stat $STAT_SIZE "$DIR/testfile2")
 PART2_SIZE=$(( ($PART2_FILE_SIZE & $ADDR_MASK) - $POOL_HEADER_OFFSET ))
 PART3_OFFSET=$(( $M40 - ($PART1_SIZE + $PART2_SIZE)\
 	+ $POOL_HEADER_OFFSET ))

--- a/src/test/pmempool_sync/TEST5
+++ b/src/test/pmempool_sync/TEST5
@@ -72,8 +72,8 @@ rm -f $DIR/testfile01
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat -c %A $DIR/testfile00 >> $LOG_TEMP
-stat -c %A $DIR/testfile01 >> $LOG_TEMP
+stat $STAT_PERM $DIR/testfile00 >> $LOG_TEMP
+stat $STAT_PERM $DIR/testfile01 >> $LOG_TEMP
 
 # Delete the first part in the second replica
 rm -f $DIR/testfile10
@@ -85,8 +85,8 @@ chmod 600 $DIR/testfile*
 expect_normal_exit $PMEMPOOL$EXESUFFIX sync $POOLSET >> $LOG_TEMP
 
 # Check if restored part file have the same permissions as other parts
-stat -c %A $DIR/testfile10 >> $LOG_TEMP
-stat -c %A $DIR/testfile11 >> $LOG_TEMP
+stat $STAT_PERM $DIR/testfile10 >> $LOG_TEMP
+stat $STAT_PERM $DIR/testfile11 >> $LOG_TEMP
 
 mv $LOG_TEMP $LOG
 check

--- a/src/test/remote_obj_basic/TEST0
+++ b/src/test/remote_obj_basic/TEST0
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST1
+++ b/src/test/remote_obj_basic/TEST1
@@ -48,7 +48,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST2
+++ b/src/test/remote_obj_basic/TEST2
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/remote_obj_basic/TEST3
+++ b/src/test/remote_obj_basic/TEST3
@@ -51,7 +51,7 @@ setup
 require_nodes 1
 
 # create a unique name for pool file
-POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`date +%s`
+POOL_FILE=/tmp/pool-remote_obj_basic-TEST$UNITTEST_NUM-$$-`$DATE +%s`
 
 # create poolset file
 POOLSET_FILE=pool$UNITTEST_NUM.set

--- a/src/test/unittest/Makefile
+++ b/src/test/unittest/Makefile
@@ -45,6 +45,7 @@ OBJS = ut.o ut_alloc.o ut_file.o ut_pthread.o ut_signal.o ut_backtrace.o\
 	os_linux.o os_thread_linux.o
 CFLAGS = -I$(TOP)/src/include
 CFLAGS += -I$(TOP)/src/common
+CFLAGS += $(OS_INCS)
 CFLAGS += -std=gnu99
 CFLAGS += -ggdb
 CFLAGS += -Wall
@@ -88,6 +89,8 @@ LIBS += $(GCOV_LIBS)
 endif
 
 CFLAGS += $(EXTRA_CFLAGS)
+
+LIBS += $(LIBUTIL)
 
 all test: $(TARGET)
 

--- a/src/test/util_map_proc/Makefile
+++ b/src/test/util_map_proc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,4 +39,4 @@ OBJS = util_map_proc.o
 LIBPMEMCOMMON=y
 
 include ../Makefile.inc
-LIBS += -ldl
+LIBS += $(LIBDL)

--- a/src/test/vmem_pages_purging/Makefile
+++ b/src/test/vmem_pages_purging/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -41,4 +41,4 @@ LIBVMEM=y
 include ../Makefile.inc
 
 INCS += -I../../jemalloc/include/
-INCS += -I../../nondebug/jemalloc/include/
+INCS += -I../../nondebug/libvmem/jemalloc/include/

--- a/src/test/vmmalloc_calloc/Makefile
+++ b/src/test/vmmalloc_calloc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,4 +39,4 @@ OBJS = vmmalloc_calloc.o
 include ../Makefile.inc
 
 INCS += -I../../jemalloc/include/
-INCS += -I../../nondebug/jemalloc/include/
+INCS += -I../../nondebug/libvmmalloc/jemalloc/include/

--- a/src/test/vmmalloc_init/Makefile
+++ b/src/test/vmmalloc_init/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,5 +48,5 @@ clobber: libtest_clean
 libtest_clean:
 	$(RM) libtest.so
 
-LIBS += -ldl
+LIBS += $(LIBDL)
 CFLAGS += -Wno-deprecated-declarations

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -39,6 +39,7 @@ INSTALL_TARGET ?= y
 
 INCS += -I.
 INCS += -I$(TOP)/src/include
+INCS += $(OS_INCS)
 CFLAGS += -std=gnu99
 CFLAGS += -Wall
 CFLAGS += -Werror
@@ -70,9 +71,20 @@ else
 CFLAGS += -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 $(EXTRA_CFLAGS_RELEASE)
 endif
 
+ifneq ($(SANITIZE),)
+CFLAGS += -fsanitize=$(SANITIZE)
+LDFLAGS += -fsanitize=$(SANITIZE)
+endif
+LDFLAGS += $(OS_LIBS)
+
 CFLAGS += $(EXTRA_CFLAGS)
 
-LDFLAGS += -Wl,-z,relro -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS) -L$(TOP)/src/nondebug
+LDFLAGS += -Wl,-z,relro -Wl,--warn-common -Wl,--fatal-warnings $(EXTRA_LDFLAGS)
+ifeq ($(DEBUG),1)
+LDFLAGS += -L$(TOP)/src/debug
+else
+LDFLAGS += -L$(TOP)/src/nondebug
+endif
 TARGET_DIR=$(DESTDIR)$(bindir)
 BASH_COMP_FILES ?=
 BASH_COMP_DESTDIR = $(DESTDIR)$(bashcompdir)
@@ -94,7 +106,7 @@ PMEMLOG_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemlog/libpmemlog_unscoped.o
 PMEMOBJ_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemobj/libpmemobj_unscoped.o
 PMEMBLK_PRIV_OBJ=$(LIBSDIR_PRIV)/libpmemblk/libpmemblk_unscoped.o
 
-LIBS += -pthread
+LIBS += -pthread $(LIBUUID)
 
 # XXX: required by clock_gettime(), if glibc version < 2.17
 # The os_clock_gettime() function is now in OS abstraction layer,
@@ -112,7 +124,7 @@ DYNAMIC_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcommon.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcommon.a
 CFLAGS += -I$(TOP)/src/common
-LIBS += -ldl
+LIBS += $(LIBDL)
 endif
 
 ifeq ($(LIBPMEMPOOL), y)
@@ -134,7 +146,7 @@ STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemlog.a
 endif
 
 ifeq ($(LIBPMEMOBJ), y)
-LIBS += -ldl
+LIBS += $(LIBDL)
 DYNAMIC_LIBS += -lpmemobj
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemobj.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemobj.a
@@ -162,7 +174,9 @@ CFLAGS += -I$(TOP)/src/libpmemlog
 CFLAGS += -I$(TOP)/src/libpmemblk
 CFLAGS += -I$(TOP)/src/libpmemobj
 CFLAGS += -I$(TOP)/src/tools/pmempool
+ifneq ($(OSTYPE),FreeBSD)
 common.o: CFLAGS += -D__USE_UNIX98
+endif
 
 endif
 


### PR DESCRIPTION
FreeBSD requires separate jemalloc builds for libvmem and libvmmalloc.
Add SANITIZE make option; ignore for libvmmalloc and its tests on FreeBSD.
Include FreeBSD configure changes for jemalloc to align with new Makefiles.
Include unittest.sh changes to align with new Makefiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2226)
<!-- Reviewable:end -->
