### PR TITLE
test: Match file enhancement and cleanup

### DIFF
--- a/src/test/README
+++ b/src/test/README
@@ -219,6 +219,7 @@ The match script provides several pattern-matching macros that allow for normal
 variation in the test output:
 
 	$(N)	an integer (i.e. one or more decimal digits)
+	$(NC)	one or more decimal digits with optional comma separators
 	$(FP)	a floating point number
 	$(S)	ascii string
 	$(X)	hex number
@@ -227,6 +228,8 @@ variation in the test output:
 	$(*)	any string
 	$(DD)	output of a "dd" run
 	$(OPT)	the entire line is optional
+	$(OPX)	ends a contiguous list of $(OPT)...$(OPX) lines, at least
+		one of which must match
 
 The small C programs used for unit testing are designed to not worry about the
 return values for things not under test.  This is done with the all-caps
@@ -262,3 +265,14 @@ pattern for creating new unit tests is to follow steps like these:
 When a "check" type test is run (the default), each test should try to limit
 the real execution time to a couple minutes or less.  "short" and "long"
 versions of the tests are encouraged, especially for stress testing.
+
+PORTABILITY CONSIDERATIONS
+
+unittest.sh defines a number of macros to support portability across POSIX
+operating systems. See the Portability section of unittest.sh for details.
+
+When a matching line count of an output file is required, use "$GREP -c" rather
+than "$GREP | wc -l".
+
+Use canonical ordering of program options and arguments, i.e., put all options
+before any arguments. Not all operating systems support option reordering.

--- a/src/test/match
+++ b/src/test/match
@@ -46,6 +46,7 @@
 # exact matches.  the supported tokens are:
 #
 #	$(N)	an integer (i.e. one or more decimal digits)
+#	$(NC)	one or more decimal digits with comma separators
 #	$(FP)	a floating point number
 #	$(S)	ascii string
 #	$(X)	hex number
@@ -55,6 +56,8 @@
 #	$(*)	any string
 #	$(DD)	output of a "dd" run
 #	$(OPT)	line is optional (may be missing, matched if found)
+#	$(OPX)	ends a contiguous list of $(OPT)...$(OPX) lines, at least
+#		one of which must match
 #
 # arguments are:
 #
