### PR TITLE
common: Unify (most of) __sync builtin usage

### DIFF
--- a/src/benchmarks/obj_locks.cpp
+++ b/src/benchmarks/obj_locks.cpp
@@ -184,7 +184,7 @@ get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 			if (util_bool_compare_and_swap64(runid, tmp_runid,
 							 (pop_runid - 1))) {
 				if (init_lock(&lock, NULL)) {
-					__sync_fetch_and_and(runid, 0);
+					util_fetch_and_and64(runid, 0);
 					return NULL;
 				}
 

--- a/src/jemalloc/include/jemalloc/internal/util.h
+++ b/src/jemalloc/include/jemalloc/internal/util.h
@@ -27,12 +27,14 @@
 #  define JEMALLOC_CC_SILENCE_INIT(v)
 #endif
 
+#ifndef likely
 #ifdef __GNUC__
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #else
 #define likely(x) !!(x)
 #define unlikely(x) !!(x)
+#endif
 #endif
 
 /*

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -523,7 +523,7 @@ pmem_is_pmem(const void *addr, size_t len)
 	/* This is not thread-safe, but pmem_is_pmem_init() is. */
 	if (once == 0) {
 		pmem_is_pmem_init();
-		util_fetch_and_add(&once, 1);
+		util_fetch_and_add32(&once, 1);
 	}
 
 	VALGRIND_ANNOTATE_HAPPENS_AFTER(&Func_is_pmem);

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -65,7 +65,7 @@ lane_enter(PMEMblkpool *pbp, unsigned *lane)
 {
 	unsigned mylane;
 
-	mylane = __sync_fetch_and_add(&pbp->next_lane, 1) % pbp->nlane;
+	mylane = util_fetch_and_add32(&pbp->next_lane, 1) % pbp->nlane;
 
 	/* lane selected, grab the per-lane lock */
 	util_mutex_lock(&pbp->locks[mylane]);

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -135,6 +135,7 @@
 #include "btt.h"
 #include "btt_layout.h"
 #include "sys_util.h"
+#include "util.h"
 
 /*
  * The opaque btt handle containing state tracked by this module
@@ -633,7 +634,7 @@ arena_setf(struct btt *bttp, struct arena *arenap, unsigned lane, uint32_t setf)
 	LOG(3, "bttp %p arenap %p lane %u setf 0x%x", bttp, arenap, lane, setf);
 
 	/* update runtime state */
-	__sync_fetch_and_or(&arenap->flags, setf);
+	util_fetch_and_or32(&arenap->flags, setf);
 
 	if (!bttp->laidout) {
 		/* no layout yet to update */
@@ -750,7 +751,7 @@ build_rtt(struct btt *bttp, struct arena *arenap)
 	}
 	for (uint32_t lane = 0; lane < bttp->nfree; lane++)
 		arenap->rtt[lane] = BTT_MAP_ENTRY_ERROR;
-	__sync_synchronize();
+	util_synchronize();
 
 	return 0;
 }
@@ -1575,7 +1576,7 @@ btt_read(struct btt *bttp, unsigned lane, uint64_t lba, void *buf)
 		 * both set.
 		 */
 		arenap->rtt[lane] = entry;
-		__sync_synchronize();
+		util_synchronize();
 
 		/*
 		 * In case this thread was preempted between reading entry and

--- a/src/libpmemobj/container_seglists.c
+++ b/src/libpmemobj/container_seglists.c
@@ -42,6 +42,7 @@
 #include "ctree.h"
 #include "out.h"
 #include "sys_util.h"
+#include "util.h"
 #include "valgrind_internal.h"
 #include "queue.h"
 
@@ -133,7 +134,7 @@ container_seglists_get_rm_block_bestfit(struct block_container *bc,
 		return ENOMEM;
 
 	/* finds the list that serves the smallest applicable size */
-	i = (uint32_t)__builtin_ffsll((long long)v) - 1;
+	i = util_lssb_index64(v);
 
 	struct seglist_entry *e = STAILQ_FIRST(&c->blocks[i]);
 	VALGRIND_ADD_TO_TX(e, sizeof(*e));

--- a/src/libpmemobj/ctree.c
+++ b/src/libpmemobj/ctree.c
@@ -81,10 +81,10 @@ struct ctree {
 static unsigned
 find_crit_bit(uint64_t lhs, uint64_t rhs)
 {
-	/* __builtin_clzll is undefined for 0 */
+	/* util_mssb_index is undefined for 0 */
 	uint64_t val = lhs ^ rhs;
 	ASSERTne(val, 0);
-	return 64 - (unsigned)__builtin_clzll(val) - 1;
+	return util_mssb_index64(val);
 }
 
 /*

--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -138,7 +138,7 @@ static void
 heap_thread_arena_destructor(void *arg)
 {
 	struct arena *a = arg;
-	util_fetch_and_sub(&a->nthreads, 1);
+	util_fetch_and_sub64(&a->nthreads, 1);
 }
 
 /*
@@ -166,7 +166,7 @@ heap_thread_arena_assign(struct heap_rt *heap)
 
 	LOG(4, "assigning %p arena to current thread", least_used);
 
-	util_fetch_and_add(&least_used->nthreads, 1);
+	util_fetch_and_add64(&least_used->nthreads, 1);
 
 	os_mutex_unlock(&heap->arenas_lock);
 

--- a/src/libpmemobj/lane.c
+++ b/src/libpmemobj/lane.c
@@ -453,7 +453,7 @@ lane_hold(PMEMobjpool *pop, struct lane_section **section,
 	struct lane_info *lane = get_lane_info_record(pop);
 	while (unlikely(lane->lane_idx == UINT64_MAX)) {
 		/* initial wrap to next CL */
-		lane->primary = lane->lane_idx = __sync_fetch_and_add(
+		lane->primary = lane->lane_idx = util_fetch_and_add32(
 			&pop->lanes_desc.next_lane_idx, LANE_JUMP);
 	} /* handles wraparound */
 

--- a/src/libpmemobj/pvector.c
+++ b/src/libpmemobj/pvector.c
@@ -140,15 +140,6 @@ pvector_reinit(struct pvector_context *ctx)
 }
 
 /*
- * find_highest_bit -- (internal) searches for the highest set bit
- */
-static unsigned
-find_highest_bit(uint64_t value)
-{
-	return 64 - (unsigned)__builtin_clzll(value) - 1;
-}
-
-/*
  * A small helper structure that defines the position of a value in the array
  * of arrays.
  */
@@ -176,7 +167,7 @@ pvector_get_array_spec(uint64_t idx)
 	 * the bit position from which the algorithm starts.
 	 */
 	uint64_t pos = idx + PVECTOR_INIT_SIZE;
-	unsigned hbit = find_highest_bit(pos);
+	unsigned hbit = util_mssb_index64(pos);
 	s.idx = (size_t)(hbit - PVECTOR_INIT_SHIFT);
 
 	/*

--- a/src/libpmemobj/recycler.c
+++ b/src/libpmemobj/recycler.c
@@ -158,7 +158,7 @@ recycler_calc_score(struct recycler *r, const struct memory_block *m,
 		if (value == 0)
 			continue;
 
-		uint16_t free_in_value = (uint16_t)__builtin_popcountll(value);
+		uint16_t free_in_value = util_popcount64(value);
 		free_space = (uint16_t)(free_space + free_in_value);
 
 		/*
@@ -257,7 +257,8 @@ recycler_inc_unaccounted(struct recycler *r, const struct memory_block *m)
 	struct empty_runs runs;
 	VEC_INIT(&runs);
 
-	uint64_t units = util_fetch_and_add(&r->unaccounted_units, m->size_idx);
+	uint64_t units;
+	units = util_fetch_and_add64(&r->unaccounted_units, m->size_idx);
 
 	if (r->recalc_inprogress || units < (r->nallocs * THRESHOLD_MUL))
 		return runs;
@@ -297,7 +298,7 @@ recycler_inc_unaccounted(struct recycler *r, const struct memory_block *m)
 
 	VEC_CLEAR(&r->recalc);
 
-	util_fetch_and_sub(&r->unaccounted_units, units);
+	util_fetch_and_sub64(&r->unaccounted_units, units);
 	int ret = util_bool_compare_and_swap32(&r->recalc_inprogress, 0, 1);
 	ASSERTeq(ret, 1);
 

--- a/src/libpmemobj/sync.c
+++ b/src/libpmemobj/sync.c
@@ -41,6 +41,7 @@
 #include "util.h"
 #include "sync.h"
 #include "sys_util.h"
+#include "util.h"
 #include "valgrind_internal.h"
 
 #define GET_MUTEX(pop, mutexp)\
@@ -106,7 +107,7 @@ _get_lock(uint64_t pop_runid, volatile uint64_t *runid, void *lock,
 
 		if (init_lock(lock, NULL)) {
 			ERR("error initializing lock");
-			__sync_fetch_and_and(runid, 0);
+			util_fetch_and_and64(runid, 0);
 			return NULL;
 		}
 

--- a/src/librpmem/rpmem.c
+++ b/src/librpmem/rpmem.c
@@ -585,7 +585,7 @@ rpmem_close(RPMEMpool *rpp)
 
 	RPMEM_LOG(INFO, "closing out-of-band connection");
 
-	__sync_fetch_and_or(&rpp->closing, 1);
+	util_fetch_and_or32(&rpp->closing, 1);
 
 	rpmem_fip_close(rpp->fip);
 

--- a/src/librpmem/rpmem_obc.c
+++ b/src/librpmem/rpmem_obc.c
@@ -51,6 +51,7 @@
 #include "rpmem_ssh.h"
 #include "out.h"
 #include "sys_util.h"
+#include "util.h"
 
 /*
  * rpmem_obc -- rpmem out-of-band client connection handle
@@ -139,7 +140,7 @@ rpmem_obc_close_conn(struct rpmem_obc *rpc)
 {
 	rpmem_ssh_close(rpc->ssh);
 
-	(void) __sync_fetch_and_and(&rpc->ssh, 0);
+	(void) util_fetch_and_and64(&rpc->ssh, 0);
 }
 
 /*

--- a/src/test/obj_ctree/obj_ctree.c
+++ b/src/test/obj_ctree/obj_ctree.c
@@ -54,7 +54,7 @@ static int Rcounter_malloc;
 static void *
 __wrap_malloc(size_t size)
 {
-	switch (__sync_fetch_and_add(&Rcounter_malloc, 1)) {
+	switch (util_fetch_and_add32(&Rcounter_malloc, 1)) {
 		default:
 			return malloc(size);
 		case TEST_INSERT + 3: /* accessor malloc */

--- a/src/test/obj_cuckoo/obj_cuckoo.c
+++ b/src/test/obj_cuckoo/obj_cuckoo.c
@@ -49,7 +49,7 @@ static int Rcounter_malloc;
 static void *
 __wrap_malloc(size_t size)
 {
-	switch (__sync_fetch_and_add(&Rcounter_malloc, 1)) {
+	switch (util_fetch_and_add32(&Rcounter_malloc, 1)) {
 		case 1: /* internal out_err malloc */
 		default:
 			return malloc(size);

--- a/src/test/obj_ringbuf/obj_ringbuf.c
+++ b/src/test/obj_ringbuf/obj_ringbuf.c
@@ -114,10 +114,10 @@ consumer(void *arg)
 
 	for (int i = 0; i < thp->nmsg; ++i) {
 		m = ringbuf_dequeue_s(thp->rbuf, sizeof(struct th_msg));
-		long long nmsg_consumed = util_fetch_and_add(
+		long long nmsg_consumed = util_fetch_and_add32(
 			&thp->msg_per_producer_sum[m->th_id], 1);
 
-		util_fetch_and_add(&m->consumed, 1);
+		util_fetch_and_add32(&m->consumed, 1);
 
 		/* check if the ringbuf is FIFO for a single consumer */
 		if (thp->nconsumers == 1) {
@@ -125,7 +125,7 @@ consumer(void *arg)
 			last_msg_id[m->th_id] = m->msg_id;
 		}
 
-		util_fetch_and_add(thp->consumers_msg_sum, m->msg_id);
+		util_fetch_and_add64(thp->consumers_msg_sum, m->msg_id);
 
 		/*
 		 * For multiple consumers, it's guaranteed that each dequeue

--- a/src/test/obj_sync/obj_sync.c
+++ b/src/test/obj_sync/obj_sync.c
@@ -79,12 +79,7 @@ pmemobj_pool_by_ptr(const void *arg)
 static void
 mock_open_pool(PMEMobjpool *pop)
 {
-#ifdef _WIN32
-	__sync_fetch_and_add64(&pop->run_id, 2);
-#else
-	__sync_fetch_and_add(&pop->run_id, 2);
-#endif
-
+	util_fetch_and_add64(&pop->run_id, 2);
 }
 
 /*

--- a/src/test/tools/pmemspoil/spoil.c
+++ b/src/test/tools/pmemspoil/spoil.c
@@ -58,6 +58,7 @@
 #include "output.h"
 #include "btt.h"
 #include "set.h"
+#include "util.h"
 
 #define STR(x)	#x
 
@@ -682,11 +683,11 @@ pmemspoil_process_chunk_type_t(struct pmemspoil *psp,
 	if (util_parse_chunk_types(pfp->value, &types))
 		return -1;
 
-	if (util_count_ones(types) != 1)
+	if (util_popcount64(types) != 1)
 		return -1;
 
 	/* ignore 'le' */
-	*valp = (enum chunk_type)(__builtin_ffsll((long long)types) - 1);
+	*valp = (enum chunk_type)util_lssb_index64(types);
 
 	return 0;
 }

--- a/src/test/unittest/unittest.h
+++ b/src/test/unittest/unittest.h
@@ -118,6 +118,7 @@ extern "C" {
 /* XXX: move OS abstraction layer out of common */
 #include "os.h"
 #include "os_thread.h"
+#include "util.h"
 
 int ut_get_uuid_str(char *);
 #define UT_MAX_ERR_MSG 128
@@ -710,7 +711,7 @@ intptr_t ut_spawnv(int argc, const char **argv, ...);
 	static unsigned RCOUNTER(name);\
 	ret_type __wrap_##name(__VA_ARGS__);\
 	ret_type __wrap_##name(__VA_ARGS__) {\
-		switch (__sync_fetch_and_add(&RCOUNTER(name), 1)) {
+		switch (util_fetch_and_add32(&RCOUNTER(name), 1)) {
 
 #define FUNC_MOCK_END\
 	}}

--- a/src/tools/pmempool/common.h
+++ b/src/tools/pmempool/common.h
@@ -227,12 +227,6 @@ unsigned util_heap_max_zone(size_t size);
 int util_heap_get_bitmap_params(uint64_t block_size, uint64_t *nallocsp,
 		uint64_t *nvalsp, uint64_t *last_valp);
 
-static inline uint32_t
-util_count_ones(uint64_t val)
-{
-	return (uint32_t)__builtin_popcountll(val);
-}
-
 static const struct range ENTIRE_UINT64 = {
 	{ NULL, NULL },	/* range */
 	0,		/* first */

--- a/src/tools/pmempool/info_obj.c
+++ b/src/tools/pmempool/info_obj.c
@@ -47,6 +47,7 @@
 #include "common.h"
 #include "output.h"
 #include "info.h"
+#include "util.h"
 
 #define BITMAP_BUFF_SIZE 1024
 
@@ -162,8 +163,8 @@ get_bitmap_reserved(struct chunk_run *run, uint32_t *reserved)
 
 	uint32_t ret = 0;
 	for (uint64_t i = 0; i < nvals - 1; i++)
-		ret += util_count_ones(run->bitmap[i]);
-	ret += util_count_ones(run->bitmap[nvals - 1] & ~last_val);
+		ret += util_popcount64(run->bitmap[i]);
+	ret += util_popcount64(run->bitmap[nvals - 1] & ~last_val);
 
 	*reserved = ret;
 

--- a/src/tools/rpmemd/rpmemd_fip.c
+++ b/src/tools/rpmemd/rpmemd_fip.c
@@ -904,7 +904,7 @@ static int
 rpmemd_fip_process_stop_gpspm(struct rpmemd_fip *fip)
 {
 	/* this stops all worker threads */
-	__sync_fetch_and_or(&fip->closing, 1);
+	util_fetch_and_or32(&fip->closing, 1);
 	int ret;
 	int lret = 0;
 

--- a/src/windows/include/platform.h
+++ b/src/windows/include/platform.h
@@ -96,60 +96,6 @@ extern "C" {
 #define __builtin_constant_p(cnd) 0
 
 /*
- * atomics
- */
-
-__inline int
-__builtin_clzll(uint64_t val)
-{
-	DWORD lz = 0;
-
-	if (BitScanReverse64(&lz, val))
-		return 63 - (int)lz;
-	else
-		return 64;
-}
-
-__inline int
-__builtin_ffsll(long long val)
-{
-	unsigned long ret;
-	return _BitScanForward64(&ret, val) ? ret + 1 : 0;
-}
-
-#define __builtin_popcountll(val) __popcnt64(val)
-
-__inline uint32_t
-__sync_fetch_and_or(volatile uint32_t *a, uint32_t val)
-{
-	return InterlockedOr((LONG *)a, (LONG)val);
-}
-
-__inline uint64_t
-__sync_fetch_and_and(volatile uint64_t *a, uint64_t val)
-{
-	return InterlockedAnd64((LONG64 *)a, (LONG64)val);
-}
-
-__inline uint32_t
-__sync_fetch_and_add(volatile uint32_t *a, uint32_t val)
-{
-	return InterlockedExchangeAdd(a, val);
-}
-
-__inline uint64_t
-__sync_fetch_and_add64(volatile uint64_t *a, uint64_t val)
-{
-	return InterlockedExchangeAdd64((LONG64 *)a, (LONG64)val);
-}
-
-__inline void
-__sync_synchronize()
-{
-	MemoryBarrier();
-}
-
-/*
  * missing definitions
  */
 


### PR DESCRIPTION
The usage of __sync* builtin functions was very inconsistent.
This patch brings these usages into sync thorough most of
the code, with the exceptions of jemalloc and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2289)
<!-- Reviewable:end -->
