### PR TITLE
common: PR cleanup for FreeBSD port

### DIFF
--- a/src/common/os_linux.c
+++ b/src/common/os_linux.c
@@ -58,9 +58,10 @@ os_open(const char *pathname, int flags, ...)
 	if (flags & O_CREAT) {
 		va_list arg;
 		va_start(arg, flags);
-		mode_t mode = va_arg(arg, mode_t);
+		/* Clang requires int due to auto-promotion */
+		int mode = va_arg(arg, int);
 		va_end(arg);
-		return open(pathname, flags, mode);
+		return open(pathname, flags, (mode_t)mode);
 	} else {
 		return open(pathname, flags);
 	}

--- a/src/common/out.c
+++ b/src/common/out.c
@@ -273,8 +273,7 @@ out_init(const char *log_prefix, const char *log_level_var,
 #ifndef _WIN32
 	if (os_thread_atfork(out_prefork, out_postfork_parent,
 		out_postfork_child)) {
-		ERR("!os_thread_atfork");
-		abort();
+		FATAL("!os_thread_atfork");
 	}
 #endif
 

--- a/src/libpmemobj/ctl.c
+++ b/src/libpmemobj/ctl.c
@@ -94,7 +94,14 @@ ctl_find_node(struct ctl_node *nodes, const char *name,
 	 */
 	while (node_name != NULL) {
 		char *endptr;
+		/*
+		 * Ignore errno from strtol: FreeBSD returns EINVAL if no
+		 * conversion is performed. Linux does not, but endptr
+		 * check is valid in both cases.
+		 */
+		int tmp_errno = errno;
 		long index_value = strtol(node_name, &endptr, 0);
+		errno = tmp_errno;
 		struct ctl_index *index_entry = NULL;
 		if (endptr != node_name) { /* a valid index */
 			index_entry = Malloc(sizeof(*index_entry));

--- a/src/rpmem_common/rpmem_proto.h
+++ b/src/rpmem_common/rpmem_proto.h
@@ -245,6 +245,11 @@ struct rpmem_msg_set_attr_resp {
 } PACKED;
 
 /*
+ * XXX Begin: Suppress gcc conversion warnings for FreeBSD be*toh macros.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+/*
  * rpmem_ntoh_msg_ibc_attr -- convert rpmem_msg_ibc attr to host byte order
  */
 static inline void
@@ -376,7 +381,10 @@ rpmem_ntoh_msg_open(struct rpmem_msg_open *msg)
 	msg->provider = be32toh(msg->provider);
 	rpmem_ntoh_msg_pool_desc(&msg->pool_desc);
 }
-
+/*
+ * XXX End: Suppress gcc conversion warnings for FreeBSD be*toh macros
+ */
+#pragma GCC diagnostic pop
 /*
  * rpmem_hton_msg_open -- convert rpmem_msg_open to network byte order
  */

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -268,15 +268,13 @@ VMMALLOC_TESTS = \
 	vmmalloc_fork\
 	vmmalloc_init\
 	vmmalloc_malloc\
+	vmmalloc_malloc_hooks\
 	vmmalloc_malloc_usable_size\
 	vmmalloc_memalign\
 	vmmalloc_out_of_memory\
 	vmmalloc_realloc\
 	vmmalloc_valgrind\
 	vmmalloc_valloc
-ifneq ($(OSTYPE),FreeBSD)
-	VMMALLOC_TESTS += vmmalloc_malloc_hooks	# No malloc hooks in FreeBSD
-endif
 
 EXAMPLES_TESTS = \
 	ex_libpmem\

--- a/src/test/ex_libpmem/TEST0
+++ b/src/test/ex_libpmem/TEST0
@@ -54,7 +54,10 @@ create_nonzeroed_file 2M 0K $DIR/testfile1
 expect_normal_exit $EX_PATH/simple_copy $DIR/testfile1 $DIR/testfile2 \
 	> out$UNITTEST_NUM.log 2>&1
 
-cmp -n 4096 $DIR/testfile1 $DIR/testfile2 > cmp$UNITTEST_NUM.log 2>&1
+# XXX FreeBSD does not support the -n option to cmp(1)
+dd if=$DIR/testfile1 of=$DIR/testfile1.4k bs=4096 count=1 status=none
+dd if=$DIR/testfile2 of=$DIR/testfile2.4k bs=4096 count=1 status=none
+cmp $DIR/testfile1.4k $DIR/testfile2.4k > cmp$UNITTEST_NUM.log 2>&1
 
 check
 

--- a/src/test/ex_libpmemobj/TEST15
+++ b/src/test/ex_libpmemobj/TEST15
@@ -52,13 +52,13 @@ setup
 EX_PATH=../../examples/libpmemobj/pminvaders
 INPUT=$DIR/input.txt
 
-dd if=/dev/zero bs=1k count=4 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
+dd if=/dev/zero bs=1k count=2 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
 echo -n oooo >> $INPUT
-dd if=/dev/zero bs=1k count=4 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
+dd if=/dev/zero bs=1k count=2 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
 echo -n ppppppp >> $INPUT
-dd if=/dev/zero bs=1k count=4 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
+dd if=/dev/zero bs=1k count=2 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
 echo -n ooo >> $INPUT
-dd if=/dev/zero bs=1k count=4 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
+dd if=/dev/zero bs=1k count=2 2>>prep$UNITTEST_NUM.log | tr '\0' ' ' >> $INPUT
 echo -n q >> $INPUT
 
 if [ -t 1 -a -z "$NOTTY" ]

--- a/src/test/unittest/ut_file.c
+++ b/src/test/unittest/ut_file.c
@@ -486,7 +486,8 @@ ut_rename(const char *file, int line, const char *func,
 	return retval;
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__FreeBSD__)
+/* XXX Fix for FreeBSD if ever used */
 /*
  * ut_mount -- a mount that cannot return -1
  */

--- a/src/test/vmmalloc_init/TEST16
+++ b/src/test/vmmalloc_init/TEST16
@@ -46,6 +46,7 @@ require_fs_type any
 # there's no point in testing statically linked builds
 require_build_type nondebug
 require_no_asan
+require_no_freebsd
 
 # Valgrind does not call vmmalloc's malloc implementation from library
 # loaded with RTLD_DEEPBIND.

--- a/src/test/vmmalloc_init/TEST6
+++ b/src/test/vmmalloc_init/TEST6
@@ -46,6 +46,7 @@ require_fs_type any
 # there's no point in testing statically linked builds
 require_build_type debug
 require_no_asan
+require_no_freebsd
 
 # Valgrind does not call vmmalloc's malloc implementation from library
 # loaded with RTLD_DEEPBIND.

--- a/src/test/vmmalloc_init/vmmalloc_init.c
+++ b/src/test/vmmalloc_init/vmmalloc_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016, Intel Corporation
+ * Copyright 2014-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
  * usage: vmmalloc_init [d|l]
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <dlfcn.h>
 #include "unittest.h"
 

--- a/src/test/vmmalloc_malloc_hooks/TEST0
+++ b/src/test/vmmalloc_malloc_hooks/TEST0
@@ -47,6 +47,7 @@ require_fs_type any
 # there's no point in testing statically linked builds
 require_build_type debug nondebug
 require_no_asan
+require_no_freebsd
 
 setup
 

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -915,13 +915,12 @@ info_obj_stats_alloc_classes(struct pmem_info *pip, int v,
 				pip->obj.alloc_classes, (uint8_t)class);
 		if (c == NULL)
 			continue;
+		if (!stats->class_stats[class].n_units)
+			continue;
 
 		double used_perc = 100.0 *
 			(double)stats->class_stats[class].n_used /
 			(double)stats->class_stats[class].n_units;
-
-		if (!stats->class_stats[class].n_units)
-			continue;
 
 		outv_nl(v);
 		outv_field(v, "Unit size", "%s", out_get_size_str(


### PR DESCRIPTION
Fix clang warning in common/os_linux.c.
Address PR comments that do not conflict with PR 2277.
More FreeBSD portability fixes.
Shorten pminvaders test to avoid timeout when sanitizing.
Fix divide by zero in tools/pmempool/info_obj.c.

Split from FreeBSD port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2285)
<!-- Reviewable:end -->
