### PR TITLE
[RFC] common: add support for headerless pools

### DIFF
--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -632,6 +632,10 @@ as **PMEMOBJ_MIN_PART**. The net pool size of the pool set is equal to:
 ```
 net_pool_size = sum_over_all_parts(page_aligned_part_size - 4KiB) + 4KiB
 ```
+or, in case when the pool was created with *OPTION NOHDRS*:
+```
+net_pool_size = sum_over_all_parts(page_aligned_part_size) - 4KiB
+```
 where
 ```
 page_aligned_part_size = part_size & ~(page_size - 1)

--- a/src/common/pool_hdr.h
+++ b/src/common/pool_hdr.h
@@ -143,4 +143,9 @@ int util_feature_check(struct pool_hdr *hdrp, uint32_t incompat,
 (alignment_desc_of(long double)	<<  9 * ALIGNMENT_DESC_BITS) |\
 (alignment_desc_of(void *)	<< 10 * ALIGNMENT_DESC_BITS)
 
+/*
+ * incompat features
+ */
+#define POOL_FEAT_NOHDRS 0x0001 /* pool header only in the first part */
+
 #endif

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -798,18 +798,6 @@ util_parse_add_part(struct pool_set *set, const char *path, size_t filesize)
 	ASSERTne(rep, NULL);
 
 	int is_dev_dax = util_file_is_device_dax(path);
-	if (rep->nparts != 0) {
-		if (is_dev_dax != rep->part[0].is_dev_dax) {
-			ERR("either all the parts must be device dax or none");
-			return -1;
-		}
-		if (is_dev_dax &&
-		    util_file_device_dax_alignment(path) != Pagesize) {
-			ERR("Device DAX using huge pages must be the only "
-				"part of the replica");
-			return -1;
-		}
-	}
 
 	/* XXX - pre-allocate space for X parts, and reallocate every X parts */
 	rep = Realloc(rep, sizeof(struct pool_replica) +
@@ -876,6 +864,38 @@ util_parse_add_replica(struct pool_set **setp)
 	return 0;
 }
 
+
+/*
+ * util_poolset_check_devdax -- (internal) check Device DAX restrictions
+ */
+static int
+util_poolset_check_devdax(struct pool_set *set)
+{
+	LOG(3, "set %p", set);
+
+	for (unsigned r = 0; r < set->nreplicas; r++) {
+		struct pool_replica *rep = set->replica[r];
+		int is_dev_dax = rep->part[0].is_dev_dax;
+
+		for (unsigned p = 0; p < rep->nparts; p++) {
+			if (rep->part[p].is_dev_dax != is_dev_dax) {
+				ERR(
+					"either all the parts must be Device DAX or none");
+				return -1;
+			}
+
+			if (is_dev_dax && set->nohdrs == 0 &&
+			    util_file_device_dax_alignment(rep->part[p].path)
+					!= Pagesize) {
+				ERR(
+					"Device DAX using huge pages must be the only part of the replica");
+				return -1;
+			}
+		}
+	}
+	return 0;
+}
+
 /*
  * util_poolset_set_size -- (internal) calculate pool size
  */
@@ -883,14 +903,16 @@ static void
 util_poolset_set_size(struct pool_set *set)
 {
 	set->poolsize = SIZE_MAX;
+
 	for (unsigned r = 0; r < set->nreplicas; r++) {
 		struct pool_replica *rep = set->replica[r];
-		rep->repsize = Mmap_align;
+		rep->nhdrs = set->nohdrs ? 1 : rep->nparts;
+		rep->repsize = 0;
 		for (unsigned p = 0; p < rep->nparts; p++) {
 			rep->repsize +=
-				(rep->part[p].filesize & ~(Mmap_align - 1)) -
-				Mmap_align;
+				(rep->part[p].filesize & ~(Mmap_align - 1));
 		}
+		rep->repsize -= (rep->nhdrs - 1) * Mmap_align;
 
 		/*
 		 * Calculate pool size - choose the smallest replica size.
@@ -899,6 +921,7 @@ util_poolset_set_size(struct pool_set *set)
 		if (rep->remote == NULL && rep->repsize < set->poolsize)
 			set->poolsize = rep->repsize;
 	}
+
 	LOG(3, "pool size set to %zu", set->poolsize);
 }
 
@@ -1133,17 +1156,25 @@ util_poolset_parse(struct pool_set **setp, const char *path, int fd)
 		}
 	}
 
-	if (result == PARSER_FORMAT_OK) {
-		LOG(4, "set file format correct (%s)", path);
-		(void) fclose(fs);
-		Free(line);
-		util_poolset_set_size(set);
-		*setp = set;
-		return 0;
-	} else {
+	if (result != PARSER_FORMAT_OK) {
 		ERR("%s [%s:%d]", path, parser_errstr[result], nlines);
 		errno = EINVAL;
+		goto err;
 	}
+
+	set->nohdrs = Nohdrs; /* XXX */
+
+	if (util_poolset_check_devdax(set) != 0) {
+		errno = EINVAL;
+		goto err;
+	}
+
+	LOG(4, "set file format correct (%s)", path);
+	(void) fclose(fs);
+	Free(line);
+	util_poolset_set_size(set);
+	*setp = set;
+	return 0;
 
 err:
 	Free(line);
@@ -1200,6 +1231,7 @@ util_poolset_single(const char *path, size_t filesize, int create)
 	ASSERTne(rep->part[0].alignment, 0);
 
 	rep->nparts = 1;
+	rep->nhdrs = 1;
 
 	/* it does not have a remote replica */
 	rep->remote = NULL;
@@ -1696,14 +1728,26 @@ util_header_create(struct pool_set *set, unsigned repidx, unsigned partidx,
 	hdrp->incompat_features = incompat;
 	hdrp->ro_compat_features = ro_compat;
 
+	if (set->nohdrs)
+		hdrp->incompat_features |= POOL_FEAT_NOHDRS;
+
 	memcpy(hdrp->poolset_uuid, set->uuid, POOL_HDR_UUID_LEN);
 	memcpy(hdrp->uuid, PART(rep, partidx).uuid, POOL_HDR_UUID_LEN);
 
 	/* link parts */
-	memcpy(hdrp->prev_part_uuid, PARTP(rep, partidx).uuid,
+	if (set->nohdrs) {
+		/* next/prev part point to part #0 */
+		ASSERTeq(partidx, 0);
+		memcpy(hdrp->prev_part_uuid, PART(rep, 0).uuid,
 							POOL_HDR_UUID_LEN);
-	memcpy(hdrp->next_part_uuid, PARTN(rep, partidx).uuid,
+		memcpy(hdrp->next_part_uuid, PART(rep, 0).uuid,
 							POOL_HDR_UUID_LEN);
+	} else {
+		memcpy(hdrp->prev_part_uuid, PARTP(rep, partidx).uuid,
+							POOL_HDR_UUID_LEN);
+		memcpy(hdrp->next_part_uuid, PARTN(rep, partidx).uuid,
+							POOL_HDR_UUID_LEN);
+	}
 
 	/* link replicas */
 	if (prev_repl_uuid) {
@@ -1977,6 +2021,7 @@ util_replica_map_local(struct pool_set *set, unsigned repidx, int flags)
 #endif
 	int retry_for_contiguous_addr;
 	size_t mapsize;
+	size_t hdrsize = set->nohdrs ? 0 : Mmap_align;
 	void *addr;
 	struct pool_replica *rep = set->replica[repidx];
 
@@ -1996,7 +2041,7 @@ util_replica_map_local(struct pool_set *set, unsigned repidx, int flags)
 
 		/* map the first part and reserve space for remaining parts */
 		if (util_map_part(&rep->part[0], addr, rep->repsize, 0,
-			flags, 0) != 0) {
+				flags, 0) != 0) {
 			LOG(2, "pool mapping failed - replica #%u part #0",
 				repidx);
 			return -1;
@@ -2017,7 +2062,7 @@ util_replica_map_local(struct pool_set *set, unsigned repidx, int flags)
 		 */
 		for (unsigned p = 1; p < rep->nparts; p++) {
 			/* map data part */
-			if (util_map_part(&rep->part[p], addr, 0, Mmap_align,
+			if (util_map_part(&rep->part[p], addr, 0, hdrsize,
 					flags | MAP_FIXED, 0) != 0) {
 				/*
 				 * if we can't map the part at the address we
@@ -2046,7 +2091,7 @@ util_replica_map_local(struct pool_set *set, unsigned repidx, int flags)
 
 			VALGRIND_REGISTER_PMEM_FILE(rep->part[p].fd,
 				rep->part[p].addr, rep->part[p].size,
-				Mmap_align);
+				hdrsize);
 
 			mapsize += rep->part[p].size;
 			set->zeroed &= rep->part[p].created;
@@ -2105,7 +2150,7 @@ util_replica_init_headers_local(struct pool_set *set, unsigned repidx,
 	struct pool_replica *rep = set->replica[repidx];
 
 	/* map all headers - don't care about the address */
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
 		if (util_map_hdr(&rep->part[p], flags, 0) != 0) {
 			LOG(2, "header mapping failed - part #%d", p);
 			goto err;
@@ -2113,7 +2158,7 @@ util_replica_init_headers_local(struct pool_set *set, unsigned repidx,
 	}
 
 	/* create headers, set UUID's */
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
 		if (util_header_create(set, repidx, p, sig, major,
 				compat, incompat, ro_compat,
 				prev_repl_uuid, next_repl_uuid,
@@ -2124,7 +2169,7 @@ util_replica_init_headers_local(struct pool_set *set, unsigned repidx,
 	}
 
 	/* unmap all headers */
-	for (unsigned p = 0; p < rep->nparts; p++)
+	for (unsigned p = 0; p < rep->nhdrs; p++)
 		util_unmap_hdr(&rep->part[p]);
 
 	return 0;
@@ -2132,7 +2177,7 @@ util_replica_init_headers_local(struct pool_set *set, unsigned repidx,
 err:
 	LOG(4, "error clean up");
 	int oerrno = errno;
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
 		util_unmap_hdr(&rep->part[p]);
 	}
 	errno = oerrno;
@@ -2155,6 +2200,7 @@ util_replica_create_local(struct pool_set *set, unsigned repidx, int flags,
 		set, repidx, flags, sig, major,
 		compat, incompat, ro_compat,
 		prev_repl_uuid, next_repl_uuid, arch_flags);
+
 	/*
 	 * the first replica has to be mapped prior to remote ones so if
 	 * a replica is already mapped skip mapping creation
@@ -2196,6 +2242,7 @@ util_replica_create_remote(struct pool_set *set, unsigned repidx, int flags,
 	ASSERTne(rep->remote, NULL);
 	ASSERTne(rep->part, NULL);
 	ASSERTeq(rep->nparts, 1);
+	ASSERTeq(rep->nhdrs, 1);
 
 	struct pool_set_part *part = rep->part;
 
@@ -2241,7 +2288,7 @@ util_replica_close(struct pool_set *set, unsigned repidx)
 	struct pool_replica *rep = set->replica[repidx];
 
 	if (rep->remote == NULL) {
-		for (unsigned p = 0; p < rep->nparts; p++)
+		for (unsigned p = 0; p < rep->nhdrs; p++)
 			util_unmap_hdr(&rep->part[p]);
 		util_unmap_part(&rep->part[0]);
 	} else {
@@ -2349,7 +2396,7 @@ util_pool_create_uuids(struct pool_set **setp, const char *path,
 	/* generate UUID's for all the parts */
 	for (unsigned r = 0; r < set->nreplicas; r++) {
 		struct pool_replica *rep = set->replica[r];
-		for (unsigned i = 0; i < rep->nparts; i++) {
+		for (unsigned i = 0; i < rep->nhdrs; i++) {
 			ret = util_uuid_generate(rep->part[i].uuid);
 			if (ret < 0) {
 				LOG(2, "cannot generate pool set part UUID");
@@ -2472,6 +2519,7 @@ util_replica_open_local(struct pool_set *set, unsigned repidx, int flags)
 	int remaining_retries = 10;
 	int retry_for_contiguous_addr;
 	size_t mapsize;
+	size_t hdrsize = set->nohdrs ? 0 : Mmap_align;
 	void *addr;
 	struct pool_replica *rep = set->replica[repidx];
 
@@ -2501,7 +2549,7 @@ util_replica_open_local(struct pool_set *set, unsigned repidx, int flags)
 			rep->part[0].addr, rep->part[0].size, 0);
 
 		/* map all headers - don't care about the address */
-		for (unsigned p = 0; p < rep->nparts; p++) {
+		for (unsigned p = 0; p < rep->nhdrs; p++) {
 			if (util_map_hdr(&rep->part[p], flags, 0) != 0) {
 				LOG(2, "header mapping failed - part #%d", p);
 				goto err;
@@ -2516,7 +2564,7 @@ util_replica_open_local(struct pool_set *set, unsigned repidx, int flags)
 		 */
 		for (unsigned p = 1; p < rep->nparts; p++) {
 			/* map data part */
-			if (util_map_part(&rep->part[p], addr, 0, Mmap_align,
+			if (util_map_part(&rep->part[p], addr, 0, hdrsize,
 					flags | MAP_FIXED, 0) != 0) {
 				/*
 				 * if we can't map the part at the address we
@@ -2543,7 +2591,7 @@ util_replica_open_local(struct pool_set *set, unsigned repidx, int flags)
 
 			VALGRIND_REGISTER_PMEM_FILE(rep->part[p].fd,
 				rep->part[p].addr, rep->part[p].size,
-				Mmap_align);
+				hdrsize);
 
 			mapsize += rep->part[p].size;
 			addr = (char *)addr + rep->part[p].size;
@@ -2577,10 +2625,10 @@ err:
 		ASSERTne(rep->part[0].addr, MAP_FAILED);
 		munmap(rep->part[0].addr, rep->repsize - mapsize);
 	}
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++)
 		util_unmap_hdr(&rep->part[p]);
+	for (unsigned p = 0; p < rep->nparts; p++)
 		util_unmap_part(&rep->part[p]);
-	}
 	errno = oerrno;
 	return -1;
 }
@@ -2598,6 +2646,7 @@ util_replica_open_remote(struct pool_set *set, unsigned repidx, int flags)
 	ASSERTne(rep->remote, NULL);
 	ASSERTne(rep->part, NULL);
 	ASSERTeq(rep->nparts, 1);
+	ASSERTeq(rep->nhdrs, 1);
 
 	struct pool_set_part *part = rep->part;
 
@@ -2656,7 +2705,8 @@ util_replica_set_attr(struct pool_replica *rep, const char *sig,
 	const unsigned char *part_uuid;
 	const unsigned char *next_part_uuid;
 	const unsigned char *prev_part_uuid;
-	for (unsigned p = 0; p < rep->nparts; p++) {
+
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
 		struct pool_hdr *hdrp = HDR(rep, p);
 		ASSERTne(hdrp, NULL);
 		util_convert2h_hdr_nocheck(hdrp);
@@ -2679,12 +2729,12 @@ util_replica_set_attr(struct pool_replica *rep, const char *sig,
 	}
 
 	/* unmap all headers */
-	for (unsigned p = 0; p < rep->nparts; p++)
+	for (unsigned p = 0; p < rep->nhdrs; p++)
 		util_unmap_hdr(&rep->part[p]);
 
 	return 0;
 err:
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
 		util_unmap_hdr(&rep->part[p]);
 	}
 	return -1;
@@ -2701,7 +2751,7 @@ util_unmap_all_hdrs(struct pool_set *set)
 	for (unsigned r = 0; r < set->nreplicas; r++) {
 		struct pool_replica *rep = set->replica[r];
 		if (rep->remote == NULL) {
-			for (unsigned p = 0; p < rep->nparts; p++)
+			for (unsigned p = 0; p < rep->nhdrs; p++)
 				util_unmap_hdr(&rep->part[p]);
 		} else {
 			/*
@@ -2727,7 +2777,8 @@ util_replica_check(struct pool_set *set, const char *sig, uint32_t major,
 
 	for (unsigned r = 0; r < set->nreplicas; r++) {
 		struct pool_replica *rep = set->replica[r];
-		for (unsigned p = 0; p < rep->nparts; p++) {
+		for (unsigned p = 0; p < rep->nhdrs; p++) {
+			rep->part[p].rdonly = 0; /* XXX */
 			if (util_header_check(set, r, p, sig, major,
 					compat, incompat, ro_compat) != 0) {
 				LOG(2, "header check failed - part #%d", p);
@@ -2961,7 +3012,8 @@ util_pool_open_remote(struct pool_set **setp, const char *path, int cow,
 	set->rdonly |= rep->part[0].rdonly;
 
 	/* check headers, check UUID's, check replicas linkage */
-	for (unsigned p = 0; p < rep->nparts; p++) {
+	for (unsigned p = 0; p < rep->nhdrs; p++) {
+		rep->part[p].rdonly = 0;
 		if (util_header_check_remote(rep, p) != 0) {
 			LOG(2, "header check failed - part #%d", p);
 			goto err_replica;
@@ -2981,7 +3033,7 @@ util_pool_open_remote(struct pool_set **setp, const char *path, int cow,
 	memcpy(arch_flags, &hdr->arch_flags, sizeof(struct arch_flags));
 
 	/* unmap all headers */
-	for (unsigned p = 0; p < rep->nparts; p++)
+	for (unsigned p = 0; p < rep->nhdrs; p++)
 		util_unmap_hdr(&rep->part[p]);
 
 	return 0;

--- a/src/common/set.h
+++ b/src/common/set.h
@@ -101,6 +101,7 @@ struct remote_replica {
 
 struct pool_replica {
 	unsigned nparts;
+	unsigned nhdrs;		/* should be either 1 or nparts */
 	size_t repsize;		/* total size of all the parts (mappings) */
 	int is_pmem;		/* true if all the parts are in PMEM */
 	struct remote_replica *remote;	/* not NULL if the replica */
@@ -115,6 +116,7 @@ struct pool_set {
 	int zeroed;		/* true if all the parts are new files */
 	size_t poolsize;	/* the smallest replica size */
 	int remote;		/* true if contains a remote replica */
+	int nohdrs;		/* pool header only in the first part */
 	struct pool_replica *replica[];
 };
 
@@ -141,12 +143,19 @@ struct pool_attr {
 /* get index of the (r - 1)th replica */
 #define REPPidx(set, r) (((set)->nreplicas + (r) - 1) % (set)->nreplicas)
 
-/* get intex of the (r)th part */
+/* get index of the (r)th part */
 #define PARTidx(rep, p) (((rep)->nparts + (p)) % (rep)->nparts)
-/* get intex of the (r + 1)th part */
+/* get index of the (r + 1)th part */
 #define PARTNidx(rep, p) (((rep)->nparts + (p) + 1) % (rep)->nparts)
-/* get intex of the (r - 1)th part */
+/* get index of the (r - 1)th part */
 #define PARTPidx(rep, p) (((rep)->nparts + (p) - 1) % (rep)->nparts)
+
+/* get index of the (r)th part */
+#define HDRidx(rep, p) (((rep)->nhdrs + (p)) % (rep)->nhdrs)
+/* get index of the (r + 1)th part */
+#define HDRNidx(rep, p) (((rep)->nhdrs + (p) + 1) % (rep)->nhdrs)
+/* get index of the (r - 1)th part */
+#define HDRPidx(rep, p) (((rep)->nhdrs + (p) - 1) % (rep)->nhdrs)
 
 /* get (r)th replica */
 #define REP(set, r)\
@@ -166,11 +175,11 @@ struct pool_attr {
 	((rep)->part[PARTPidx(rep, p)])
 
 #define HDR(rep, p)\
-	((struct pool_hdr *)(PART(rep, p).hdr))
+	((struct pool_hdr *)(((rep)->part[HDRidx(rep, p)]).hdr))
 #define HDRN(rep, p)\
-	((struct pool_hdr *)(PARTN(rep, p).hdr))
+	((struct pool_hdr *)(((rep)->part[HDRNidx(rep, p)]).hdr))
 #define HDRP(rep, p)\
-	((struct pool_hdr *)(PARTP(rep, p).hdr))
+	((struct pool_hdr *)(((rep)->part[HDRPidx(rep, p)]).hdr))
 
 extern int Prefault_at_open;
 extern int Prefault_at_create;

--- a/src/common/util.c
+++ b/src/common/util.c
@@ -43,6 +43,7 @@
 #include <time.h>
 
 #include "util.h"
+#include "os.h"
 #include "valgrind_internal.h"
 
 /* library-wide page size */
@@ -50,6 +51,9 @@ unsigned long long Pagesize;
 
 /* allocation/mmap granularity */
 unsigned long long Mmap_align;
+
+/* indicates only first part contains pool header */
+int Nohdrs;
 
 /*
  * our versions of malloc & friends start off pointing to the libc versions
@@ -253,6 +257,10 @@ util_init(void)
 #ifdef ANY_VG_TOOL_ENABLED
 	_On_valgrind = RUNNING_ON_VALGRIND;
 #endif
+
+	char *env = os_getenv("PMEM_NO_HDRS");
+	if (env && strcmp(env, "1") == 0)
+		Nohdrs = 1;
 }
 
 /*

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -53,6 +53,8 @@ extern "C" {
 
 #include <sys/param.h>
 
+extern int Nohdrs;
+
 extern unsigned long long Pagesize;
 extern unsigned long long Mmap_align;
 

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -418,8 +418,8 @@ pmemblk_createU(const char *path, size_t bsize, size_t poolsize, mode_t mode)
 	if (util_pool_create(&set, path,
 			poolsize, PMEMBLK_MIN_POOL, PMEMBLK_MIN_PART,
 			BLK_HDR_SIG, BLK_FORMAT_MAJOR,
-			BLK_FORMAT_COMPAT, BLK_FORMAT_INCOMPAT,
-			BLK_FORMAT_RO_COMPAT, NULL,
+			BLK_FORMAT_COMPAT_DEFAULT, BLK_FORMAT_INCOMPAT_DEFAULT,
+			BLK_FORMAT_RO_COMPAT_DEFAULT, NULL,
 			REPLICAS_DISABLED) != 0) {
 		LOG(2, "cannot create pool or pool set");
 		return NULL;
@@ -514,8 +514,8 @@ blk_open_common(const char *path, size_t bsize, int cow)
 
 	if (util_pool_open(&set, path, cow, PMEMBLK_MIN_PART,
 			BLK_HDR_SIG, BLK_FORMAT_MAJOR,
-			BLK_FORMAT_COMPAT, BLK_FORMAT_INCOMPAT,
-			BLK_FORMAT_RO_COMPAT, NULL) != 0) {
+			BLK_FORMAT_COMPAT_CHECK, BLK_FORMAT_INCOMPAT_CHECK,
+			BLK_FORMAT_RO_COMPAT_CHECK, NULL) != 0) {
 		LOG(2, "cannot open pool or pool set");
 		return NULL;
 	}

--- a/src/libpmemblk/blk.h
+++ b/src/libpmemblk/blk.h
@@ -46,9 +46,14 @@
 /* attributes of the blk memory pool format for the pool header */
 #define BLK_HDR_SIG "PMEMBLK"	/* must be 8 bytes including '\0' */
 #define BLK_FORMAT_MAJOR 1
-#define BLK_FORMAT_COMPAT 0x0000
-#define BLK_FORMAT_INCOMPAT 0x0000
-#define BLK_FORMAT_RO_COMPAT 0x0000
+
+#define BLK_FORMAT_COMPAT_DEFAULT 0x0000
+#define BLK_FORMAT_INCOMPAT_DEFAULT 0x0000
+#define BLK_FORMAT_RO_COMPAT_DEFAULT 0x0000
+
+#define BLK_FORMAT_COMPAT_CHECK 0x0000
+#define BLK_FORMAT_INCOMPAT_CHECK POOL_FEAT_NOHDRS
+#define BLK_FORMAT_RO_COMPAT_CHECK 0x0000
 
 struct pmemblk {
 	struct pool_hdr hdr;	/* memory pool header */

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -177,8 +177,8 @@ pmemlog_createU(const char *path, size_t poolsize, mode_t mode)
 	if (util_pool_create(&set, path,
 			poolsize, PMEMLOG_MIN_POOL, PMEMLOG_MIN_PART,
 			LOG_HDR_SIG, LOG_FORMAT_MAJOR,
-			LOG_FORMAT_COMPAT, LOG_FORMAT_INCOMPAT,
-			LOG_FORMAT_RO_COMPAT, NULL,
+			LOG_FORMAT_COMPAT_DEFAULT, LOG_FORMAT_INCOMPAT_DEFAULT,
+			LOG_FORMAT_RO_COMPAT_DEFAULT, NULL,
 			REPLICAS_DISABLED) != 0) {
 		LOG(2, "cannot create pool or pool set");
 		return NULL;
@@ -269,8 +269,8 @@ log_open_common(const char *path, int cow)
 
 	if (util_pool_open(&set, path, cow, PMEMLOG_MIN_PART,
 			LOG_HDR_SIG, LOG_FORMAT_MAJOR,
-			LOG_FORMAT_COMPAT, LOG_FORMAT_INCOMPAT,
-			LOG_FORMAT_RO_COMPAT, NULL) != 0) {
+			LOG_FORMAT_COMPAT_CHECK, LOG_FORMAT_INCOMPAT_CHECK,
+			LOG_FORMAT_RO_COMPAT_CHECK, NULL) != 0) {
 		LOG(2, "cannot open pool or pool set");
 		return NULL;
 	}

--- a/src/libpmemlog/log.h
+++ b/src/libpmemlog/log.h
@@ -49,9 +49,14 @@
 /* attributes of the log memory pool format for the pool header */
 #define LOG_HDR_SIG "PMEMLOG"	/* must be 8 bytes including '\0' */
 #define LOG_FORMAT_MAJOR 1
-#define LOG_FORMAT_COMPAT 0x0000
-#define LOG_FORMAT_INCOMPAT 0x0000
-#define LOG_FORMAT_RO_COMPAT 0x0000
+
+#define LOG_FORMAT_COMPAT_DEFAULT 0x0000
+#define LOG_FORMAT_INCOMPAT_DEFAULT 0x0000
+#define LOG_FORMAT_RO_COMPAT_DEFAULT 0x0000
+
+#define LOG_FORMAT_COMPAT_CHECK 0x0000
+#define LOG_FORMAT_INCOMPAT_CHECK POOL_FEAT_NOHDRS
+#define LOG_FORMAT_RO_COMPAT_CHECK 0x0000
 
 struct pmemlog {
 	struct pool_hdr hdr;	/* memory pool header */

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1209,8 +1209,8 @@ pmemobj_createU(const char *path, const char *layout,
 	if (util_pool_create(&set, path,
 			poolsize, PMEMOBJ_MIN_POOL, PMEMOBJ_MIN_PART,
 			OBJ_HDR_SIG, OBJ_FORMAT_MAJOR,
-			OBJ_FORMAT_COMPAT, OBJ_FORMAT_INCOMPAT,
-			OBJ_FORMAT_RO_COMPAT, &runtime_nlanes,
+			OBJ_FORMAT_COMPAT_DEFAULT, OBJ_FORMAT_INCOMPAT_DEFAULT,
+			OBJ_FORMAT_RO_COMPAT_DEFAULT, &runtime_nlanes,
 			REPLICAS_ENABLED) != 0) {
 		LOG(2, "cannot create pool or pool set");
 		return NULL;
@@ -1450,8 +1450,8 @@ obj_pool_open(struct pool_set **set, const char *path, int cow,
 
 	if (util_pool_open(set, path, cow, PMEMOBJ_MIN_PART,
 			OBJ_HDR_SIG, OBJ_FORMAT_MAJOR,
-			OBJ_FORMAT_COMPAT, OBJ_FORMAT_INCOMPAT,
-			OBJ_FORMAT_RO_COMPAT, nlanes) != 0) {
+			OBJ_FORMAT_COMPAT_CHECK, OBJ_FORMAT_INCOMPAT_CHECK,
+			OBJ_FORMAT_RO_COMPAT_CHECK, nlanes) != 0) {
 		LOG(2, "cannot open pool or pool set");
 		return -1;
 	}

--- a/src/libpmemobj/obj.h
+++ b/src/libpmemobj/obj.h
@@ -54,9 +54,14 @@
 /* attributes of the obj memory pool format for the pool header */
 #define OBJ_HDR_SIG "PMEMOBJ"	/* must be 8 bytes including '\0' */
 #define OBJ_FORMAT_MAJOR 4
-#define OBJ_FORMAT_COMPAT 0x0000
-#define OBJ_FORMAT_INCOMPAT 0x0000
-#define OBJ_FORMAT_RO_COMPAT 0x0000
+
+#define OBJ_FORMAT_COMPAT_DEFAULT 0x0000
+#define OBJ_FORMAT_INCOMPAT_DEFAULT 0x000
+#define OBJ_FORMAT_RO_COMPAT_DEFAULT 0x0000
+
+#define OBJ_FORMAT_COMPAT_CHECK 0x0000
+#define OBJ_FORMAT_INCOMPAT_CHECK POOL_FEAT_NOHDRS
+#define OBJ_FORMAT_RO_COMPAT_CHECK 0x0000
 
 /* size of the persistent part of PMEMOBJ pool descriptor (2kB) */
 #define OBJ_DSC_P_SIZE		2048

--- a/src/libpmempool/check_pool_hdr.c
+++ b/src/libpmempool/check_pool_hdr.c
@@ -422,7 +422,7 @@ pool_hdr_poolset_uuid_find(PMEMpoolcheck *ppc, location *loc)
 	uuid_t *common_puuid = loc->valid_puuid;
 	for (unsigned r = 0; r < nreplicas; r++) {
 		struct pool_replica *rep = REP(poolset, r);
-		for (unsigned p = 0; p < rep->nparts; p++) {
+		for (unsigned p = 0; p < rep->nhdrs; p++) {
 			struct pool_hdr *hdr = HDR(rep, p);
 
 			/*
@@ -945,7 +945,7 @@ init_location_data(PMEMpoolcheck *ppc, location *loc)
 
 	if (!loc->valid_part_done || loc->valid_part_replica != loc->replica) {
 		loc->valid_part_hdrp = NULL;
-		for (unsigned p = 0; p < rep->nparts; ++p) {
+		for (unsigned p = 0; p < rep->nhdrs; ++p) {
 			if (pool_hdr_valid(HDR(rep, p))) {
 				loc->valid_part_hdrp = HDR(rep, p);
 				break;
@@ -969,7 +969,7 @@ check_pool_hdr(PMEMpoolcheck *ppc)
 
 	for (; loc->replica < nreplicas; loc->replica++) {
 		struct pool_replica *rep = poolset->replica[loc->replica];
-		for (; loc->part < rep->nparts; loc->part++) {
+		for (; loc->part < rep->nhdrs; loc->part++) {
 			init_location_data(ppc, loc);
 
 			/* do all checks */

--- a/src/libpmempool/pool.c
+++ b/src/libpmempool/pool.c
@@ -920,21 +920,21 @@ pool_hdr_default(enum pool_type type, struct pool_hdr *hdrp)
 	switch (type) {
 	case POOL_TYPE_LOG:
 		hdrp->major = LOG_FORMAT_MAJOR;
-		hdrp->compat_features = LOG_FORMAT_COMPAT;
-		hdrp->incompat_features = LOG_FORMAT_INCOMPAT;
-		hdrp->ro_compat_features = LOG_FORMAT_RO_COMPAT;
+		hdrp->compat_features = LOG_FORMAT_COMPAT_DEFAULT;
+		hdrp->incompat_features = LOG_FORMAT_INCOMPAT_DEFAULT;
+		hdrp->ro_compat_features = LOG_FORMAT_RO_COMPAT_DEFAULT;
 		break;
 	case POOL_TYPE_BLK:
 		hdrp->major = BLK_FORMAT_MAJOR;
-		hdrp->compat_features = BLK_FORMAT_COMPAT;
-		hdrp->incompat_features = BLK_FORMAT_INCOMPAT;
-		hdrp->ro_compat_features = BLK_FORMAT_RO_COMPAT;
+		hdrp->compat_features = BLK_FORMAT_COMPAT_DEFAULT;
+		hdrp->incompat_features = BLK_FORMAT_INCOMPAT_DEFAULT;
+		hdrp->ro_compat_features = BLK_FORMAT_RO_COMPAT_DEFAULT;
 		break;
 	case POOL_TYPE_OBJ:
 		hdrp->major = OBJ_FORMAT_MAJOR;
-		hdrp->compat_features = OBJ_FORMAT_COMPAT;
-		hdrp->incompat_features = OBJ_FORMAT_INCOMPAT;
-		hdrp->ro_compat_features = OBJ_FORMAT_RO_COMPAT;
+		hdrp->compat_features = OBJ_FORMAT_COMPAT_DEFAULT;
+		hdrp->incompat_features = OBJ_FORMAT_INCOMPAT_DEFAULT;
+		hdrp->ro_compat_features = OBJ_FORMAT_RO_COMPAT_DEFAULT;
 		break;
 	default:
 		break;

--- a/src/libpmempool/replica.h
+++ b/src/libpmempool/replica.h
@@ -67,6 +67,7 @@
  */
 struct replica_health_status {
 	unsigned nparts;
+	unsigned nhdrs;
 	/* a flag for the replica */
 	unsigned flags;
 	/* effective size of a pool, valid only for healthy replica */

--- a/src/libpmempool/sync.c
+++ b/src/libpmempool/sync.c
@@ -139,7 +139,7 @@ fill_struct_part_uuids(struct pool_set *set, unsigned repn,
 	LOG(3, "set %p, repn %u, set_hs %p", set, repn, set_hs);
 	struct pool_replica *rep = REP(set, repn);
 	struct pool_hdr *hdrp;
-	for (unsigned p = 0; p < rep->nparts; ++p) {
+	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		/* skip broken parts */
 		if (replica_is_part_broken(repn, p, set_hs))
 			continue;
@@ -175,7 +175,7 @@ fill_struct_broken_part_uuids(struct pool_set *set, unsigned repn,
 			flags);
 	struct pool_replica *rep = REP(set, repn);
 	struct pool_hdr *hdrp;
-	for (unsigned p = 0; p < rep->nparts; ++p) {
+	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		/* skip unbroken parts */
 		if (!replica_is_part_broken(repn, p, set_hs))
 			continue;
@@ -282,7 +282,7 @@ create_headers_for_broken_parts(struct pool_set *set, unsigned src_replica,
 		if (!replica_is_replica_broken(r, set_hs))
 			continue;
 
-		for (unsigned p = 0; p < set_hs->replica[r]->nparts; p++) {
+		for (unsigned p = 0; p < set_hs->replica[r]->nhdrs; p++) {
 			/* skip unbroken parts */
 			if (!replica_is_part_broken(r, p, set_hs))
 				continue;
@@ -450,7 +450,7 @@ update_parts_linkage(struct pool_set *set, unsigned repn,
 {
 	LOG(3, "set %p, repn %u, set_hs %p", set, repn, set_hs);
 	struct pool_replica *rep = REP(set, repn);
-	for (unsigned p = 0; p < rep->nparts; ++p) {
+	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		struct pool_hdr *hdrp = HDR(rep, p);
 		struct pool_hdr *prev_hdrp = HDRP(rep, p);
 		struct pool_hdr *next_hdrp = HDRN(rep, p);
@@ -501,7 +501,7 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	ASSERT(next_r->nparts > 0);
 
 	/* set uuids in the current replica */
-	for (unsigned p = 0; p < rep->nparts; ++p) {
+	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		struct pool_hdr *hdrp = HDR(rep, p);
 		memcpy(hdrp->prev_repl_uuid, PART(prev_r, 0).uuid,
 				POOL_HDR_UUID_LEN);
@@ -514,7 +514,7 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	}
 
 	/* set uuids in the previous replica */
-	for (unsigned p = 0; p < prev_r->nparts; ++p) {
+	for (unsigned p = 0; p < prev_r->nhdrs; ++p) {
 		struct pool_hdr *prev_hdrp = HDR(prev_r, p);
 		memcpy(prev_hdrp->next_repl_uuid, PART(rep, 0).uuid,
 				POOL_HDR_UUID_LEN);
@@ -527,7 +527,7 @@ update_replicas_linkage(struct pool_set *set, unsigned repn)
 	}
 
 	/* set uuids in the next replica */
-	for (unsigned p = 0; p < next_r->nparts; ++p) {
+	for (unsigned p = 0; p < next_r->nhdrs; ++p) {
 		struct pool_hdr *next_hdrp = HDR(next_r, p);
 
 		memcpy(next_hdrp->prev_repl_uuid, PART(rep, 0).uuid,
@@ -552,7 +552,7 @@ update_poolset_uuids(struct pool_set *set, unsigned repn,
 {
 	LOG(3, "set %p, repn %u, set_hs %p", set, repn, set_hs);
 	struct pool_replica *rep = REP(set, repn);
-	for (unsigned p = 0; p < rep->nparts; ++p) {
+	for (unsigned p = 0; p < rep->nhdrs; ++p) {
 		struct pool_hdr *hdrp = HDR(rep, p);
 		memcpy(hdrp->poolset_uuid, set->uuid, POOL_HDR_UUID_LEN);
 		util_checksum(hdrp, sizeof(*hdrp), &hdrp->checksum, 1);

--- a/src/libvmem/vmem.h
+++ b/src/libvmem/vmem.h
@@ -45,10 +45,6 @@
 /* attributes of the vmem memory pool format for the pool header */
 #define VMEM_HDR_SIG "VMEM   "	/* must be 8 bytes including '\0' */
 #define VMEM_FORMAT_MAJOR 1
-#define VMEM_FORMAT_COMPAT 0x0000
-#define VMEM_FORMAT_INCOMPAT 0x0000
-#define VMEM_FORMAT_RO_COMPAT 0x0000
-
 
 struct vmem {
 	struct pool_hdr hdr;	/* memory pool header */

--- a/src/test/blk_rw/TEST12
+++ b/src/test/blk_rw/TEST12
@@ -32,13 +32,14 @@
 #
 
 #
-# src/test/blk_rw/TEST11 -- unit test for pmemblk_read/write/set_zero/set_error
+# src/test/blk_rw/TEST12 -- unit test for pmemblk_read/write/set_zero/set_error
 #
 # Same as TEST10, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported yet.
+# with 2M alignment. Expected failure, as 2M alignment is not supported
+# if NODHRS option is not specified.
 #
-export UNITTEST_NAME=blk_rw/TEST11
-export UNITTEST_NUM=11
+export UNITTEST_NAME=blk_rw/TEST12
+export UNITTEST_NUM=12
 
 # standard unit test setup
 . ../unittest/unittest.sh

--- a/src/test/blk_rw/TEST13
+++ b/src/test/blk_rw/TEST13
@@ -32,24 +32,13 @@
 #
 
 #
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
+# src/test/blk_rw/TEST13 -- unit test for pmemblk_read/write/set_zero/set_error
 #
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
+# Same as TEST10, but run on a pool set that spans two Device DAX devices
+# with 2M alignment. Expected success, as pool is created with NOHDRS option.
 #
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
+export UNITTEST_NAME=blk_rw/TEST13
+export UNITTEST_NUM=13
 
 # standard unit test setup
 . ../unittest/unittest.sh
@@ -61,10 +50,14 @@ require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
+# XXX temporary
+export PMEM_NO_HDRS=1
+
 dax_device_zero
 
 create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+expect_normal_exit ./blk_rw$EXESUFFIX 512 $DIR/testset c\
+	r:0 r:1 r:32201 r:32313 z:0 z:1 r:0
 
 pass

--- a/src/test/log_basic/TEST10
+++ b/src/test/log_basic/TEST10
@@ -32,7 +32,7 @@
 #
 
 #
-# src/test/log_basic/TEST9 -- unit test for:
+# src/test/log_basic/TEST10 -- unit test for:
 # - pmemlog_append
 # and:
 # - pmemlog_nbyte
@@ -45,11 +45,10 @@
 # - pmemlog_close
 #
 # Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
+# with 2M alignment. Expected success, as pool is created with NOHDRS option.
 #
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
+export UNITTEST_NAME=log_basic/TEST10
+export UNITTEST_NUM=10
 
 # standard unit test setup
 . ../unittest/unittest.sh
@@ -61,10 +60,13 @@ require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
+# XXX temporary
+export PMEM_NO_HDRS=1
+
 dax_device_zero
 
 create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+expect_normal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
 
 pass

--- a/src/test/obj_basic_integration/TEST12
+++ b/src/test/obj_basic_integration/TEST12
@@ -32,10 +32,11 @@
 #
 
 #
-# src/test/obj_basic_integration/TEST11 -- basic integration tests for libpmemobj
+# src/test/obj_basic_integration/TEST12 -- basic integration tests for libpmemobj
 #
 # Same as TEST0, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported yet.
+# with 2M alignment. Expected failure, as 2M alignment is not supported
+# if NOHDRS option is not specified.
 #
 export UNITTEST_NAME=obj_basic_integration/TEST12
 export UNITTEST_NUM=12

--- a/src/test/obj_basic_integration/TEST13
+++ b/src/test/obj_basic_integration/TEST13
@@ -32,39 +32,31 @@
 #
 
 #
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
+# src/test/obj_basic_integration/TEST13 -- basic integration tests for libpmemobj
 #
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
+# Same as TEST0, but run on a pool set that spans two Device DAX devices
+# with 2M alignment. Expected success, as pool is created with NOHDRS option.
 # if NOHDRS option is not specified.
 #
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
+export UNITTEST_NAME=obj_basic_integration/TEST13
+export UNITTEST_NUM=13
 
 # standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
-require_fs_type any
 require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
+# XXX temporary
+export PMEM_NO_HDRS=1
+
 dax_device_zero
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+create_poolset $DIR/testset1 AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+expect_normal_exit ./obj_basic_integration$EXESUFFIX $DIR/testset1
 
 pass

--- a/src/test/pmempool_check/TEST26
+++ b/src/test/pmempool_check/TEST26
@@ -30,41 +30,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_check/TEST26 -- test for checking pools with device dax
+#
+# Same as TEST12, but run on a pool set that spans two Device DAX devices
+# with 2M alignment.
+#
+export UNITTEST_NAME=pmempool_check/TEST26
+export UNITTEST_NUM=26
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
+
 require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
+# covered by TEST21
+configure_valgrind memcheck force-disable $PMEMPOOL$EXESUFFIX
+
 setup
+
+# XXX temporary
+export PMEM_NO_HDRS=1
 
 dax_device_zero
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+LOG=out${UNITTEST_NUM}.log
+rm -rf $LOG && touch $LOG
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+POOLSET=$DIR/testset1
+create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -vry $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
 
 pass

--- a/src/test/pmempool_check/TEST27
+++ b/src/test/pmempool_check/TEST27
@@ -30,41 +30,56 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_check/TEST27 -- test for checking pools with device dax
+#
+# Same as TEST14, but run on a pool set that spans two Device DAX devices
+# with 2M alignment.
+#
+export UNITTEST_NAME=pmempool_check/TEST27
+export UNITTEST_NUM=27
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
+
 require_dax_devices 2
 require_dax_device_alignments 2097152 2097152 # 2MiB
 
+# memcheck covered by TEST23, pmemcheck takes too long
+configure_valgrind force-disable $PMEMPOOL$EXESUFFIX
+
 setup
 
-dax_device_zero
+# XXX temporary
+export PMEM_NO_HDRS=1
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+LOG=out${UNITTEST_NUM}.log
+rm -rf $LOG && touch $LOG
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+POOLSET=$DIR/testset1
+create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
+
+#remove the pools in the poolset while preserving the file itself
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -s $POOLSET
+#verify that the poolset still exists
+check_files $POOLSET
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX create -w blk 512 $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX check -v $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET &> /dev/null
+
+check
 
 pass

--- a/src/test/pmempool_check/out27.log.match
+++ b/src/test/pmempool_check/out27.log.match
@@ -1,0 +1,17 @@
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+$(nW) consistent
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+checking pmemlog header
+pmemlog header correct
+$(nW) consistent
+replica 0 part 0: checking pool header
+replica 0 part 0: pool header correct
+checking pmemblk header
+pmemblk header correct
+checking BTT Info headers
+arena 0: BTT Info header checksum correct
+checking BTT Map and Flog
+arena 0: checking BTT Map and Flog
+$(nW) consistent

--- a/src/test/pmempool_create/TEST8
+++ b/src/test/pmempool_create/TEST8
@@ -30,41 +30,68 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_create/TEST8 -- test for pmempool create command with poolset
+#
+export UNITTEST_NAME=pmempool_create/TEST8
+export UNITTEST_NUM=8
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
-require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+# XXX temporary
+export PMEM_NO_HDRS=1
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+POOLSET=$DIR/pool.set
+POOL1=$DIR/pool.part1
+POOL2=$DIR/pool.part2
+POOL3=$DIR/pool.part3
+POOLS="$POOL1 $POOL2 $POOL3"
+POOLREP=$DIR/rep.set
+REPL1=$DIR/pool.rep.part1
+REPL2=$DIR/pool.rep.part2
+REPL3=$DIR/pool.rep.part3
+REPS="$REPL1 $REPL2 $REPL3"
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+rm -f $POOLSET
+create_poolset $POOLSET 32M:$POOL1:z 32M:$POOL2:z 32M:$POOL3:z
+check_file $POOLSET
 
+rm -f $POOLREP
+create_poolset $POOLREP 32M:$POOL1:z 32M:$POOL2:z 32M:$POOL3:z\
+	R 32M:$REPL1:z 32M:$REPL2:z 32M:$REPL3:z
+check_file $POOLREP
+
+# PMEMBLK
+rm -f $POOLS
+expect_normal_exit $PMEMPOOL$EXESUFFIX create blk 512 $POOLSET
+check_files $POOLS
+check_signatures PMEMBLK $POOL1
+
+# PMEMLOG
+rm -f $POOLS
+expect_normal_exit $PMEMPOOL$EXESUFFIX create log $POOLSET
+check_files $POOLS
+check_signatures PMEMLOG $POOL1
+
+# PMEMOBJ
+rm -f $POOLS
+expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout=LAYOUT_NAME$SUFFIX obj $POOLSET
+check_files $POOL
+check_signatures PMEMOBJ $POOL1
+
+# PMEMOBJ with replica
+rm -f $POOLS
+expect_normal_exit $PMEMPOOL$EXESUFFIX create --layout=LAYOUT_NAME$SUFFIX obj $POOLREP
+check_files $POOLS $REPS
+check_signatures PMEMOBJ $POOL1 $REPL1
+
+rm -f $POOLS
+rm -f $REPS
+rm -f $POOLSET
+rm -f $POOLREP
 pass

--- a/src/test/pmempool_create/TEST8w.PS1
+++ b/src/test/pmempool_create/TEST8w.PS1
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -30,41 +29,68 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_create/TEST8w.PS1 -- test for pmempool create command with poolset
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "pmempool_create/TEST8w"
+$Env:UNITTEST_NUM = "8w"
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
-. ../unittest/unittest.sh
+. ..\unittest\unittest.ps1
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
-require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+$POOLSET="$DIR\pool.set"
+$POOL1="$DIR\pool.part1"
+$POOL2="$DIR\pool.part2"
+$POOL3="$DIR\pool.part3"
+$POOLS="$POOL1 $POOL2 $POOL3"
+$POOLREP="$DIR\rep.set"
+$REPL1="$DIR\pool.rep.part1"
+$REPL2="$DIR\pool.rep.part2"
+$REPL3="$DIR\pool.rep.part3"
+$REPS="$REPL1 $REPL2 $REPL3"
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+remove_files $POOLSET
+create_poolset $POOLSET 32M:${POOL1}:z 32M:${POOL2}:z 32M:${POOL3}:z
+check_file $POOLSET
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+remove_files $POOLREP
+create_poolset $POOLREP 32M:${POOL1}:x 32M:${POOL2}:x 32M:${POOL3}:x `
+                        R 32M:${REPL1}:z 32M:${REPL2}:z 32M:${REPL3}:z
+check_file $POOLREP
+
+#PMEMBLK
+remove_files $POOLS
+expect_normal_exit $PMEMPOOL create blk 512 $POOLSET
+check_files $POOL1 $POOL2 $POOL3
+check_signatures PMEMBLK $POOL1
+
+# PMEMLOG
+remove_files $POOLS
+expect_normal_exit $PMEMPOOL create log $POOLSET
+check_files $POOL1 $POOL2 $POOL3
+check_signatures PMEMLOG $POOL1
+
+# PMEMOBJ
+remove_files $POOLS
+expect_normal_exit $PMEMPOOL create --layout=pmempool$Env:SUFFIX obj $POOLSET
+check_files $POOL1 $POOL2 $POOL3
+check_signatures PMEMOBJ $POOL1
+
+# PMEMOBJ with replica
+remove_files $POOLS
+expect_normal_exit $PMEMPOOL create --layout=pmempool$Env:SUFFIX obj $POOLREP
+check_files $POOL1 $POOL2 $POOL3 $REPL1 $REPL2 $REPL3
+check_signatures PMEMOBJ $POOL1 $REPL1
+
+remove_files $POOLS $REPS $POOLSET $POOLREP
 
 pass

