### PR TITLE
common: Use clang-format 3.8 only

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -46,8 +46,13 @@ OS_BANNED = $(TOP)/utils/os-banned
 COVERAGE = 0
 
 PKG_CONFIG ?= pkg-config
-CLANG_FORMAT ?= clang-format
 HEADERS = $(wildcard *.h) $(wildcard *.hpp)
+
+ifeq ($(shell command -v clang-format-3.8 > /dev/null && echo y || echo n), y)
+CLANG_FORMAT ?= clang-format-3.8
+else
+CLANG_FORMAT ?= clang-format
+endif
 
 GCOV_CFLAGS=-fprofile-arcs -ftest-coverage --coverage
 GCOV_LDFLAGS=-fprofile-arcs -ftest-coverage

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -48,15 +48,15 @@ function usage() {
 }
 
 #
-# require clang-format version 3.8+
+# require clang-format version 3.8
 #
 function check_clang_version() {
 	set +e
 	which ${clang_format_bin} &> /dev/null && ${clang_format_bin} --version |\
-	grep "version 3.[8-9]\|version [4-9].[0-9]*\|version 3.[1-9][0-9]"i\
+	grep "version 3\.8"\
 	&> /dev/null
 	if [ $? -ne 0 ]; then
-		echo "SKIP: requires clang-format version 3.8+"
+		echo "SKIP: requires clang-format version 3.8"
 		exit 0
 	fi
 	set -e


### PR DESCRIPTION
Even using 3.9 appears to break the build:
```
$ CLANG_FORMAT=clang-format-3.9 make cstyle
diff --git a/pmemobj_atomic_lists.cpp b/
index 1bc5ffccc..000000000 100644
--- a/pmemobj_atomic_lists.cpp
+++ b/
@@ -166,10 +166,10 @@ struct obj_worker {
        size_t n_elm;                /* number of elements in array */
        fn_position_t *fn_positions; /* element access functions */
        struct element elm;       /* pointer to current element */
-                                    /*
-                                     * list_move is a pointer to structure storing variables used by
-                                     * second list (used only for obj_move benchmark).
-                                     */
+       /*
+        * list_move is a pointer to structure storing variables used by
+        * second list (used only for obj_move benchmark).
+        */
        struct obj_worker *list_move;
 };

../../src/common.inc:137: recipe for target 'cstyle-check' failed

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2276)
<!-- Reviewable:end -->