@@ -164,6 +167,8 @@ sub match {
 	my $line_pat = 0;
 	my $line_out = 0;
 	my $opt = 0;
+	my $opx = 0;
+	my $opt_found = 0;
 
 	my $fstr = snarf($mfile);
 	for (split /^/, $fstr) {
@@ -173,6 +178,7 @@ sub match {
 		s/([*+?|{}.\\^\$\[()])/\\$1/g;
 		s/\\\$\\\(FP\\\)/[-+]?\\d*\\.?\\d+([eE][-+]?\\d+)?/g;
 		s/\\\$\\\(N\\\)/[-+]?\\d+/g;
+		s/\\\$\\\(NC\\\)/[-+]?\\d+(,[0-9]+)*/g;
 		s/\\\$\\\(\\\*\\\)/\\p{Print}*/g;
 		s/\\\$\\\(S\\\)/\\P{IsC}+/g;
 		s/\\\$\\\(X\\\)/\\p{XPosixXDigit}+/g;
@@ -182,6 +188,10 @@ sub match {
 		s/\\\$\\\(DD\\\)/\\d+\\+\\d+ records in\n\\d+\\+\\d+ records out\n\\d+ bytes \\\(\\d+ .B\\\) copied, [.0-9e-]+[^,]*, [.0-9]+ .B.s/g;
 		if (s/\\\$\\\(OPT\\\)//) {
 			$opt = 1;
+		} elsif (s/\\\$\\\(OPX\\\)//) {
+			$opx = 1;
+		} else {
+			$opt_found = 0;
 		}
 
 		if ($opt_v) {
@@ -199,7 +209,7 @@ sub match {
 		print " => /$_/\n" if $opt_d;
 		print " [$output]\n" if $opt_d;
 		unless ($output =~ s/^$_//) {
-			if ($opt) {
+			if ($opt || ($opx && $opt_found)) {
 				printf("%s:%-3d      [skipping optional line]\n", $ofile, $line_out) if $opt_v;
 				$line_out--;
 				$opt = 0;
@@ -216,7 +226,10 @@ sub match {
 
 				die "$mfile:$line_pat did not match pattern\n";
 			}
+		} elsif ($opt) {
+			$opt_found = 1;
 		}
+		$opx = 0;
 	}
 
 	if ($output ne '') {

--- a/src/test/out_err/out0.log.match
+++ b/src/test/out_err/out0.log.match
@@ -1,7 +1,8 @@
 out_err$(nW)TEST0: START: out_err$(nW)
  $(nW)out_err$(nW)
 ERR #1
-ERR #2: Success
+$(OPT)ERR #2: Success
+$(OPX)ERR #2: No error: 0
 ERR #3: Invalid argument
 ERR1: Bad file descriptor:1234
 ERR2: Bad file descriptor:1234

--- a/src/test/out_err/traces0.log.match
+++ b/src/test/out_err/traces0.log.match
@@ -6,7 +6,8 @@ $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind h
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind memcheck
 $(OPT)<trace>: <1> [out.c:$(N) out_init]$(W)compiled with support for Valgrind drd
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #1
-<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
+$(OPT)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: Success
+$(OPX)<trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #2: No error: 0
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR #3: Invalid argument
 <trace>: <1> [out_err$(nW).c:$(N) $(nW)main]$(W)ERR1: Bad file descriptor:1234
 ERR2: Bad file descriptor:1234

--- a/src/test/util_map_proc/out0.log.match
+++ b/src/test/util_map_proc/out0.log.match
@@ -1,13 +1,13 @@
 util_map_proc/TEST0: START: util_map_proc
- ./util_map_proc$(nW) maps_all 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
-redirecting /proc/self/maps to maps_all
+ ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
+redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x$(X)
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0x$(X)
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x$(X)
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x$(X)
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x$(X)
 util_map_proc/TEST0: DONE

--- a/src/test/util_map_proc/out1.log.match
+++ b/src/test/util_map_proc/out1.log.match
@@ -1,13 +1,13 @@
 util_map_proc/TEST1: START: util_map_proc
- ./util_map_proc$(nW) maps_none 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
-redirecting /proc/self/maps to maps_none
+ ./util_map_proc$(nW) maps_none$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
+redirecting /proc/$(*) to maps_none$(*)
 len 1048576: (nil) 0x$(X)
-redirecting /proc/self/maps to maps_none
+redirecting /proc/$(*) to maps_none$(*)
 len 16777216: (nil) 0x$(X)
-redirecting /proc/self/maps to maps_none
+redirecting /proc/$(*) to maps_none$(*)
 len 1073741824: (nil) 0x$(X)
-redirecting /proc/self/maps to maps_none
+redirecting /proc/$(*) to maps_none$(*)
 len 17179869184: (nil) 0x$(X)
-redirecting /proc/self/maps to maps_none
+redirecting /proc/$(*) to maps_none$(*)
 len 274877906944: (nil) 0x$(X)
 util_map_proc/TEST1: DONE

--- a/src/test/util_map_proc/out2.log.match
+++ b/src/test/util_map_proc/out2.log.match
@@ -1,13 +1,13 @@
 util_map_proc/TEST2: START: util_map_proc
- ./util_map_proc$(nW) maps_align 0x0001000000 0x0001100000 0x0001110000 0x0001110800 0x0001111000
-redirecting /proc/self/maps to maps_align
+ ./util_map_proc$(nW) maps_align$(*) 0x0001000000 0x0001100000 0x0001110000 0x0001110800 0x0001111000
+redirecting /proc/$(*) to maps_align$(*)
 len 16777216: 0x10080000000 0x$(X)
-redirecting /proc/self/maps to maps_align
+redirecting /proc/$(*) to maps_align$(*)
 len 17825792: 0x10080000000 0x$(X)
-redirecting /proc/self/maps to maps_align
+redirecting /proc/$(*) to maps_align$(*)
 len 17891328: 0x10080000000 0x$(X)
-redirecting /proc/self/maps to maps_align
+redirecting /proc/$(*) to maps_align$(*)
 len 17893376: (nil) 0x$(X)
-redirecting /proc/self/maps to maps_align
+redirecting /proc/$(*) to maps_align$(*)
 len 17895424: (nil) 0x$(X)
 util_map_proc/TEST2: DONE

--- a/src/test/util_map_proc/out3.log.match
+++ b/src/test/util_map_proc/out3.log.match
@@ -1,13 +1,13 @@
 util_map_proc/TEST3: START: util_map_proc
- ./util_map_proc$(nW) maps_end 0x0000100000 0x0001000000 0x003F000000 0x003FFFF000 0x0040000000
-redirecting /proc/self/maps to maps_end
+ ./util_map_proc$(nW) maps_end$(*) 0x0000100000 0x0001000000 0x003F000000 0x003FFFF000 0x0040000000
+redirecting /proc/$(*) to maps_end$(*)
 len 1048576: 0xffffffffc0000000 0x$(X)
-redirecting /proc/self/maps to maps_end
+redirecting /proc/$(*) to maps_end$(*)
 len 16777216: 0xffffffffc0000000 0x$(X)
-redirecting /proc/self/maps to maps_end
+redirecting /proc/$(*) to maps_end$(*)
 len 1056964608: 0xffffffffc0000000 0x$(X)
-redirecting /proc/self/maps to maps_end
+redirecting /proc/$(*) to maps_end$(*)
 len 1073737728: 0xffffffffc0000000 0x$(X)
-redirecting /proc/self/maps to maps_end
+redirecting /proc/$(*) to maps_end$(*)
 len 1073741824: 0xffffffffffffffff 0x$(X)
 util_map_proc/TEST3: DONE

--- a/src/test/util_map_proc/out4.log.match
+++ b/src/test/util_map_proc/out4.log.match
@@ -1,18 +1,18 @@
 util_map_proc/TEST4: START: util_map_proc
- ./util_map_proc$(nW) maps_all 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+ ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x2e000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0x2e000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x2e000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x2e000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x800000000000
 util_map_proc/TEST4: DONE

--- a/src/test/util_map_proc/out5.log.match
+++ b/src/test/util_map_proc/out5.log.match
@@ -1,18 +1,18 @@
 util_map_proc/TEST5: START: util_map_proc
- ./util_map_proc$(nW) maps_all 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+ ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x1000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0xa00000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x2800000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x40000000
-redirecting /proc/self/maps to maps_all
-redirecting /proc/self/maps to maps_all
+redirecting /proc/$(*) to maps_all$(*)
+redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x3300000000
 util_map_proc/TEST5: DONE

--- a/src/test/vmem_valgrind/memcheck2.log.match
+++ b/src/test/vmem_valgrind/memcheck2.log.match
@@ -6,8 +6,8 @@
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
-==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(NC) bytes allocated
 ==$(N)== 
 ==$(N)== $(N) bytes in 1 blocks are definitely lost in loss record 1 of $(N)
 ==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
@@ -19,7 +19,7 @@ $(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
 ==$(N)==    indirectly lost: 0 bytes in 0 blocks
 ==$(N)==      possibly lost: 0 bytes in 0 blocks
 ==$(N)==    still reachable: 0 bytes in 0 blocks
-==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind/memcheck3.log.match
+++ b/src/test/vmem_valgrind/memcheck3.log.match
@@ -4,10 +4,10 @@
 ==$(N)== Command:$(*)
 ==$(N)== Parent PID: $(N)
 ==$(N)== 
-$(OPT)==$(N)== 
+==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
-==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(NC) bytes allocated
 ==$(N)== 
 ==$(N)== $(N) bytes in 1 blocks are definitely lost in loss record 1 of $(N)
 ==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
@@ -19,7 +19,7 @@ $(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
 ==$(N)==    indirectly lost: 0 bytes in 0 blocks
 ==$(N)==      possibly lost: 0 bytes in 0 blocks
 ==$(N)==    still reachable: 0 bytes in 0 blocks
-==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind/memcheck4.log.match
+++ b/src/test/vmem_valgrind/memcheck4.log.match
@@ -13,16 +13,16 @@ $(OPT)==$(N)==    by 0x$(X): vmem_malloc $(*)
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
-==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(NC) bytes allocated
 ==$(N)== 
 $(OPT)==$(N)== All heap blocks were freed -- no leaks are possible
-$(OPT)==$(N)== LEAK SUMMARY:
+$(OPX)==$(N)== LEAK SUMMARY:
 $(OPT)==$(N)==    definitely lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    indirectly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==      possibly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    still reachable: 0 bytes in 0 blocks
-$(OPT)==$(N)==         suppressed: $(N) bytes in $(N) blocks
+$(OPT)==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmem_valgrind/vmem_valgrind.c
+++ b/src/test/vmem_valgrind/vmem_valgrind.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016, Intel Corporation
+ * Copyright 2014-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -186,6 +186,8 @@ main(int argc, char *argv[])
 
 			/* prevent reporting leaked memory as still reachable */
 			ptr = NULL;
+			/* Clean up pool, above malloc will still leak */
+			vmem_delete(vmp);
 			break;
 		}
 		case 4: {

--- a/src/test/vmmalloc_valgrind/memcheck1.log.match
+++ b/src/test/vmmalloc_valgrind/memcheck1.log.match
@@ -6,8 +6,8 @@
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
-==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(NC) bytes allocated
 ==$(N)== 
 ==$(N)== $(N) bytes in 1 blocks are definitely lost in loss record 1 of $(N)
 ==$(N)==    at 0x$(X): je_vmem_pool_malloc $(*)
@@ -19,7 +19,7 @@ $(OPT)==$(N)==    by 0x$(X): malloc $(*)
 ==$(N)==    indirectly lost: 0 bytes in 0 blocks
 ==$(N)==      possibly lost: 0 bytes in 0 blocks
 ==$(N)==    still reachable: 0 bytes in 0 blocks
-==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/vmmalloc_valgrind/memcheck2.log.match
+++ b/src/test/vmmalloc_valgrind/memcheck2.log.match
@@ -13,16 +13,16 @@ $(OPT)==$(N)==    by 0x$(X): malloc $(*)
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
-==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
+==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(NC) bytes allocated
 ==$(N)== 
 $(OPT)==$(N)== All heap blocks were freed -- no leaks are possible
-$(OPT)==$(N)== LEAK SUMMARY:
+$(OPX)==$(N)== LEAK SUMMARY:
 $(OPT)==$(N)==    definitely lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    indirectly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==      possibly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    still reachable: 0 bytes in 0 blocks
-$(OPT)==$(N)==         suppressed: $(N) bytes in $(N) blocks
-==$(N)== 
+$(OPT)==$(N)==         suppressed: $(NC) bytes in $(N) blocks
+$(OPT)==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))


### PR DESCRIPTION
Add $(OPX) and $(NC) match macros.
Make match files portable across Linux and FreeBSD.
Fix vmem_valgrind.c to call vmem_delete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2259)
<!-- Reviewable:end -->
