### PR TITLE
examples: pi: fix persist range

### DIFF
--- a/src/examples/libpmemobj/pi.c
+++ b/src/examples/libpmemobj/pi.c
@@ -108,7 +108,7 @@ calc_pi(LPVOID arg)
 		result += (pow(-1, (double)i) / (2 * i + 1));
 	}
 	D_RW(task)->proto.result = result;
-	pmemobj_persist(pop, &D_RW(task)->proto.result, sizeof(double));
+	pmemobj_persist(pop, &D_RW(task)->proto.result, sizeof(result));
 
 	POBJ_LIST_MOVE_ELEMENT_HEAD(pop, &D_RW(pi)->todo, &D_RW(pi)->done,
 					task, todo, done);


### PR DESCRIPTION
Modified result has type 'long double' that is twice the size of 'double'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2270)
<!-- Reviewable:end -->
