### PR TITLE
[RFC] Add support for pool set options

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -638,15 +638,24 @@ page_aligned_part_size = part_size & ~(page_size - 1)
 ```
 
 Note that page size is OS specific. For more information please see **sysconf**(3).
-The minimum net pool size of a pool set allowed by the library for a transactional object store is defined in **\<libpmemobj.h\>** as **PMEMOBJ_MIN_POOL**.
+The minimum net pool size of a pool set allowed by the library for
+a transactional object store is defined in **\<libpmemobj.h\>**
+as **PMEMOBJ_MIN_POOL**.
 
-Sections defining the replica sets are optional. There could be multiple replica sections and each must start with the line containing a *REPLICA* string.
-Lines starting with "#" character are ignored. A replica can be local or remote. In case of a local replica, the REPLICA line has to consist of the *REPLICA*
-string only and it has to be followed by at least one line defining a part of the local replica. The format of such line is the same as the format of the line
-defining a part of the PMEMOBJ pool as described above.
+The "#" character indicates the beginning of a comment.  Comments can start
+anywhere on the line and continue until the end of the line.
+
+Sections defining the replica sets are optional.  There could be multiple
+replica sections and each must start with the line containing a *REPLICA*
+string.  A replica can be local or remote.  In case of a local replica,
+the REPLICA line has
+to consist of the *REPLICA* string only and it has to be followed by
+at least one line defining a part of the local replica.  The format of such
+line is the same as the format of the line defining a part of the PMEMOBJ
+pool as described above.
 
 The path of a part can point to a Device DAX and in such case the size
-argument can be set to an "AUTO" string, which means that the size of the device
+argument can be set to an *AUTO* string, which means that the size of the device
 will be automatically resolved at pool creation time.
 When using Device DAX there's also one additional restriction - it is not allowed
 to concatenate more than one Device DAX device in a single replica
@@ -658,6 +667,26 @@ desired alignment on Device DAX.
 Device DAX is the device-centric analogue of Filesystem DAX. It allows memory
 ranges to be allocated and mapped without need of an intervening file system.
 For more information please see **ndctl-create-namespace**(1).
+
+Lines starting with the *OPTION* string may be used to specify some optional
+pool set configuration settings.  The *OPTION* string must be followed by
+one or more option names saparated by whitespace.
+There could be more than one lines with *OPTION* directive and they may appear
+anywhere in the pool set file.
+It is not an error if the same option name is specified more than once.
+If the specified option is unknown or unsupported in given version of the library
+!pmemobj_create and !pmemobj_open return NULL and set *errno* appropriately.
+
+The valid option names:
++ **NOHDRS** - Only the first part of each replica contains the pool header.
+  This option is required when creating a pool set that spans multiple Device DAX
+  devices with the internal alignment other than 4KiB.
+
++ **AUTOGROW** - If specified, the pool will grow up automatically when it runs
+  out of free space.  The pool is expanded by resizing the last part of each
+  replica.  The size of the last part of each replica specified in the pool
+  set file is assumed to be its initial size used only in !pmemobj_create -
+  it is not validated when the pool is open with !pmemobj_open.
 
 !ifndef{WIN32}
 {
@@ -689,6 +718,7 @@ REPLICA
 REPLICA user@example.com remote-objpool.set
 ```
 }
