### PR TITLE
common: Fix ASAN check

### DIFF
--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -86,16 +86,8 @@ LIBS += $(GCOV_LIBS)
 endif
 
 ifneq ($(SANITIZE),)
-# On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
-ifneq ($(JEMALLOC_NVMLDIR),libvmmalloc)
 CFLAGS += -fsanitize=$(SANITIZE)
 LDFLAGS += -fsanitize=$(SANITIZE)
-else ifneq ($(OSTYPE),FreeBSD)
-CFLAGS += -fsanitize=$(SANITIZE)
-LDFLAGS += -fsanitize=$(SANITIZE)
-else
-$(info SANITIZE not supported for libvmmalloc, ignored)
-endif
 endif
 
 CFLAGS += $(EXTRA_CFLAGS)

--- a/src/benchmarks/pmembench.cpp
+++ b/src/benchmarks/pmembench.cpp
@@ -530,7 +530,7 @@ pmembench_parse_clo(struct pmembench *pb, struct benchmark *bench,
 static int
 pmembench_parse_affinity(const char *list, char **saveptr)
 {
-	char *str;
+	char *str = NULL;
 	char *end;
 	int cpu = 0;
 
@@ -555,7 +555,7 @@ pmembench_parse_affinity(const char *list, char **saveptr)
 			goto err;
 	}
 
-	if (*str == '\0')
+	if ((str == NULL) || (*str == '\0'))
 		goto err;
 
 	cpu = strtol(str, &end, 10);

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -234,18 +234,9 @@ LIBS += $(GCOV_LIBS)
 endif
 
 ifneq ($(SANITIZE),)
-# On FreeBSD libvmmalloc defines pthread_create, which conflicts with asan
-ifeq (,$(filter vmmalloc_%,$(TARGET)))
 CFLAGS += -fsanitize=$(SANITIZE)
 CXXFLAGS += -fsanitize=$(SANITIZE)
 LDFLAGS += -fsanitize=$(SANITIZE)
-else ifneq ($(OSTYPE),FreeBSD)
-CFLAGS += -fsanitize=$(SANITIZE)
-CXXFLAGS += -fsanitize=$(SANITIZE)
-LDFLAGS += -fsanitize=$(SANITIZE)
-else
-$(info SANITIZE not supported for libvmmalloc, ignored)
-endif
 endif
 
 LINKER=$(CC)

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -1334,8 +1334,11 @@ function require_valgrind_dev_version() {
 #	NOT require libasan
 #
 function require_no_asan_for() {
-	nm $1 | grep -q __asan_ || ASAN_ENABLED=$?
-	if [ "$ASAN_ENABLED" = "0" ]; then
+	disable_exit_on_error
+	nm $1 | grep -q __asan_
+	ASAN_ENABLED=$?
+	restore_exit_on_error
+	if [ "$ASAN_ENABLED" == "0" ]; then
 		echo "$UNITTEST_NAME: SKIP: ASAN enabled"
 		exit 0
 	fi


### PR DESCRIPTION
Fix broken ASAN check in unittest.sh.
Remove FreeBSD libvmmalloc SANITIZE check (handled by
corrected ASAN check).
Fix gcc maybe-uninitialized error in pmembench.cpp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2235)
<!-- Reviewable:end -->
