### PR TITLE
obj: fix very large allocation classes

### DIFF
--- a/src/libpmemobj/alloc_class.h
+++ b/src/libpmemobj/alloc_class.h
@@ -100,8 +100,9 @@ void alloc_class_collection_delete(struct alloc_class_collection *ac);
 void alloc_class_generate_run_proto(struct alloc_class_run_proto *dest,
 	size_t unit_size, uint32_t size_idx);
 
-struct alloc_class *alloc_class_by_unit_size(
-	struct alloc_class_collection *ac, size_t size);
+struct alloc_class *alloc_class_by_run(
+	struct alloc_class_collection *ac,
+	size_t unit_size, enum header_type header_type, uint32_t size_idx);
 struct alloc_class *alloc_class_by_alloc_size(
 	struct alloc_class_collection *ac, size_t size);
 struct alloc_class *alloc_class_by_id(

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -593,14 +593,11 @@ heap_reclaim_run(struct palloc_heap *heap, struct bucket *defb,
 
 		*m = nb;
 	} else {
-		struct alloc_class *c = alloc_class_by_unit_size(
+		struct alloc_class *c = alloc_class_by_run(
 			heap->rt->alloc_classes,
-			run->block_size);
+			run->block_size, m->header_type, m->size_idx);
 
 		if (c == NULL ||
-		    c->type != CLASS_RUN ||
-		    c->run.size_idx != m->size_idx ||
-		    c->header_type != m->header_type ||
 		    recycler_put(heap->rt->recyclers[c->id], m) < 0)
 			m->m_ops->claim_revoke(m);
 	}

--- a/src/test/obj_heap/obj_heap.vcxproj
+++ b/src/test/obj_heap/obj_heap.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\libpmemobj\bucket.c" />
     <ClCompile Include="..\..\libpmemobj\ctree.c" />
+    <ClCompile Include="..\..\libpmemobj\cuckoo.c" />
     <ClCompile Include="..\..\libpmemobj\heap.c" />
     <ClCompile Include="..\..\libpmemobj\memblock.c" />
     <ClCompile Include="..\..\libpmemobj\memops.c" />

--- a/src/test/obj_heap/obj_heap.vcxproj.filters
+++ b/src/test/obj_heap/obj_heap.vcxproj.filters
@@ -29,6 +29,9 @@
     <ClCompile Include="..\..\libpmemobj\ctree.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libpmemobj\cuckoo.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\libpmemobj\memblock.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/tools/pmempool/Makefile
+++ b/src/tools/pmempool/Makefile
@@ -53,9 +53,9 @@ TOOLS_COMMON=y
 
 LIBPMEMOBJ_PRIV=pvector_new pvector_nvalues pvector_first pvector_next\
 	pvector_delete memblock_from_offset alloc_class_by_id\
-	memblock_rebuild_state alloc_class_get_create_by_unit_size\
+	memblock_rebuild_state alloc_class_by_run\
 	heap_run_foreach_object alloc_class_collection_new\
-	alloc_class_by_unit_size alloc_class_collection_delete
+	alloc_class_collection_delete
 
 LIBPMEMBLK_PRIV=btt_init btt_write btt_fini btt_info_convert2h\
 	btt_info_convert2le btt_flog_convert2h btt_flog_convert2le

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -675,8 +675,9 @@ info_obj_chunk(struct pmem_info *pip, uint64_t c, uint64_t z,
 				sizeof(run->block_size) + sizeof(run->bitmap),
 				PTR_TO_OFF(pop, run), 1);
 
-		struct alloc_class *aclass = alloc_class_by_unit_size(
-			pip->obj.alloc_classes, run->block_size);
+		struct alloc_class *aclass = alloc_class_by_run(
+			pip->obj.alloc_classes,
+			run->block_size, m.header_type, m.size_idx);
 		if (aclass) {
 			outv_field(v, "Block size", "%s",
 					out_get_size_str(run->block_size,


### PR DESCRIPTION
This patch changes the internal unit_size<>class mapping from a
simple array into a hashmap, thus allowing for arbitrary sized
classes.

Ref: pmem/issues#626

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2253)
<!-- Reviewable:end -->
