### PR TITLE
common: disable reporting of coverage for tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 ignore:
-  - "src/jemalloc/.*"
-  - "src/windows/.*"
-  - "src/test/unittest/.*"
+  - src/jemalloc/
+  - src/windows/
+  - src/test/
 
 comment:
   layout: "diff"


### PR DESCRIPTION
Code coverage is supposed to tell us about how much the code we ship is
tested. We are not shipping tests, so including them in coverage reports
doesn't make much sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2230)
<!-- Reviewable:end -->
