### PR TITLE
common: Fix cstyle for "long long intxxx"

### DIFF
--- a/utils/cstyle
+++ b/utils/cstyle
@@ -705,12 +705,12 @@ line: while (<$filehandle>) {
 	if (/typedef[\S\s]+\*\s*\w+\s*;/) {
 		err("typedefed pointer type");
 	}
-	if (/unsigned\s+int/) {
+	if (/unsigned\s+int\s/) {
 		err("'unsigned int' instead of just 'unsigned'");
 	}
-	if (/long\s+long\s+int/) {
+	if (/long\s+long\s+int\s/) {
 		err("'long long int' instead of just 'long long'");
-	} elsif (/long\s+int/) {
+	} elsif (/long\s+int\s/) {
 		err("'long int' instead of just 'long'");
 	}
 


### PR DESCRIPTION
The current cstyle prohibits "long long internal_var" because it doesn't look for whitespace after "int".

Split from FreeBSD port PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2255)
<!-- Reviewable:end -->