--- a/src/test/pmempool_info/TEST17
+++ b/src/test/pmempool_info/TEST17
@@ -64,7 +64,7 @@ check_file $POOLSET
 rm -f $POOLS $REPS
 expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL1 >> $LOG
-expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL1 >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL2 >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $REPL1 >> $LOG
 expect_normal_exit $PMEMPOOL$EXESUFFIX info $REPL2 >> $LOG
 

--- a/src/test/pmempool_info/TEST17.PS1
+++ b/src/test/pmempool_info/TEST17.PS1
@@ -68,7 +68,7 @@ check_file $POOLSET
 remove_files $POOLS $REPS
 expect_normal_exit $PMEMPOOL create obj --layout pmempool$Env:SUFFIX $POOLSET
 expect_normal_exit $PMEMPOOL info $POOL1 >> $LOG
-expect_normal_exit $PMEMPOOL info $POOL1 >> $LOG
+expect_normal_exit $PMEMPOOL info $POOL2 >> $LOG
 expect_normal_exit $PMEMPOOL info $REPL1 >> $LOG
 expect_normal_exit $PMEMPOOL info $REPL2 >> $LOG
 

--- a/src/test/pmempool_info/TEST20
+++ b/src/test/pmempool_info/TEST20
@@ -30,41 +30,44 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_info/TEST20 -- test for info command
+#
+export UNITTEST_NAME=pmempool_info/TEST20
+export UNITTEST_NUM=20
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
-require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+# XXX temporary
+export PMEM_NO_HDRS=1
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+LOG=out${UNITTEST_NUM}.log
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+rm -rf $LOG && touch $LOG
+
+POOLSET=$DIR/pool.set
+POOL1=$DIR/pool.part1
+POOL2=$DIR/pool.part2
+POOLS="$POOL1 $POOL2"
+REPL1=$DIR/pool.rep.part1
+REPL2=$DIR/pool.rep.part2
+REPS="$REPL1 $REPL2"
+
+rm -f $POOLSET
+create_poolset $POOLSET 32M:$POOL1:z 32M:$POOL2:z\
+	R 32M:$REPL1:z 32M:$REPL2:z
+check_file $POOLSET
+
+rm -f $POOLS $REPS
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOL1 >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $REPL1 >> $LOG
+
+check
 
 pass

