### PR TITLE
test: KEEP_GOING support

### DIFF
--- a/src/test/RUNTESTS
+++ b/src/test/RUNTESTS
@@ -116,6 +116,8 @@ runtest_local() {
 		echo "RUNTESTS: stopping: $RUNTEST_DIR/$RUNTEST_SCRIPT $errmsg, $RUNTEST_PARAMS" >&2
 		if [ "$keep_going" == "y" ]; then
 			keep_going_exit_code=1
+			fail_list="$fail_list $RUNTEST_DIR/$RUNTEST_SCRIPT"
+			((fail_count+=1))
 		else
 			exit 1
 		fi
@@ -367,6 +369,8 @@ checktype="none"
 skip_dir=""
 keep_going=n
 keep_going_exit_code=0
+fail_count=0
+fail_list=""
 
 #
 # some of defaults can be overwritten with environment variables
@@ -648,7 +652,8 @@ else
 fi
 [ "$pmem_skip" ] && echo "SKIPPED fs-type \"pmem\" runs: testconfig.sh doesn't set PMEM_FS_DIR"
 [ "$non_pmem_skip" ] && echo "SKIPPED fs-type \"non-pmem\" runs: testconfig.sh doesn't set NON_PMEM_FS_DIR"
-if [ "$keep_going" == "y" ]; then
+if [ "$fail_count" != "0" ]; then
+	echo "$(tput setaf 1)$fail_count tests failed:$(tput sgr0) $fail_list"
 	exit $keep_going_exit_code
 else
 	exit 0

--- a/src/test/testconfig.sh.example
+++ b/src/test/testconfig.sh.example
@@ -83,6 +83,14 @@ NON_PMEM_FS_DIR=/tmp
 TM=1
 
 #
+# Normally the first failed test terminates the test run. If KEEP_GOING
+# is set, continues executing all tests. If any tests fail, once all tests
+# have completed reports number of failures, lists failed tests and exits
+# with error status.
+#
+#KEEP_GOING=y
+
+#
 # 2) *** REMOTE CONFIGURATION ***
 #
 # The second part of the file tells the script unittest/unittest.sh
@@ -94,6 +102,9 @@ TM=1
 # Addresses of nodes should be defined as an array:
 #
 #    NODE[index]=[<user>@]<host-name-or-IP>
+#
+# The remote account must be set up for automated ssh authentication.
+# The remote user's login shell must be bash.
 #
 #NODE[0]=127.0.0.1
 #NODE[1]=user1@host1


### PR DESCRIPTION
Make KEEP_GOING flag more useful by recording and counting
failures.
Document KEEP_GOING flag in testconfig.sh.example.
Add note on remote account requirements in testconfig.sh.example.

Split from FreeBSD port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2287)
<!-- Reviewable:end -->
