### PR TITLE
common: issue vs15.3 offsetof fix

### DIFF
--- a/src/include/libpmemobj/types.h
+++ b/src/include/libpmemobj/types.h
@@ -43,6 +43,17 @@
 extern "C" {
 #endif
 
+/*
+ * XXX - workaround for issue in VS 15.3
+ * https://developercommunity.visualstudio.com/content/problem/96174/
+ * offsetof-macro-is-broken-for-nested-objects.html
+ */
+#ifdef _CRT_USE_BUILTIN_OFFSETOF
+#undef offsetof
+#define offsetof(s, m) ((size_t)&reinterpret_cast < char const volatile& > \
+((((s *)0)->m)))
+#endif
+
 #define TOID_NULL(t)	((TOID(t))OID_NULL)
 #define PMEMOBJ_MAX_LAYOUT ((size_t)1024)
 


### PR DESCRIPTION
Ref: pmem/issues#645

Here is the issue described:
https://developercommunity.visualstudio.com/content/problem/96174/offsetof-macro-is-broken-for-nested-objects.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2254)
<!-- Reviewable:end -->
