### PR TITLE
common: More Makefile portability changes

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -224,13 +224,17 @@ endif
 
 sparse-c = $(shell for c in *.c; do sparse -Wsparse-all -Wno-declaration-after-statement $(CFLAGS) $(INCS) $$c || true; done)
 
-ifeq ($(OSTYPE),FreeBSD)
-OS_INCS = -I$(TOP)/src/freebsd/include -I/usr/local/include
-OS_LIBS = -L/usr/local/lib
+ifeq ($(shell uname -s),FreeBSD)
+GLIBC_CXXFLAGS=-D_GLIBCXX_USE_C99
+UNIX98_CFLAGS=
+OS_INCS=-I$(TOP)/src/freebsd/include -I/usr/local/include
+OS_LIBS=-L/usr/local/lib
 LIBDL=
 LIBUTIL=-lutil
 LIBUUID=-luuid
 else
+GLIBC_CXXFLAGS=
+UNIX98_CFLAGS=-D__USE_UNIX98
 OS_INCS=
 OS_LIBS=
 LIBDL=-ldl

--- a/src/examples/Makefile.inc
+++ b/src/examples/Makefile.inc
@@ -43,9 +43,7 @@ LIBDIR = $(TOP_SRC)/debug
 include $(TOP)/src/common.inc
 
 CXXFLAGS = -std=c++11 -ggdb -Wall -Werror
-ifeq ($(OSTYPE),FreeBSD)
-CXXFLAGS += -D_GLIBCXX_USE_C99
-endif
+CXXFLAGS += $(GLIBC_CXXFLAGS)
 CXXFLAGS +=  $(EXTRA_CXXFLAGS)
 CFLAGS = -std=gnu99 -ggdb -Wall -Werror -Wmissing-prototypes $(EXTRA_CFLAGS)
 LDFLAGS = -Wl,-rpath=$(LIBDIR) -L$(LIBDIR) $(EXTRA_LDFLAGS)

--- a/src/examples/libpmemobj/panaconda/Makefile
+++ b/src/examples/libpmemobj/panaconda/Makefile
@@ -45,7 +45,7 @@ $(info NOTE: Skipping panaconda because ncurses is missing \
 endif
 
 LIBS = -lpmemobj -lpmem -pthread
-ifeq ($(OSTYPE),FreeBSD)
+ifeq ($(shell uname -s),FreeBSD)
 LIBS += -lc
 endif
 

--- a/src/examples/libpmemobj/pmpong/Makefile
+++ b/src/examples/libpmemobj/pmpong/Makefile
@@ -34,7 +34,7 @@ include $(TOP)/src/common.inc
 
 SFML := $(call check_package, sfml-all --atleast-version 2.4)
 ifeq ($(SFML),y)
-ifeq ($(OSTYPE),FreeBSD)
+ifeq ($(shell uname -s),FreeBSD)
 FONTDIR=/usr/local/share/fonts
 else
 FONTDIR=/usr/share/fonts

--- a/src/jemalloc/jemalloc.mk
+++ b/src/jemalloc/jemalloc.mk
@@ -55,7 +55,7 @@ JEMALLOC_CFG_OUT_FILES = $(patsubst $(JEMALLOC_DIR)/%, $(JEMALLOC_OBJDIR)/%, $(J
 JEMALLOC_AUTOM4TE_CACHE=autom4te.cache
 JEMALLOC_CONFIG_FILE = $(JEMALLOC_DIR)/jemalloc.cfg
 JEMALLOC_CONFIG = $(shell cat $(JEMALLOC_CONFIG_FILE))
-ifeq ($(OSTYPE), FreeBSD)
+ifeq ($(shell uname -s),FreeBSD)
 ifndef $(CC)
 JEMALLOC_CONFIG += CC=$(CC) # Default to system compiler (not gcc) on FreeBSD
 endif
@@ -81,7 +81,7 @@ CFLAGS_FILTER += -Wshadow
 CFLAGS_FILTER += -Wdisabled-macro-expansion
 CFLAGS_FILTER += -Wlanguage-extension-token
 JEMALLOC_CFLAGS=$(filter-out $(CFLAGS_FILTER), $(CFLAGS))
-ifeq ($(OSTYPE), FreeBSD)
+ifeq ($(shell uname -s),FreeBSD)
 JEMALLOC_CFLAGS += -I/usr/local/include
 endif
 JEMALLOC_REMOVE_LDFLAGS_TMP = -Wl,--warn-common

--- a/src/test/Makefile.inc
+++ b/src/test/Makefile.inc
@@ -193,11 +193,13 @@ endif
 # in the unittest framework. It scans the code for functions that should be
 # wrapped and adds required linker flags.
 #
-WRAPPER_FUNCS=FUNC_MOCK_RET_ALWAYS|FUNC_MOCK_RET_ALWAYS_VOID|FUNC_MOCK
 PAREN=(
 extract_funcs = $(shell \
-    grep -Po '($(WRAPPER_FUNCS))\$(PAREN)\K[^,]*' $(1) | \
-    awk '{print "-Wl,--wrap="$$0}')
+    awk -F '[$(PAREN),]' \
+    '/(FUNC_MOCK_RET_ALWAYS|FUNC_MOCK_RET_ALWAYS_VOID|FUNC_MOCK)\$(PAREN)[^,]/ \
+    { \
+        print "-Wl,--wrap=" $$2 \
+    }' $(1) )
 
 INCS += -I../unittest -I$(TOP)/src/include -I$(TOP)/src/common
 
@@ -212,9 +214,7 @@ endif
 COMMON_FLAGS += -fno-common
 
 CXXFLAGS  = -std=c++11
-ifeq ($(OSTYPE),FreeBSD)
-CXXFLAGS += -D_GLIBCXX_USE_C99
-endif
+CXXFLAGS += $(GLIBC_CXXFLAGS)
 CXXFLAGS += -ggdb
 CXXFLAGS += $(COMMON_FLAGS)
 CXXFLAGS += $(EXTRA_CXXFLAGS)
@@ -334,7 +334,7 @@ objdir=.
 	$(call check-cstyle, $<, $@)
 
 clean:
-	$(RM) *.o */*.o core a.out *.log testfile* $(SYNC_FILE) $(TMP_HEADERS)
+	$(RM) *.o */*.o core *.core a.out *.log testfile* $(SYNC_FILE) $(TMP_HEADERS)
 
 clobber: clean
 	$(RM) $(TARGET) $(TARGET_STATIC_DEBUG) $(TARGET_STATIC_NONDEBUG)

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -174,9 +174,7 @@ CFLAGS += -I$(TOP)/src/libpmemlog
 CFLAGS += -I$(TOP)/src/libpmemblk
 CFLAGS += -I$(TOP)/src/libpmemobj
 CFLAGS += -I$(TOP)/src/tools/pmempool
-ifneq ($(OSTYPE),FreeBSD)
-common.o: CFLAGS += -D__USE_UNIX98
-endif
+CFLAGS += $(UNIX98_CFLAGS)
 
 endif
 


### PR DESCRIPTION
Use uname -s rather than $OSTYPE.
Add more flags in common.inc.
Avoid need for GNU grep.

Split from FreeBSD port PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2256)
<!-- Reviewable:end -->
