### PR TITLE
obj: fix same-size realloc volatile state change

### DIFF
--- a/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
+++ b/src/test/obj_pmalloc_basic/obj_pmalloc_basic.c
@@ -298,6 +298,13 @@ test_mock_pool_allocs(void)
 	UT_ASSERTeq(tiny0, tiny1);
 	UT_ASSERTeq(medium0, medium1);
 
+	/* realloc to the same size shouldn't affect anything */
+	for (size_t i = 0; i < tiny1; ++i)
+		test_realloc(TEST_TINY_ALLOC_SIZE, TEST_TINY_ALLOC_SIZE);
+
+	size_t tiny2 = test_oom_allocs(TEST_TINY_ALLOC_SIZE);
+	UT_ASSERTeq(tiny1, tiny2);
+
 	test_realloc(TEST_SMALL_ALLOC_SIZE, TEST_MEDIUM_ALLOC_SIZE);
 	test_realloc(TEST_HUGE_ALLOC_SIZE, TEST_MEGA_ALLOC_SIZE);
 


### PR DESCRIPTION
Currently, when performing realloc, the new block is unconditionally
allocated, and when the decision to bail out (because the request is
a no-op) happens, the volatile state changes are not reversed. This
is a pointless waste of CPU cycles, and in some cases might even lead
to persistent memory being locked out until the next heap incarnation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2245)
<!-- Reviewable:end -->