--- a/src/test/pmempool_info/TEST20.PS1
+++ b/src/test/pmempool_info/TEST20.PS1
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -30,41 +29,46 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_info\TEST20.PS1 -- test for info command
+#
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+    [alias("d")]
+    $DIR = ""
+    )
+$Env:UNITTEST_NAME = "pmempool_info/TEST20"
+$Env:UNITTEST_NUM = "20"
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
 
-# standard unit test setup
-. ../unittest/unittest.sh
+. ..\unittest\unittest.ps1
 
 require_test_type medium
 require_fs_type any
-require_dax_devices 2
-require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+$LOG="out$Env:UNITTEST_NUM.log"
+remove_files $LOG
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+$POOLSET="$DIR\pool.set"
+$POOL1="$DIR\pool.part1"
+$POOL2="$DIR\pool.part2"
+$POOLS="$POOL1 $POOL2"
+$REPL1="$DIR\pool.rep.part1"
+$REPL2="$DIR\pool.rep.part2"
+$REPS="$REPL1 $REPL2"
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+remove_files $POOLSET
+create_poolset $POOLSET 32M:${POOL1}:z 32M:${POOL2}:z `
+	R 32M:${REPL1}:z 32M:${REPL2}:z
+check_file $POOLSET
+
+remove_files $POOLS $REPS
+expect_normal_exit $PMEMPOOL create obj --layout pmempool$Env:SUFFIX $POOLSET
+expect_normal_exit $PMEMPOOL info $POOL1 >> $LOG
+expect_normal_exit $PMEMPOOL info $REPL1 >> $LOG
+
+check
 
 pass

--- a/src/test/pmempool_info/TEST21
+++ b/src/test/pmempool_info/TEST21
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,28 +30,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_info/TEST21 -- test for info command with device dax
+#
+# Same as TEST18, but run on a pool set that spans two Device DAX devices
+# with 2M alignment.
+#
+export UNITTEST_NAME=pmempool_info/TEST21
+export UNITTEST_NUM=21
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
@@ -61,10 +48,21 @@ require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+# XXX temporary
+export PMEM_NO_HDRS=1
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+LOG=out${UNITTEST_NUM}.log
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+rm -rf $LOG && touch $LOG
+
+POOLSET=$DIR/testset1
+create_poolset $POOLSET AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX create obj --layout pmempool$SUFFIX $POOLSET
+expect_normal_exit $PMEMPOOL$EXESUFFIX info $POOLSET >> $LOG
+expect_normal_exit $PMEMPOOL$EXESUFFIX info ${DEVICE_DAX_PATH[0]} >> $LOG
+
+check
 
 pass

--- a/src/test/pmempool_info/out17.log.match
+++ b/src/test/pmempool_info/out17.log.match
@@ -22,7 +22,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(nW) [OK]
 Part file:
-path                     : $(nW)pool.part1
+path                     : $(nW)pool.part2
 type                     : regular file
 size                     : $(nW)
 

--- a/src/test/pmempool_info/out20.log.match
+++ b/src/test/pmempool_info/out20.log.match
@@ -22,53 +22,7 @@ Data                     : $(*)
 Machine                  : $(*)
 Checksum                 : $(nW) [OK]
 Part file:
-path                     : $(nW)pool.part1
-type                     : regular file
-size                     : $(nW)
-
-POOL Header:
-Signature                : PMEMOBJ [part file]
-Major                    : $(*)
-Mandatory features       : $(*)
-Not mandatory features   : $(*)
-Forced RO                : $(*)
-Pool set UUID            : $(*)
-UUID                     : $(*)
-Previous part UUID       : $(*)
-Next part UUID           : $(*)
-Previous replica UUID    : $(*)
-Next replica UUID        : $(*)
-Creation Time            : $(*)
-Alignment Descriptor     : $(*)
-Class                    : $(*)
-Data                     : $(*)
-Machine                  : $(*)
-Checksum                 : $(nW) [OK]
-Part file:
 path                     : $(nW)pool.rep.part1
-type                     : regular file
-size                     : $(nW)
-
-POOL Header:
-Signature                : PMEMOBJ [part file]
-Major                    : $(*)
-Mandatory features       : $(*)
-Not mandatory features   : $(*)
-Forced RO                : $(*)
-Pool set UUID            : $(*)
-UUID                     : $(*)
-Previous part UUID       : $(*)
-Next part UUID           : $(*)
-Previous replica UUID    : $(*)
-Next replica UUID        : $(*)
-Creation Time            : $(*)
-Alignment Descriptor     : $(*)
-Class                    : $(*)
-Data                     : $(*)
-Machine                  : $(*)
-Checksum                 : $(nW) [OK]
-Part file:
-path                     : $(nW)pool.rep.part2
 type                     : regular file
 size                     : $(nW)
 

--- a/src/test/pmempool_info/out21.log.match
+++ b/src/test/pmempool_info/out21.log.match
@@ -1,0 +1,71 @@
+Poolset structure:
+Number of replicas       : 1
+Replica 0 (master) - local, 2 part(s):
+part 0:
+path                     : $(nW)
+type                     : device dax
+size                     : $(nW)
+part 1:
+path                     : $(nW)
+type                     : device dax
+size                     : $(nW)
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : 0x1
+Not mandatory features   : 0x0
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : ELF64
+Data                     : 2's complement, little endian
+Machine                  : AMD X86-64
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)
+Part file:
+path                     : $(nW)
+type                     : device dax
+size                     : $(nW)
+
+POOL Header:
+Signature                : PMEMOBJ
+Major                    : $(nW)
+Mandatory features       : 0x1
+Not mandatory features   : 0x0
+Forced RO                : 0x0
+Pool set UUID            : $(nW)
+UUID                     : $(nW)
+Previous part UUID       : $(nW)
+Next part UUID           : $(nW)
+Previous replica UUID    : $(nW)
+Next replica UUID        : $(nW)
+Creation Time            : $(*)
+Alignment Descriptor     : $(nW)
+Class                    : $(nW)
+Data                     : 2's complement, little endian
+Machine                  : AMD X86-64
+Checksum                 : $(*)
+
+PMEM OBJ Header:
+Layout                   : pmempool$(*)
+Lanes offset             : $(nW)
+Number of lanes          : $(nW)
+Heap offset              : $(nW)
+Heap size                : $(nW)
+Checksum                 : $(*)
+Root offset              : $(nW)

--- a/src/test/pmempool_rm/TEST6
+++ b/src/test/pmempool_rm/TEST6
@@ -31,7 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #
-# pmempool_rm/TEST4 -- test for pmempool rm
+# pmempool_rm/TEST6 -- test for pmempool rm
 #
 # Same as TEST4, but run on a pool set that spans two Device DAX devices
 # with 4K alignment.

--- a/src/test/pmempool_rm/TEST8
+++ b/src/test/pmempool_rm/TEST8
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017, Intel Corporation
+# Copyright 2015-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,28 +30,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+#
+# pmempool_rm/TEST8 -- test for pmempool rm
+#
+# Same as TEST4, but run on a pool set that spans two Device DAX devices
+# with 2M alignment.
+#
+export UNITTEST_NAME=pmempool_rm/TEST8
+export UNITTEST_NUM=8
 
-#
-# src/test/log_basic/TEST9 -- unit test for:
-# - pmemlog_append
-# and:
-# - pmemlog_nbyte
-# - pmemlog_tell
-# - pmemlog_walk
-# - pmemlog_rewind
-# in case of non-empty pool and
-# - pmemlog_check
-# - pmemlog_open
-# - pmemlog_close
-#
-# Same as TEST1, but run on a pool set that spans two Device DAX devices
-# with 2M alignment. Expected failure, as 2M alignment is not supported
-# if NOHDRS option is not specified.
-#
-export UNITTEST_NAME=log_basic/TEST9
-export UNITTEST_NUM=9
-
-# standard unit test setup
 . ../unittest/unittest.sh
 
 require_test_type medium
@@ -61,10 +48,13 @@ require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
-dax_device_zero
+# XXX temporary
+export PMEM_NO_HDRS=1
 
-create_poolset $DIR/testset AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
+create_poolset $DIR/testset1 AUTO:${DEVICE_DAX_PATH[0]} AUTO:${DEVICE_DAX_PATH[1]}
 
-expect_abnormal_exit ./log_basic$EXESUFFIX $DIR/testset a n t w r t w
+expect_normal_exit $PMEMPOOL$EXESUFFIX rm -af $DIR/testset1
+
+check_no_files $DIR/testset1
 
 pass

--- a/src/test/util_poolset/out0.log.match
+++ b/src/test/util_poolset/out0.log.match
@@ -2,14 +2,14 @@ util_poolset/TEST0: START: util_poolset
  ./util_poolset$(nW) c 4194304 $(nW)/testset0 $(nW)/testset1 $(nW)/testset2 $(nW)/testset3 $(nW)/testset4 $(nW)/testset5 $(nW)/testset6 -mo:$(nW)/testfile72 $(nW)/testset7 -mf:1073741824 $(nW)/testset8 -mo:$(nW)/testfile102 $(nW)/testset10 $(nW)/testset11 $(nW)/testset12 $(nW)/testset13 $(nW)/testset14 $(nW)/testset15 $(nW)/testset18 $(nW)/testset20 $(nW)/testset21 $(nW)/testset22 -mo:$(nW)/testset23 $(nW)/testset23 $(nW)/testset24 $(nW)/testset25 -mp:6291456 $(nW)/testset26
 $(nW)/testset0: util_pool_create: No such file or directory
 $(nW)/testset1: created: nreps 1 poolsize 4194304 zeroed 1
-  replica[0]: nparts 1 repsize 4194304 is_pmem 0
+  replica[0]: nparts 1 nhdrs 1 repsize 4194304 is_pmem 0
     part[0] path $(nW)/testfile11 filesize 4194304 size 4194304
 $(nW)/testset2: created: nreps 1 poolsize 8384512 zeroed 1
-  replica[0]: nparts 2 repsize 8384512 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile21 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile22 filesize 4194304 size 4190208
 $(nW)/testset3: created: nreps 1 poolsize 8384512 zeroed 0
-  replica[0]: nparts 2 repsize 8384512 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile31 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile32 filesize 4194304 size 4190208
 $(nW)/testset4: util_pool_create: Invalid argument
@@ -29,35 +29,35 @@ $(nW)/testset13: util_pool_create: Invalid argument
 $(nW)/testset14: util_pool_create: Invalid argument
 $(nW)/testset15: util_pool_create: Invalid argument
 $(nW)/testset18: created: nreps 1 poolsize 5238784 zeroed 0
-  replica[0]: nparts 2 repsize 5238784 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 5238784 is_pmem 0
     part[0] path $(nW)/subdir1/testfile181 filesize 2097152 size 5238784
     part[1] path $(nW)/subdir2/testfile182 filesize 3145728 size 3141632
 $(nW)/testset20: util_pool_create: File exists
 $(nW)/testset21: util_pool_create: File exists
 $(nW)/testset22: created: nreps 1 poolsize 8384512 zeroed 0
-  replica[0]: nparts 2 repsize 8384512 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile221 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile222 filesize 4194304 size 4190208
 mocked open: $(nW)/testset23
 mocked open: $(nW)/testset23
 $(nW)/testset23: util_pool_create: Permission denied
 $(nW)/testset24: created: nreps 3 poolsize 8384512 zeroed 1
-  replica[0]: nparts 2 repsize 8384512 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile241 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile242 filesize 4194304 size 4190208
-  replica[1]: nparts 1 repsize 8388608 is_pmem 0
+  replica[1]: nparts 1 nhdrs 1 repsize 8388608 is_pmem 0
     part[0] path $(nW)/testfile243 filesize 8388608 size 8388608
-  replica[2]: nparts 2 repsize 8384512 is_pmem 0
+  replica[2]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile244 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile245 filesize 4194304 size 4190208
 $(nW)/testset25: util_pool_create: Invalid argument
 mocked pmem_is_pmem: 6291456
 $(nW)/testset26: created: nreps 3 poolsize 6287360 zeroed 0
-  replica[0]: nparts 2 repsize 6287360 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 6287360 is_pmem 0
     part[0] path $(nW)/testfile261 filesize 4194304 size 6287360
     part[1] path $(nW)/testfile262 filesize 2097152 size 2093056
-  replica[1]: nparts 1 repsize 8388608 is_pmem 0
+  replica[1]: nparts 1 nhdrs 1 repsize 8388608 is_pmem 0
     part[0] path $(nW)/testfile263 filesize 8388608 size 8388608
-  replica[2]: nparts 1 repsize 6291456 is_pmem 1
+  replica[2]: nparts 1 nhdrs 1 repsize 6291456 is_pmem 1
     part[0] path $(nW)/testfile264 filesize 6291456 size 6291456
 util_poolset/TEST0: DONE

--- a/src/test/util_poolset/out0w.log.match
+++ b/src/test/util_poolset/out0w.log.match
@@ -2,14 +2,14 @@ util_poolset$(nW)TEST0w: START: util_poolset
  $(nW)util_poolset$(nW) c 4194304 $(nW)testset0 $(nW)testset1 $(nW)testset2 $(nW)testset3 $(nW)testset4 $(nW)testset5 $(nW)testset6 -mo:$(nW)testfile72 $(nW)testset7 -mf:1073741824 $(nW)testset8 -mo:$(nW)testfile102 $(nW)testset10 $(nW)testset11 $(nW)testset12 $(nW)testset13 $(nW)testset14 $(nW)testset15 $(nW)testset18 $(nW)testset20 $(nW)testset21 $(nW)testset22 -mo:$(nW)testset23 $(nW)testset23 $(nW)testset24 $(nW)testset25 -mp:5242880 $(nW)testset26
 $(nW)testset0: util_pool_create: No such file or directory
 $(nW)testset1: created: nreps 1 poolsize 4194304 zeroed 1
-  replica[0]: nparts 1 repsize 4194304 is_pmem 0
+  replica[0]: nparts 1 nhdrs 1 repsize 4194304 is_pmem 0
     part[0] path $(nW)testfile11 filesize 4194304 size 4194304
 $(nW)testset2: created: nreps 1 poolsize 8323072 zeroed 1
-  replica[0]: nparts 2 repsize 8323072 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile21 filesize 4194304 size 8323072
     part[1] path $(nW)testfile22 filesize 4194304 size 4128768
 $(nW)testset3: created: nreps 1 poolsize 8323072 zeroed 0
-  replica[0]: nparts 2 repsize 8323072 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile31 filesize 4194304 size 8323072
     part[1] path $(nW)testfile32 filesize 4194304 size 4128768
 $(nW)testset4: util_pool_create: Invalid argument
@@ -27,34 +27,34 @@ $(nW)testset13: util_pool_create: Invalid argument
 $(nW)testset14: util_pool_create: Invalid argument
 $(nW)testset15: util_pool_create: Invalid argument
 $(nW)testset18: created: nreps 1 poolsize 6225920 zeroed 0
-  replica[0]: nparts 2 repsize 6225920 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 6225920 is_pmem 0
     part[0] path $(nW)subdir1$(nW)testfile181 filesize 3145728 size 6225920
     part[1] path $(nW)subdir2$(nW)testfile182 filesize 3145728 size 3080192
 $(nW)testset20: util_pool_create: File exists
 $(nW)testset21: util_pool_create: File exists
 $(nW)testset22: created: nreps 1 poolsize 8323072 zeroed 0
-  replica[0]: nparts 2 repsize 8323072 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile221 filesize 4194304 size 8323072
     part[1] path $(nW)testfile222 filesize 4194304 size 4128768
 mocked open: $(nW)testset23
 $(nW)testset23: util_pool_create: Permission denied
 $(nW)testset24: created: nreps 3 poolsize 8323072 zeroed 1
-  replica[0]: nparts 2 repsize 8323072 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile241 filesize 4194304 size 8323072
     part[1] path $(nW)testfile242 filesize 4194304 size 4128768
-  replica[1]: nparts 1 repsize 8388608 is_pmem 0
+  replica[1]: nparts 1 nhdrs 1 repsize 8388608 is_pmem 0
     part[0] path $(nW)testfile243 filesize 8388608 size 8388608
-  replica[2]: nparts 2 repsize 8323072 is_pmem 0
+  replica[2]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile244 filesize 6291456 size 8323072
     part[1] path $(nW)testfile245 filesize 2097152 size 2031616
 $(nW)testset25: util_pool_create: Invalid argument
 mocked pmem_is_pmem: 5242880
 $(nW)testset26: created: nreps 3 poolsize 5242880 zeroed 0
-  replica[0]: nparts 2 repsize 6225920 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 6225920 is_pmem 0
     part[0] path $(nW)testfile261 filesize 4194304 size 6225920
     part[1] path $(nW)testfile262 filesize 2097152 size 2031616
-  replica[1]: nparts 1 repsize 7340032 is_pmem 0
+  replica[1]: nparts 1 nhdrs 1 repsize 7340032 is_pmem 0
     part[0] path $(nW)testfile263 filesize 7340032 size 7340032
-  replica[2]: nparts 1 repsize 5242880 is_pmem 1
+  replica[2]: nparts 1 nhdrs 1 repsize 5242880 is_pmem 1
     part[0] path $(nW)testfile264 filesize 5242880 size 5242880
 util_poolset$(nW)TEST0w: DONE

--- a/src/test/util_poolset/out2.log.match
+++ b/src/test/util_poolset/out2.log.match
@@ -1,7 +1,7 @@
 util_poolset/TEST2: START: util_poolset
  ./util_poolset$(nW) o 4194304 $(nW)/testset1 $(nW)/testset2 $(nW)/testset3 $(nW)/testset4 $(nW)/testset5 $(nW)/testset6 $(nW)/testset7 $(nW)/testset8 $(nW)/testset9 $(nW)/testset10 $(nW)/testset11 $(nW)/testset12
 $(nW)/testset1: opened: nreps 1 poolsize 8384512 rdonly 0
-  replica[0]: nparts 2 repsize 8384512 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8384512 is_pmem 0
     part[0] path $(nW)/testfile11 filesize 4194304 size 8384512
     part[1] path $(nW)/testfile12 filesize 4194304 size 4190208
 $(nW)/testset2: util_pool_open: Invalid argument

--- a/src/test/util_poolset/out2w.log.match
+++ b/src/test/util_poolset/out2w.log.match
@@ -1,7 +1,7 @@
 util_poolset$(nW)TEST2w: START: util_poolset
  $(nW)util_poolset$(nW) o 4194304 $(nW)testset1 $(nW)testset2 $(nW)testset3 $(nW)testset4 $(nW)testset5 $(nW)testset6 $(nW)testset7 $(nW)testset8 $(nW)testset9 $(nW)testset10 $(nW)testset11 $(nW)testset12
 $(nW)testset1: opened: nreps 1 poolsize 8323072 rdonly 0
-  replica[0]: nparts 2 repsize 8323072 is_pmem 0
+  replica[0]: nparts 2 nhdrs 2 repsize 8323072 is_pmem 0
     part[0] path $(nW)testfile11 filesize 4194304 size 8323072
     part[1] path $(nW)testfile12 filesize 4194304 size 4128768
 $(nW)testset2: util_pool_open: Invalid argument

--- a/src/test/util_poolset/util_poolset.c
+++ b/src/test/util_poolset/util_poolset.c
@@ -80,8 +80,9 @@ poolset_info(const char *fname, struct pool_set *set, int o)
 		struct pool_replica *rep = set->replica[r];
 		size_t repsize = 0;
 
-		UT_OUT("  replica[%d]: nparts %d repsize %zu is_pmem %d",
-			r, rep->nparts, rep->repsize, rep->is_pmem);
+		UT_OUT("  replica[%d]: nparts %d nhdrs %d repsize %zu "
+				"is_pmem %d",
+			r, rep->nparts, rep->nhdrs, rep->repsize, rep->is_pmem);
 
 		for (unsigned i = 0; i < rep->nparts; i++) {
 			struct pool_set_part *part = &rep->part[i];
@@ -92,10 +93,10 @@ poolset_info(const char *fname, struct pool_set *set, int o)
 			repsize += partsize;
 			if (i > 0)
 				UT_ASSERTeq(part->size,
-					partsize - Ut_mmap_align);
+					partsize - Ut_mmap_align); /* XXX */
 		}
 
-		repsize -= (rep->nparts - 1) * Ut_mmap_align;
+		repsize -= (rep->nhdrs - 1) * Ut_mmap_align;
 		UT_ASSERTeq(rep->repsize, repsize);
 		UT_ASSERTeq(rep->part[0].size, repsize);
 

--- a/src/test/util_poolset_parse/TEST1
+++ b/src/test/util_poolset_parse/TEST1
@@ -48,6 +48,9 @@ require_dax_devices 1
 
 setup
 
+# XXX temporary
+export PMEM_NO_HDRS=1
+
 export PARSER_LOG_LEVEL=4
 export PARSER_LOG_FILE=./parser$UNITTEST_NUM.log
 

--- a/src/test/util_poolset_parse/TEST3
+++ b/src/test/util_poolset_parse/TEST3
@@ -49,6 +49,9 @@ require_dax_device_alignments 2097152 2097152 # 2MiB
 
 setup
 
+# XXX temporary
+export PMEM_NO_HDRS=1
+
 export PARSER_LOG_LEVEL=4
 export PARSER_LOG_FILE=./parser$UNITTEST_NUM.log
 

--- a/src/test/util_poolset_parse/grep3.log.match
+++ b/src/test/util_poolset_parse/grep3.log.match
@@ -1,2 +1,3 @@
 set file format correct ($(nW)testset1)
 set file format correct ($(nW)testset2)
+set file format correct ($(nW)testset4)


### PR DESCRIPTION
The prototype support for pool sets with the pool headers only in the
first part of each replica.  It is required to allow creating pools
that span multiple Device DAX devices with internal alignment other than
4KiB.  Of course, it can be used with pool sets built on regular files,
as well.
When this option is enabled, it must be set for all the replicas
in the pool set (including remote ones).

In this prototype, the new option must be enabled by setting environment
variable "PMEM_NO_HDRS=1".  Eventually, it will be integrated with
pool set options (see PR #2268).

TBD:
- add more tests
- tests for remote replicas on 2M Device DAX devices
- backward compatibility tests (old libs cannot open "headerless pool")
- pmempool info/dump/... - print info about compat flags, etc.
- pmempool transform - convert existing pool set to "headerless" pool
  or vice versa + tests
- man pages update

OPENS:
- Since prev/next part UUID does not make sense in case of "headerless"
  pool, we could add the number of parts / total pool size to
  the pool header, which would allow to verify the data in pool set
  file and/or to detect missing parts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2280)
<!-- Reviewable:end -->