+
 The files in the set may be created by running the following command:
 
 ```

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -58,6 +58,21 @@ extern "C" {
 #define POOLSET_REPLICA_SIG "REPLICA"
 #define POOLSET_REPLICA_SIG_LEN 7	/* does NOT include '\0' */
 
+#define POOLSET_OPTION_SIG "OPTION"
+#define POOLSET_OPTION_SIG_LEN 6	/* does NOT include '\0' */
+
+/* pool set option flags */
+enum pool_set_option_flag {
+	OPTION_UNKNOWN = 0x0,
+	OPTION_NO_HDRS = 0x1,
+	OPTION_AUTO_GROW = 0x2,
+};
+
+struct pool_set_option {
+	const char *name;
+	enum pool_set_option_flag flag;
+};
+
 #define POOL_LOCAL 0
 #define POOL_REMOTE 1
 
@@ -115,6 +130,7 @@ struct pool_set {
 	int zeroed;		/* true if all the parts are new files */
 	size_t poolsize;	/* the smallest replica size */
 	int remote;		/* true if contains a remote replica */
+	unsigned options;	/* enabled pool set options */
 	struct pool_replica *replica[];
 };
 

--- a/src/test/util_poolset_parse/grep0.log.match
+++ b/src/test/util_poolset_parse/grep0.log.match
@@ -43,3 +43,11 @@ $(*)pool41$(nW).set [incorrect format of size:4]
 $(*)pool42$(nW).set [incorrect format of size:8]
 $(*)pool43$(nW).set [incorrect format of size:8]
 $(*)set file format correct ($(nW)pool44$(nW).set)
+$(*)set file format correct ($(nW)pool45$(nW).set)
+$(*)set file format correct ($(nW)pool46$(nW).set)
+$(*)set file format correct ($(nW)pool47$(nW).set)
+$(*)set file format correct ($(nW)pool48$(nW).set)
+$(*)set file format correct ($(nW)pool49$(nW).set)
+$(*)set file format correct ($(nW)pool50$(nW).set)
+$(*)pool51$(nW).set [unknown option:2]
+$(*)pool52$(nW).set [missing option name:2]

--- a/src/test/util_poolset_parse/pool45.set
+++ b/src/test/util_poolset_parse/pool45.set
@@ -1,0 +1,3 @@
+PMEMPOOLSET
+OPTION NOHDRS
+100G /mountpoint1/part0

--- a/src/test/util_poolset_parse/pool46.set
+++ b/src/test/util_poolset_parse/pool46.set
@@ -1,0 +1,4 @@
+PMEMPOOLSET
+OPTION NOHDRS # same option specified twice
+OPTION NOHDRS
+100G /mountpoint1/part0

--- a/src/test/util_poolset_parse/pool47.set
+++ b/src/test/util_poolset_parse/pool47.set
@@ -1,0 +1,4 @@
+PMEMPOOLSET
+OPTION NOHDRS # each option in a separate line
+OPTION AUTOGROW		# comment
+100G /mountpoint1/part0

--- a/src/test/util_poolset_parse/pool48.set
+++ b/src/test/util_poolset_parse/pool48.set
@@ -1,0 +1,3 @@
+PMEMPOOLSET
+OPTION	NOHDRS	AUTOGROW  # two options in a single line
+100G /mountpoint1/part0

--- a/src/test/util_poolset_parse/pool49.set
+++ b/src/test/util_poolset_parse/pool49.set
@@ -1,0 +1,6 @@
+PMEMPOOLSET
+OPTION	AUTOGROW	# comment
+100G /mountpoint1/part0
+OPTION	NOHDRS		# comment
+REPLICA
+100G /mountpoint2/part0

--- a/src/test/util_poolset_parse/pool50.set
+++ b/src/test/util_poolset_parse/pool50.set
@@ -1,0 +1,6 @@
+PMEMPOOLSET
+100G /mountpoint1/part0
+OPTION	AUTOGROW	# comment
+REPLICA
+100G /mountpoint2/part0
+OPTION	NOHDRS		# comment

--- a/src/test/util_poolset_parse/pool51.set
+++ b/src/test/util_poolset_parse/pool51.set
@@ -1,0 +1,5 @@
+PMEMPOOLSET
+OPTION XXX # unknown option
+100G /mountpoint1/part0
+REPLICA
+100G /mountpoint2/part0

--- a/src/test/util_poolset_parse/pool52.set
+++ b/src/test/util_poolset_parse/pool52.set
@@ -1,0 +1,5 @@
+PMEMPOOLSET
+OPTION # no option
+100G /mountpoint1/part0
+REPLICA
+100G /mountpoint2/part0


### PR DESCRIPTION
The prototype support for pool set options:
```
PMEMPOOLSET
OPTION XXX YYY # multiple options in a single line
OPTION XXX # XXX already specified - no error, only warning
OPTION # error: missing option name
OPTION UNKNOWN # error: unknown option
100G /mnt/pmem0/part0
100G /mnt/pmem1/part1
OPTION YYY # can be anywhere in the file
REPLICA
OPTION ZZZ # can be anywhere in the file
100G /mnt/pmem2/part2
```

- The line with *OPTION* may appear anywhere in the pool set file.
- There could be one or more option specified in a single line.
- There could be more than one *OPTION* line in the pool set file.
- Pool set options affect all the replicas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2268)
<!-- Reviewable:end -->
