### PR TITLE
common: FreeBSD: omit pmemcheck with USE_VALGRIND

### DIFF
--- a/src/common/valgrind_internal.h
+++ b/src/common/valgrind_internal.h
@@ -38,7 +38,9 @@
 #define NVML_VALGRIND_INTERNAL_H 1
 
 #ifdef USE_VALGRIND
+#ifndef __FreeBSD__	/* XXX TODO: pmemcheck for FreeBSD */
 #define USE_VG_PMEMCHECK
+#endif
 #define USE_VG_HELGRIND
 #define USE_VG_MEMCHECK
 #define USE_VG_DRD

--- a/src/test/obj_recovery/obj_recovery.c
+++ b/src/test/obj_recovery/obj_recovery.c
@@ -34,8 +34,8 @@
  * obj_recovery.c -- unit test for pool recovery
  */
 #include "unittest.h"
-#if defined(USE_VG_PMEMCHECK) || defined(USE_VALGRIND)
-#include <valgrind/pmemcheck.h>
+#include "valgrind_internal.h"
+#ifdef USE_VG_PMEMCHECK
 #define VALGRIND_PMEMCHECK_END_TX VALGRIND_PMC_END_TX
 #else
 #define VALGRIND_PMEMCHECK_END_TX


### PR DESCRIPTION
Restore when pmemcheck is ported to FreeBSD.

Split from FreeBSD port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2286)
<!-- Reviewable:end -->
