### PR TITLE
doc: Doc changes for FreeBSD

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -6,10 +6,11 @@ This directory contains source for the man pages for the NVM Library.
 If you're looking for documentation to get you started using NVML,
 start here: http://pmem.io/nvml and follow the links to examples and
 man pages.  Developers new to NVML are probably looking for libpmemobj.
-To generate web-based documentation or Linux man pages, you need to have groff,
-doxygen, pandoc and pp installed. PP generic preprocessor can be found at
-https://github.com/CDSoft/pp. It is used in doc Makefile to cut out Windows-specific
-parts from Linux manuals and to generate OS-specific variants of web-based documentation.
+
+To generate web-based documentation or Linux/FreeBSD man pages, you need to
+have groff, doxygen and pandoc installed. m4 macros are used in the document
+sources to generate OS-specific variants of man pages and web-based documentation.
+The macros are defined in macros.man.
 
 All files in the *generated* directory are automatically generated and updated by the
 nvml-bot. **DO NOT MODIFY THE FILES IN THAT DIRECTORY**. All changes to the

--- a/doc/libpmem.3.md
+++ b/doc/libpmem.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBPMEM!3
+title: _MP(LIBPMEM, 3)
 header: NVM Library
 date: pmem API version 1.0
 ...
@@ -60,13 +60,10 @@ date: pmem API version 1.0
 #include <libpmem.h>
 cc ... -lpmem
 ```
-
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Most commonly used functions: #####
 
@@ -74,16 +71,8 @@ otherwise they are expanded to UNICODE API with postfix *W*.
 int pmem_is_pmem(const void *addr, size_t len);
 void pmem_persist(const void *addr, size_t len);
 int pmem_msync(const void *addr, size_t len);
-!ifdef{WIN32}
-{
-void *pmem_map_fileU(const char *path, size_t len, int flags,
-	mode_t mode, size_t *mapped_lenp, int *is_pmemp);
-void *pmem_map_fileW(const wchar_t *path, size_t len, int flags,
-	mode_t mode, size_t *mapped_lenp, int *is_pmemp);
-}{
-void *pmem_map_file(const char *path, size_t len, int flags,
-	mode_t mode, size_t *mapped_lenp, int *is_pmemp);
-}
+_UWFUNCR1(void, *pmem_map_file, *path, _q_size_t len, int flags,
+	mode_t mode, size_t *mapped_lenp, int *is_pmemp_e_)
 int pmem_unmap(void *addr, size_t len);
 ```
 
@@ -109,33 +98,16 @@ void *pmem_memset_nodrain(void *pmemdest, int c, size_t len);
 ##### Library API versioning: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmem_check_versionU(
+_UWFUNC(pmem_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmem_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmem_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmem_errormsgU(void);
-const wchar_t *pmem_errormsgW(void);
-}{
-const char *pmem_errormsg(void);
-}
+_UWFUNC(pmem_errormsg, void)
 ```
-
 
 # DESCRIPTION #
 
@@ -266,23 +238,15 @@ returns true use **pmem_persist**() to force the changes to be stored durably
 in persistent memory.
 
 ```c
-!ifdef{WIN32}
-{
-void *pmem_map_fileU(const char *path, size_t len, int flags,
-	mode_t mode, size_t *mapped_lenp, int *is_pmemp);
-void *pmem_map_fileW(const wchar_t *path, size_t len, int flags, mode_t mode,
-		size_t *mapped_lenp, int *is_pmemp);
-}{
-void *pmem_map_file(const char *path, size_t len, int flags,
-	mode_t mode, size_t *mapped_lenp, int *is_pmemp);
-}
+_UWFUNCR1(void, *pmem_map_file, *path, _q_size_t len, int flags,
+	mode_t mode, size_t *mapped_lenp, int *is_pmemp_e_)
 ```
 
-Given a *path*, !pmem_map_file function creates a new read/write
+Given a *path*, _UW(pmem_map_file) function creates a new read/write
 mapping for the named file. It will map the file using **mmap**(2), but
 it also takes extra steps to make large page mappings more likely.
 
-On success, !pmem_map_file returns a pointer to mapped area. If
+On success, _UW(pmem_map_file) returns a pointer to mapped area. If
 *mapped_lenp* is not NULL, the length of the mapping is also stored at
 the address it points to. The *is_pmemp* argument, if non-NULL, points
 to a flag that **pmem_is_pmem**() sets to say if the mapped file is
@@ -302,7 +266,7 @@ following file creation flags:
 + **PMEM_FILE_EXCL** - Same meaning as **O_EXCL** on **open**(2) -
   Ensure that this call creates the file. If this flag is specified in
   conjunction with **PMEM_FILE_CREATE**, and pathname already exists,
-  then !pmem_map_file will fail.
+  then _UW(pmem_map_file) will fail.
 
 + **PMEM_FILE_TMPFILE** - Same meaning as **O_TMPFILE** on **open**(2).
   Create a mapping for an unnamed temporary file. **PMEM_FILE_CREATE**
@@ -314,7 +278,7 @@ following file creation flags:
   in conjunction with **PMEM_FILE_CREATE** or **PMEM_FILE_TMPFILE**,
   otherwise ignored.
 
-If creation flags are not supplied, then !pmem_map_file creates a
+If creation flags are not supplied, then _UW(pmem_map_file) creates a
 mapping for an existing file. In such case, *len* should be zero. The
 entire file is mapped to memory; its length is used as the length of the
 mapping and returned via *mapped_lenp*.
@@ -324,7 +288,7 @@ The path of a file can point to a Device DAX and in such case only
 effectively do nothing. For Device DAX mappings, the *len* argument must be,
 regardless of the flags, equal to either 0 or the exact size of the device.
 
-To delete mappings created with !pmem_map_file, use **pmem_unmap**().
+To delete mappings created with _UW(pmem_map_file), use **pmem_unmap**().
 
 ```c
 int pmem_unmap(void *addr, size_t len);
@@ -472,29 +436,19 @@ This section describes how the library API is versioned, allowing
 applications to work with an evolving API.
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmem_check_versionU(
+_UWFUNC(pmem_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmem_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmem_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !pmem_check_version function is used to see if the installed
+The _UW(pmem_check_version) function is used to see if the installed
 **libpmem** supports the version of the library API required by an
 application. The easiest way to do this is for the application to supply
 the compile-time version information, supplied by defines in
 **\<libpmem.h\>**, like this:
 
 ```c
-reason = pmem_check_version!U{}(PMEM_MAJOR_VERSION,
+reason = _U(pmem_check_version)(PMEM_MAJOR_VERSION,
                             PMEM_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -513,10 +467,10 @@ in version 1.0 of the library. Interfaces added after version 1.0 will
 contain the text *introduced in version x.y* in the section of this
 manual describing the feature.
 
-When the version check performed by !pmem_check_version is
+When the version check performed by _UW(pmem_check_version) is
 successful, the return value is NULL. Otherwise the return value is a
 static string describing the reason for failing the version check. The
-string returned by !pmem_check_version must not be modified or
+string returned by _UW(pmem_check_version) must not be modified or
 freed.
 
 
@@ -531,16 +485,10 @@ call to **libpmem** function, an application may retrieve an error
 message describing the reason of failure using the following function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmem_errormsgU(void);
-const wchar_t *pmem_errormsgW(void);
-}{
-const char *pmem_errormsg(void);
-}
+_UWFUNC(pmem_errormsg, void)
 ```
 
-The !pmem_errormsg function returns a pointer to a static buffer
+The _UW(pmem_errormsg) function returns a pointer to a static buffer
 containing the last error message logged for current thread. The error
 message may include description of the corresponding error code (if
 *errno* was set), as returned by **strerror**(3). The error message buffer
@@ -553,11 +501,14 @@ message string, but it may be modified by subsequent calls to other
 library functions.
 
 A second version of **libpmem**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
-run-time assertions and trace points. The typical way to
+the libraries under
+_WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**),
+contains run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to
+_WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**),
+depending on where the debug
 libraries are installed on the system. The trace points
 in the debug version of the library are enabled using the environment
 variable **PMEM_LOG_LEVEL**, which can be set to the following values:
@@ -567,7 +518,7 @@ variable **PMEM_LOG_LEVEL**, which can be set to the following values:
 
 + **1** - Additional details on any errors detected are logged (in addition
   to returning the *errno*-based errors as usual). The same information
-  may be retrieved using !pmem_errormsg.
+  may be retrieved using _UW(pmem_errormsg).
 
 + **2** - A trace of basic operations is logged.
 
@@ -660,7 +611,7 @@ This variable is intended for use during library testing.
 + **PMEM_MMAP_HINT**=*val*
 
 This environment variable allows overriding
-the hint address used by !pmem_map_file. If set, it also disables
+the hint address used by _UW(pmem_map_file). If set, it also disables
 mapping address randomization. This variable is intended for use during
 library testing and debugging. Setting it to some fairly large value
 (i.e. 0x10000000000) will very likely result in mapping the file at the
@@ -714,9 +665,9 @@ main(int argc, char *argv[])
 
 	/* create a pmem file and memory map it */
 
-	if ((pmemaddr = pmem_map_file!U{}(PATH, PMEM_LEN, PMEM_FILE_CREATE,
+	if ((pmemaddr = _U(pmem_map_file)(PATH, PMEM_LEN, PMEM_FILE_CREATE,
 			0666, &mapped_len, &is_pmem)) == NULL) {
-		perror("pmem_map_file!U");
+		perror("_U(pmem_map_file)");
 		exit(1);
 	}
 

--- a/doc/libpmemblk.3.md
+++ b/doc/libpmemblk.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBPMEMBLK!3
+title: _MP(LIBPMEMBLK, 3)
 header: NVM Library
 date: pmemblk API version 1.0
 ...
@@ -59,30 +59,17 @@ date: pmemblk API version 1.0
 #include <libpmemblk.h>
 cc ... -lpmemblk -lpmem
 ```
-
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Most commonly used functions: #####
 
 ```c
-!ifdef{WIN32}
-{
-PMEMblkpool *pmemblk_createU(const char *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-PMEMblkpool *pmemblk_createW(const wchar_t *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-PMEMblkpool *pmemblk_openU(const char *path, size_t bsize);
-PMEMblkpool *pmemblk_openW(const wchar_t *path, size_t bsize);
-}{
-PMEMblkpool *pmemblk_create(const char *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-PMEMblkpool *pmemblk_open(const char *path, size_t bsize);
-}
+_UWFUNCR1(PMEMblkpool, *pmemblk_create, *path, _q_size_t bsize,
+		size_t poolsize, mode_t mode_e_)
+_UWFUNCR1(PMEMblkpool, *pmemblk_open, *path, size_t bsize)
 void pmemblk_close(PMEMblkpool *pbp);
 size_t pmemblk_bsize(PMEMblkpool *pbp);
 size_t pmemblk_nblock(PMEMblkpool *pbp);
@@ -95,19 +82,9 @@ int pmemblk_set_error(PMEMblkpool *pbp, long long blockno);
 ##### Library API versioning: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemblk_check_versionU(
+_UWFUNC(pmemblk_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemblk_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemblk_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
 ##### Managing library behavior: #####
@@ -118,25 +95,13 @@ void pmemblk_set_funcs(
 	void (*free_func)(void *ptr),
 	void *(*realloc_func)(void *ptr, size_t size),
 	char *(*strdup_func)(const char *s));
-!ifdef{WIN32}
-{
-int pmemblk_checkU(const char *path, size_t bsize);
-int pmemblk_checkW(const wchar_t *path, size_t bsize);
-}{
-int pmemblk_check(const char *path, size_t bsize);
-}
+_UWFUNCR1(int, pmemblk_check, *path, size_t bsize)
 ```
 
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemblk_errormsgU(void);
-const wchar_t *pmemblk_errormsgW(void);
-}{
-const char *pmemblk_errormsg(void);
-}
+_UWFUNC(pmemblk_errormsg, void)
 ```
 
 
@@ -177,7 +142,7 @@ below.
 # MOST COMMONLY USED FUNCTIONS #
 
 To use the atomic block arrays supplied by **libpmemblk**, a *memory pool*
-is first created. This is done with the !pmemblk_create function described
+is first created. This is done with the _UW(pmemblk_create) function described
 in this section. The other functions described in this section then operate
 on the resulting block memory pool. Once created, the memory pool is represented
 by an opaque handle, of type *PMEMblkpool\**, which is passed to most of the other
@@ -189,42 +154,28 @@ There is no need for applications to flush changes directly when using the
 block memory API provided by **libpmemblk**.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMblkpool *pmemblk_openU(const char *path, size_t bsize);
-PMEMblkpool *pmemblk_openW(const wchar_t *path, size_t bsize);
-}{
-PMEMblkpool *pmemblk_open(const char *path, size_t bsize);
-}
+_UWFUNCR1(PMEMblkpool, *pmemblk_open, *path, size_t bsize)
 ```
 
-The !pmemblk_open function opens an existing block memory pool, returning
+The _UW(pmemblk_open) function opens an existing block memory pool, returning
 a memory pool handle used with most of the functions in this section. *path*
 must be an existing file containing a block memory pool as created by
-!pmemblk_create. The application must have permission to open the file
+_UW(pmemblk_create). The application must have permission to open the file
 and memory map it with read/write permissions. If the *bsize* provided is
-non-zero, !pmemblk_open will verify the given block size matches the block
-size used when the pool was created. Otherwise, !pmemblk_open will open
+non-zero, _UW(pmemblk_open) will verify the given block size matches the block
+size used when the pool was created. Otherwise, _UW(pmemblk_open) will open
 the pool without verification of the block size. The *bsize* can be determined
 using the **pmemblk_bsize**() function. If an error prevents the pool from being
-opened, !pmemblk_open returns NULL and sets *errno* appropriately.
+opened, _UW(pmemblk_open) returns NULL and sets *errno* appropriately.
 A block size mismatch with the *bsize* argument passed in results in *errno*
 being set to **EINVAL**.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMblkpool *pmemblk_createU(const char *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-PMEMblkpool *pmemblk_createW(const wchar_t *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-}{
-PMEMblkpool *pmemblk_create(const char *path, size_t bsize,
-		size_t poolsize, mode_t mode);
-}
+_UWFUNCR1(PMEMblkpool, *pmemblk_create, *path, _q_size_t bsize,
+		size_t poolsize, mode_t mode_e_)
 ```
 
-The !pmemblk_create function creates a block memory pool with the given total
+The _UW(pmemblk_create) function creates a block memory pool with the given total
 *poolsize* divided up into as many elements of size *bsize* as will fit in the pool.
 Since the transactional nature of a block memory pool requires some space overhead
 in the memory pool, the resulting number of available blocks is less than
@@ -236,8 +187,8 @@ to be created. *mode* specifies the permissions to use when creating the file
 as described by **creat**(2). The memory pool file is fully allocated to the size
 *poolsize* using **posix_fallocate**(3). The caller may choose to take
 responsibility for creating the memory pool file by creating it before calling
-!pmemblk_create and then specifying *poolsize* as zero. In this case
-!pmemblk_create will take the pool size from the size of the existing file
+_UW(pmemblk_create) and then specifying *poolsize* as zero. In this case
+_UW(pmemblk_create) will take the pool size from the size of the existing file
 and will verify that the file appears to be empty by searching for any non-zero
 data in the pool header at the beginning of the file. The net pool size of a
 pool file is equal to the file size. The minimum net pool size allowed by the
@@ -252,23 +203,23 @@ device. The **libpmemblk** allows building persistent memory resident array span
 multiple memory devices by creation of persistent memory pools consisting of multiple
 files, where each part of such a *pool set* may be stored on different pmem-aware filesystem.
 
-Creation of all the parts of the pool set can be done with the !pmemblk_create
+Creation of all the parts of the pool set can be done with the _UW(pmemblk_create)
 function. However, the recommended method for creating pool sets is to do it by
 using the **pmempool**(1) utility.
 
 When creating the pool set consisting of multiple files, the *path* argument passed
-to !pmemblk_create must point to the special *set* file that defines the pool
+to _UW(pmemblk_create) must point to the special *set* file that defines the pool
 layout and the location of all the parts of the pool set. The *poolsize* argument
 must be 0. The meaning of *layout* and *mode* arguments doesn't change, except that
 the same *mode* is used for creation of all the parts of the pool set. If the error
-prevents any of the pool set files from being created, !pmemblk_create returns
+prevents any of the pool set files from being created, _UW(pmemblk_create) returns
 NULL and sets *errno* appropriately.
 
 When opening the pool set consisting of multiple files, the *path* argument passed
-to !pmemblk_open must not point to the pmemblk memory pool file, but to the same
+to _UW(pmemblk_open) must not point to the pmemblk memory pool file, but to the same
 *set* file that was used for the pool set creation. If an error prevents any of the
 pool set files from being opened, or if the actual size of any file does not match
-the corresponding part size defined in *set* file !pmemblk_open returns NULL
+the corresponding part size defined in *set* file _UW(pmemblk_open) returns NULL
 and sets *errno* appropriately.
 
 The set file is a plain text file, which must start with the line containing
@@ -330,21 +281,21 @@ void pmemblk_close(PMEMblkpool *pbp);
 ```
 
 The **pmemblk_close**() function closes the memory pool indicated by *pbp* and deletes the memory pool handle.
-The block memory pool itself lives on in the file that contains it and may be re-opened at a later time using !pmemblk_open as described above.
+The block memory pool itself lives on in the file that contains it and may be re-opened at a later time using _UW(pmemblk_open) as described above.
 
 ```c
 size_t pmemblk_bsize(PMEMblkpool *pbp);
 ```
 
-The **pmemblk_bsize**() function returns the block size of the specified block memory pool. It's the value which was passed as *bsize* to !pmemblk_create.
-*pbp* must be a block memory pool handle as returned by !pmemblk_open or !pmemblk_create.
+The **pmemblk_bsize**() function returns the block size of the specified block memory pool. It's the value which was passed as *bsize* to _UW(pmemblk_create).
+*pbp* must be a block memory pool handle as returned by _UW(pmemblk_open) or _UW(pmemblk_create).
 
 ```c
 size_t pmemblk_nblock(PMEMblkpool *pbp);
 ```
 
 The **pmemblk_nblock**() function returns the usable space in the block memory pool, expressed as the number of blocks available.
-*pbp* must be a block memory pool handle as returned by !pmemblk_open or !pmemblk_create.
+*pbp* must be a block memory pool handle as returned by _UW(pmemblk_open) or _UW(pmemblk_create).
 
 ```c
 int pmemblk_read(PMEMblkpool *pbp, void *buf, long long blockno);
@@ -393,27 +344,17 @@ resources associated with that thread might not be cleaned up properly.
 This section describes how the library API is versioned, allowing applications to work with an evolving API.
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemblk_check_versionU(
+_UWFUNC(pmemblk_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemblk_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemblk_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !pmemblk_check_version function is used to see if the installed **libpmemblk**
+The _UW(pmemblk_check_version) function is used to see if the installed **libpmemblk**
 supports the version of the library API required by an application. The easiest way
 to do this is for the application to supply the compile-time version information, supplied by defines in **\<ibpmemblk.h\>**, like this:
 
 ```c
-reason = pmemblk_check_version!U{}(PMEMBLK_MAJOR_VERSION,
+reason = _U(pmemblk_check_version)(PMEMBLK_MAJOR_VERSION,
                                PMEMBLK_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -429,9 +370,9 @@ are documented in this man page as follows: unless otherwise specified, all
 interfaces described here are available in version 1.0 of the library.
 Interfaces added after version 1.0 will contain the text *introduced in version x.y* in the section of this manual describing the feature.
 
-When the version check performed by !pmemblk_check_version is successful,
+When the version check performed by _UW(pmemblk_check_version) is successful,
 the return value is NULL. Otherwise the return value is a static string describing
-the reason for failing the version check. The string returned by !pmemblk_check_version must not be modified or freed.
+the reason for failing the version check. The string returned by _UW(pmemblk_check_version) must not be modified or freed.
 
 
 # MANAGING LIBRARY BEHAVIOR #
@@ -451,20 +392,14 @@ Passing in NULL for any of the handlers will cause the **libpmemblk** default fu
 The library does not make heavy use of the system malloc functions, but it does allocate approximately 4-8 kilobytes for each memory pool in use.
 
 ```c
-!ifdef{WIN32}
-{
-int pmemblk_checkU(const char *path, size_t bsize);
-int pmemblk_checkW(const wchar_t *path, size_t bsize);
-}{
-int pmemblk_check(const char *path, size_t bsize);
-}
+_UWFUNCR1(int, pmemblk_check, *path, size_t bsize)
 ```
 
-The !pmemblk_check function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
-inconsistencies found will cause !pmemblk_check to return 0, in which case the use of the file with **libpmemblk** will result in undefined behavior. The
+The _UW(pmemblk_check) function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
+inconsistencies found will cause _UW(pmemblk_check) to return 0, in which case the use of the file with **libpmemblk** will result in undefined behavior. The
 debug version of **libpmemblk** will provide additional details on inconsistencies when **PMEMBLK_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
-ERROR HANDLING** section below. When *bsize* is non-zero !pmemblk_check will compare it to the block size of the pool and return 0 when they don't
-match. !pmemblk_check will return -1 and set *errno* if it cannot perform the consistency check due to other errors. !pmemblk_check opens the given
+ERROR HANDLING** section below. When *bsize* is non-zero _UW(pmemblk_check) will compare it to the block size of the pool and return 0 when they don't
+match. _UW(pmemblk_check) will return -1 and set *errno* if it cannot perform the consistency check due to other errors. _UW(pmemblk_check) opens the given
 *path* read-only so it never makes any changes to the file. This function is not supported on Device DAX.
 
 
@@ -476,27 +411,21 @@ assertions. If an error is detected during the call to **libpmemblk** function, 
 using the following function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemblk_errormsgU(void);
-const wchar_t *pmemblk_errormsgW(void);
-}{
-const char *pmemblk_errormsg(void);
-}
+_UWFUNC(pmemblk_errormsg, void)
 ```
 
-The !pmemblk_errormsg function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
+The _UW(pmemblk_errormsg) function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
 include description of the corresponding error code (if *errno* was set), as returned by **strerror**(3). The error message buffer is thread-local; errors
 encountered in one thread do not affect its value in other threads. The buffer is never cleared by any library function; its content is significant only when
 the return value of the immediately preceding call to **libpmemblk** function indicated an error, or if *errno* was set. The application must not modify or
 free the error message string, but it may be modified by subsequent calls to other library functions.
 
 A second version of **libpmemblk**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
+the libraries under _WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**), contains
 run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to _WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**), depending on where the debug
 libraries are installed on the system.
 The trace points in the debug version of the library are enabled using the environment
 variable **PMEMBLK_LOG_LEVEL**, which can be set to the following values:
@@ -504,7 +433,7 @@ variable **PMEMBLK_LOG_LEVEL**, which can be set to the following values:
 + **0** - This is the default level when **PMEMBLK_LOG_LEVEL** is not set. No log messages are emitted at this level.
 
 + **1** - Additional details on any errors detected are logged (in addition to returning the *errno*-based errors as usual). The same information may be
-retrieved using !pmemblk_errormsg.
+retrieved using _UW(pmemblk_errormsg).
 
 + **2** - A trace of basic operations is logged.
 
@@ -548,10 +477,10 @@ main(int argc, char *argv[])
 	char buf[ELEMENT_SIZE];
 
 	/* create the pmemblk pool or open it if it already exists */
-	pbp = pmemblk_create!U{}(path, ELEMENT_SIZE, POOL_SIZE, 0666);
+	pbp = _U(pmemblk_create)(path, ELEMENT_SIZE, POOL_SIZE, 0666);
 
 	if (pbp == NULL)
-		pbp = pmemblk_open!U{}(path, ELEMENT_SIZE);
+		pbp = _U(pmemblk_open)(path, ELEMENT_SIZE);
 
 	if (pbp == NULL) {
 		perror(path);

--- a/doc/libpmemlog.3.md
+++ b/doc/libpmemlog.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBPMEMLOG!3
+title: _MP(LIBPMEMLOG, 3)
 header: NVM Library
 date: pmemlog API version 1.0
 ...
@@ -60,26 +60,16 @@ date: pmemlog API version 1.0
 cc ... -lpmemlog -lpmem
 ```
 
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Most commonly used functions: #####
 
 ```c
-!ifdef{WIN32}
-{
-PMEMlogpool *pmemlog_openU(const char *path);
-PMEMlogpool *pmemlog_openW(const wchar_t *path);
-PMEMlogpool *pmemlog_createU(const char *path, size_t poolsize, mode_t mode);
-PMEMlogpool *pmemlog_createW(const wchar_t *path, size_t poolsize, mode_t mode);
-}{
-PMEMlogpool *pmemlog_open(const char *path);
-PMEMlogpool *pmemlog_create(const char *path, size_t poolsize, mode_t mode);
-}
+_UWFUNCR(PMEMlogpool, *pmemlog_open, *path)
+_UWFUNCR1(PMEMlogpool, *pmemlog_create, *path, _q_size_t poolsize, mode_t mode_e_)
 void pmemlog_close(PMEMlogpool *plp);
 size_t pmemlog_nbyte(PMEMlogpool *plp);
 intpmemlog_append(PMEMlogpool *plp, const void *buf, size_t count);
@@ -94,19 +84,9 @@ void pmemlog_walk(PMEMlogpool *plp, size_t chunksize,
 ##### Library API versioning: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemlog_check_versionU(
+_UWFUNC(pmemlog_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemlog_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemlog_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
 ##### Managing library behavior: #####
@@ -117,25 +97,13 @@ void pmemlog_set_funcs(
 	void (*free_func)(void *ptr),
 	void *(*realloc_func)(void *ptr, size_t size),
 	char *(*strdup_func)(const char *s));
-!ifdef{WIN32}
-{
-	int pmemlog_checkU(const char *path);
-	int pmemlog_checkW(const wchar_t *path);
-}{
-	int pmemlog_check(const char *path);
-}
+_UWFUNCR(int, pmemlog_check, *path)
 ```
 
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemlog_errormsgU(void);
-const wchar_t *pmemlog_errormsgW(void);
-}{
-const char *pmemlog_errormsg(void);
-}
+_UWFUNC(pmemlog_errormsg, void)
 ```
 
 
@@ -166,7 +134,7 @@ information, when enabled, as described under **DEBUGGING AND ERROR HANDLING** b
 
 # MOST COMMONLY USED FUNCTIONS #
 
-To use the pmem-resident log file provided by **libpmemlog**, a *memory pool* is first created. This is done with the !pmemlog_create function described
+To use the pmem-resident log file provided by **libpmemlog**, a *memory pool* is first created. This is done with the _UW(pmemlog_create) function described
 in this section. The other functions described in this section then operate on the resulting log memory pool.
 
 Once created, the memory pool is represented by an opaque handle, of type *PMEMlogpool\**, which is passed to most of the other functions in this section.
@@ -175,35 +143,23 @@ be persistent memory or a regular file (see the **pmem_is_pmem**() function in *
 changes directly when using the log memory API provided by **libpmemlog**.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMlogpool *pmemlog_openU(const char *path);
-PMEMlogpool *pmemlog_openW(const wchar_t *path);
-}{
-PMEMlogpool *pmemlog_open(const char *path);
-}
+_UWFUNCR(PMEMlogpool, *pmemlog_open, *path)
 ```
 
-The !pmemlog_open function opens an existing log memory pool, returning a memory pool handle used with most of the functions in this section. *path* must
-be an existing file containing a log memory pool as created by !pmemlog_create. The application must have permission to open the file and memory map it
-with read/write permissions. If an error prevents the pool from being opened, !pmemlog_open returns NULL and sets *errno* appropriately.
+The _UW(pmemlog_open) function opens an existing log memory pool, returning a memory pool handle used with most of the functions in this section. *path* must
+be an existing file containing a log memory pool as created by _UW(pmemlog_create). The application must have permission to open the file and memory map it
+with read/write permissions. If an error prevents the pool from being opened, _UW(pmemlog_open) returns NULL and sets *errno* appropriately.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMlogpool *pmemlog_createU(const char *path, size_t poolsize, mode_t mode);
-PMEMlogpool *pmemlog_createW(const wchar_t *path, size_t poolsize, mode_t mode);
-}{
-PMEMlogpool *pmemlog_create(const char *path, size_t poolsize, mode_t mode);
-}
+_UWFUNCR1(PMEMlogpool, *pmemlog_create, *path, _q_size_t poolsize, mode_t mode_e_)
 ```
 
-The !pmemlog_create function creates a log memory pool with the given total *poolsize*. Since the transactional nature of a log memory pool requires some
+The _UW(pmemlog_create) function creates a log memory pool with the given total *poolsize*. Since the transactional nature of a log memory pool requires some
 space overhead in the memory pool, the resulting available log size is less than *poolsize*, and is made available to the caller via the **pmemlog_nbyte**()
 function described below. *path* specifies the name of the memory pool file to be created. *mode* specifies the permissions to use when creating the file as
 described by **creat**(2). The memory pool file is fully allocated to the size *poolsize* using **posix_fallocate**(3). The caller may choose to take
-responsibility for creating the memory pool file by creating it before calling !pmemlog_create and then specifying *poolsize* as zero. In this case
-!pmemlog_create will take the pool size from the size of the existing file and will verify that the file appears to be empty by searching for any non-zero
+responsibility for creating the memory pool file by creating it before calling _UW(pmemlog_create) and then specifying *poolsize* as zero. In this case
+_UW(pmemlog_create) will take the pool size from the size of the existing file and will verify that the file appears to be empty by searching for any non-zero
 data in the pool header at the beginning of the file. The net pool size of a pool file is equal to the file size. The minimum net pool size allowed by the library for a log pool is defined in **\<libpmemlog.h\>** as
 **PMEMLOG_MIN_POOL**.
 
@@ -212,17 +168,17 @@ maximum size of the pmemlog memory pool could be limited by the capacity of a si
 resident log spanning multiple memory devices by creation of persistent memory pools consisting of multiple files, where each part of such a *pool set* may be
 stored on different pmem-aware filesystem.
 
-Creation of all the parts of the pool set can be done with the !pmemlog_create function. However, the recommended method for creating pool sets is to do
+Creation of all the parts of the pool set can be done with the _UW(pmemlog_create) function. However, the recommended method for creating pool sets is to do
 it by using the **pmempool**(1) utility.
 
-When creating the pool set consisting of multiple files, the *path* argument passed to !pmemlog_create must point to the special *set* file that defines
+When creating the pool set consisting of multiple files, the *path* argument passed to _UW(pmemlog_create) must point to the special *set* file that defines
 the pool layout and the location of all the parts of the pool set. The *poolsize* argument must be 0. The meaning of *layout* and *mode* arguments doesn't
 change, except that the same *mode* is used for creation of all the parts of the pool set. If the error prevents any of the pool set files from being created,
-!pmemlog_create returns NULL and sets *errno* appropriately.
+_UW(pmemlog_create) returns NULL and sets *errno* appropriately.
 
-When opening the pool set consisting of multiple files, the *path* argument passed to !pmemlog_open must not point to the pmemlog memory pool file, but to
+When opening the pool set consisting of multiple files, the *path* argument passed to _UW(pmemlog_open) must not point to the pmemlog memory pool file, but to
 the same *set* file that was used for the pool set creation. If an error prevents any of the pool set files from being opened, or if the actual size of any
-file does not match the corresponding part size defined in *set* file !pmemlog_open returns NULL and sets *errno* appropriately.
+file does not match the corresponding part size defined in *set* file _UW(pmemlog_open) returns NULL and sets *errno* appropriately.
 
 The set file is a plain text file, which must start with the line containing a *PMEMPOOLSET* string, followed by the specification of all the pool parts in the
 next lines. For each part, the file size and the absolute path must be provided.
@@ -280,7 +236,7 @@ void pmemlog_close(PMEMlogpool *plp);
 ```
 
 The **pmemlog_close**() function closes the memory pool indicated by *plp* and deletes the memory pool handle. The log memory pool itself lives on in the file
-that contains it and may be re-opened at a later time using !pmemlog_open as described above.
+that contains it and may be re-opened at a later time using _UW(pmemlog_open) as described above.
 
 ```c
 size_t pmemlog_nbyte(PMEMlogpool *plp);
@@ -351,26 +307,16 @@ resources associated with that thread might not be cleaned up properly.
 This section describes how the library API is versioned, allowing applications to work with an evolving API.
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemlog_check_versionU(
+_UWFUNC(pmemlog_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemlog_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemlog_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !pmemlog_check_version function is used to see if the installed **libpmemlog** supports the version of the library API required by an application. The
+The _UW(pmemlog_check_version) function is used to see if the installed **libpmemlog** supports the version of the library API required by an application. The
 easiest way to do this is for the application to supply the compile-time version information, supplied by defines in **\<libpmemlog.h\>**, like this:
 
 ```c
-reason = pmemlog_check_version!U{}(PMEMLOG_MAJOR_VERSION,
+reason = _U(pmemlog_check_version)(PMEMLOG_MAJOR_VERSION,
                                PMEMLOG_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -384,8 +330,8 @@ An application can also check specifically for the existence of an interface by 
 are documented in this man page as follows: unless otherwise specified, all interfaces described here are available in version 1.0 of the library. Interfaces
 added after version 1.0 will contain the text *introduced in version x.y* in the section of this manual describing the feature.
 
-When the version check performed by !pmemlog_check_version is successful, the return value is NULL. Otherwise the return value is a static string
-describing the reason for failing the version check. The string returned by !pmemlog_check_version must not be modified or freed.
+When the version check performed by _UW(pmemlog_check_version) is successful, the return value is NULL. Otherwise the return value is a static string
+describing the reason for failing the version check. The string returned by _UW(pmemlog_check_version) must not be modified or freed.
 
 
 # MANAGING LIBRARY BEHAVIOR #
@@ -405,20 +351,14 @@ the handlers will cause the **libpmemlog** default function to be used. The libr
 allocate approximately 4-8 kilobytes for each memory pool in use.
 
 ```c
-!ifdef{WIN32}
-{
-	int pmemlog_checkU(const char *path);
-	int pmemlog_checkW(const wchar_t *path);
-}{
-	int pmemlog_check(const char *path);
-}
+_UWFUNCR(int, pmemlog_check, *path)
 ```
 
-The !pmemlog_check function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
-inconsistencies found will cause !pmemlog_check to return 0, in which case the use of the file with **libpmemlog** will result in undefined behavior. The
+The _UW(pmemlog_check) function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
+inconsistencies found will cause _UW(pmemlog_check) to return 0, in which case the use of the file with **libpmemlog** will result in undefined behavior. The
 debug version of **libpmemlog** will provide additional details on inconsistencies when **PMEMLOG_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
-ERROR HANDLING** section below. !pmemlog_check will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
-!pmemlog_check opens the given *path* read-only so it never makes any changes to the file. This function is not supported on Device DAX.
+ERROR HANDLING** section below. _UW(pmemlog_check) will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
+_UW(pmemlog_check) opens the given *path* read-only so it never makes any changes to the file. This function is not supported on Device DAX.
 
 
 # DEBUGGING AND ERROR HANDLING #
@@ -429,27 +369,21 @@ assertions. If an error is detected during the call to **libpmemlog** function, 
 using the following function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemlog_errormsgU(void);
-const wchar_t *pmemlog_errormsgW(void);
-}{
-const char *pmemlog_errormsg(void);
-}
+_UWFUNC(pmemlog_errormsg, void)
 ```
 
-The !pmemlog_errormsg function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
+The _UW(pmemlog_errormsg) function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
 include description of the corresponding error code (if *errno* was set), as returned by **strerror**(3). The error message buffer is thread-local; errors
 encountered in one thread do not affect its value in other threads. The buffer is never cleared by any library function; its content is significant only when
 the return value of the immediately preceding call to **libpmemlog** function indicated an error, or if *errno* was set. The application must not modify or
 free the error message string, but it may be modified by subsequent calls to other library functions.
 
 A second version of **libpmemlog**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
+the libraries under _WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**), contains
 run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to _WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**), depending on where the debug
 libraries are installed on the system.
 The trace points in the debug version of the library are enabled using the environment
 variable **PMEMLOG_LOG_LEVEL**, which can be set to the following values:
@@ -457,7 +391,7 @@ variable **PMEMLOG_LOG_LEVEL**, which can be set to the following values:
 + **0** - This is the default level when **PMEMLOG_LOG_LEVEL** is not set. No log messages are emitted at this level.
 
 + **1** - Additional details on any errors detected are logged (in addition to returning the *errno*-based errors as usual). The same information may be
-retrieved using !pmemlog_errormsg.
+retrieved using _UW(pmemlog_errormsg).
 
 + **2** - A trace of basic operations is logged.
 
@@ -508,10 +442,10 @@ main(int argc, char *argv[])
 	char *str;
 
 	/* create the pmemlog pool or open it if it already exists */
-	plp = pmemlog_create!U{}(path, POOL_SIZE, 0666);
+	plp = _U(pmemlog_create)(path, POOL_SIZE, 0666);
 
 	if (plp == NULL)
-		plp = pmemlog_open!U{}(path);
+		plp = _U(pmemlog_open)(path);
 
 	if (plp == NULL) {
 		perror(path);

--- a/doc/libpmemobj.3.md
+++ b/doc/libpmemobj.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBPMEMOBJ!3
+title: _MP(LIBPMEMOBJ, 3)
 header: NVM Library
 date: pmemobj API version 2.2
 ...
@@ -73,29 +73,17 @@ date: pmemobj API version 2.2
 cc -std=gnu99 ... -lpmemobj -lpmem
 ```
 
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Most commonly used functions: #####
 
 ```c
-!ifdef{WIN32}
-{
-PMEMobjpool *pmemobj_openU(const char *path, const char *layout);
-PMEMobjpool *pmemobj_openW(const wchar_t *path, const wchar_t *layout);
-PMEMobjpool *pmemobj_createU(const char *path, const char *layout,
-	size_t poolsize, mode_t mode);
-PMEMobjpool *pmemobj_createW(const wchar_t *path, const wchar_t *layout,
-	size_t poolsize, mode_t mode);
-}{
-PMEMobjpool *pmemobj_open(const char *path, const char *layout);
-PMEMobjpool *pmemobj_create(const char *path, const char *layout,
-	size_t poolsize, mode_t mode);
-}
+_UWFUNCR1(PMEMobjpool, *pmemobj_open, *path, const char *layout)
+_UWFUNCR1(PMEMobjpool, *pmemobj_create, *path, _q_const char *layout,
+	size_t poolsize, mode_t mode_e_)
 void pmemobj_close(PMEMobjpool *pop);
 ```
 
@@ -377,19 +365,9 @@ TX_MEMSET(void *dest, int c, size_t num)
 ##### Library API versioning: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemobj_check_versionU(
+_UWFUNC(pmemobj_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemobj_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemobj_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
 ##### Managing library behavior: #####
@@ -401,40 +379,22 @@ void pmemobj_set_funcs(
 	void *(*realloc_func)(void *ptr, size_t size),
 	char *(*strdup_func)(const char *s));
 
-!ifdef{WIN32}
-{
-int pmemobj_checkU(const char *path, const char *layout);
-int pmemobj_checkW(const wchar_t *path, const wchar_t *layout);
-}{
-int pmemobj_check(const char *path, const char *layout);
-}
+_UWFUNCR1(int, pmemobj_check, *path, const char *layout)
 ```
 
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemobj_errormsgU(void);
-const wchar_t *pmemobj_errormsgW(void);
-}{
-const char *pmemobj_errormsg(void);
-}
+_UWFUNC(pmemobj_errormsg, void)
 ```
 
 ##### Control and statistics: #####
 
 ```c
-!ifdef{WIN32}
-{
-int pmemobj_ctl_getU(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_getW(PMEMobjpool *pop, const wchar_t *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_setU(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_setW(PMEMobjpool *pop, const wchar_t *name, void *arg); (EXPERIMENTAL)
-}{
-int pmemobj_ctl_get(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_set(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-}
+_UWFUNCR2(int, pmemobj_ctl_get, PMEMobjpool *pop, *name, void *arg,
+	_q_ (EXPERIMENTAL)_e_)
+_UWFUNCR2(int, pmemobj_ctl_set, PMEMobjpool *pop, *name, void *arg,
+	_q_ (EXPERIMENTAL)_e_)
 ```
 
 # DESCRIPTION #
@@ -446,8 +406,8 @@ Memory mapping a file from this type of file system results in the load/store, n
 file.
 
 This library is for applications that need a transactions and persistent memory management.
-!ifndef{WIN32}
-{The **libpmemobj** requires a **-std=gnu99** compilation flag to build properly.}
+_WINUX(,
+_q_The **libpmemobj** requires a **-std=gnu99** compilation flag to build properly._e_)
 This library builds on the low-level pmem support provided by **libpmem**, handling the transactional updates, flushing changes to persistence,
 and recovery for the application.
 
@@ -465,7 +425,7 @@ information, when enabled, as described under **DEBUGGING AND ERROR HANDLING** b
 
 # MOST COMMONLY USED FUNCTIONS #
 
-To use the pmem-resident transactional object store provided by **libpmemobj**, a *memory pool* is first created. This is done with the !pmemobj_create
+To use the pmem-resident transactional object store provided by **libpmemobj**, a *memory pool* is first created. This is done with the _UW(pmemobj_create)
 function described in this section. The other functions described in this section then operate on the resulting memory pool.
 
 Additionally, none of the three functions described below are thread-safe with
@@ -478,50 +438,37 @@ be persistent memory or a regular file (see the **pmem_is_pmem**() function in *
 changes directly when using the obj memory API provided by **libpmemobj**.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMobjpool *pmemobj_openU(const char *path, const char *layout);
-PMEMobjpool *pmemobj_openW(const wchar_t *path, const wchar_t *layout);
-}{
-PMEMobjpool *pmemobj_open(const char *path, const char *layout);
-}
+_UWFUNCR1(PMEMobjpool, *pmemobj_open, *path, const char *layout)
 ```
 
-The !pmemobj_open function opens an existing object store memory pool, returning a memory pool handle used with most of the functions in this section.
-*path* must be an existing file containing a pmemobj memory pool as created by !pmemobj_create. If *layout* is non-NULL, it is compared to the layout
-name provided to !pmemobj_create when the pool was first created. This can be used to verify the layout of the pool matches what was expected. The
+The _UW(pmemobj_open) function opens an existing object store memory pool, returning a memory pool handle used with most of the functions in this section.
+*path* must be an existing file containing a pmemobj memory pool as created by _UW(pmemobj_create). If *layout* is non-NULL, it is compared to the layout
+name provided to _UW(pmemobj_create) when the pool was first created. This can be used to verify the layout of the pool matches what was expected. The
 application must have permission to open the file and memory map it with read/write permissions. If an error prevents the pool from being opened, or if the
-given *layout* does not match the pool's layout, !pmemobj_open returns NULL and sets *errno* appropriately.
+given *layout* does not match the pool's layout, _UW(pmemobj_open) returns NULL and sets *errno* appropriately.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMobjpool *pmemobj_createU(const char *path, const char *layout,
-	size_t poolsize, mode_t mode);
-PMEMobjpool *pmemobj_createW(const wchar_t *path, const wchar_t *layout,
-	size_t poolsize, mode_t mode);
-}{
-PMEMobjpool *pmemobj_create(const char *path, const char *layout,
-	size_t poolsize, mode_t mode);
-}
+_UWFUNCR1(PMEMobjpool, *pmemobj_create, *path, _q_const char *layout,
+	size_t poolsize, mode_t mode_e_)
 ```
 
-The !pmemobj_create function creates a transactional object store with the given total *poolsize*. *path* specifies the name of the memory pool file to be
+The _UW(pmemobj_create) function creates a transactional object store with the given total *poolsize*. *path* specifies the name of the memory pool file to be
 created. *layout* specifies the application's layout type in the form of a string. The layout name is not interpreted by **libpmemobj**, but may be used as a
-check when !pmemobj_open is called. The layout name, including the terminating null byte ('\0'), cannot be longer than **PMEMOBJ_MAX_LAYOUT** as defined in
+check when _UW(pmemobj_open) is called. The layout name, including the terminating null byte ('\0'), cannot be longer than **PMEMOBJ_MAX_LAYOUT** as defined in
 **\<libpmemobj.h\>**. It is allowed to pass NULL as *layout*, which is equivalent for using an empty string as a layout name. *mode* specifies the permissions to
 use when creating the file as described by **creat**(2). The memory pool file is fully allocated to the size *poolsize* using **posix_fallocate**(3). The
-caller may choose to take responsibility for creating the memory pool file by creating it before calling !pmemobj_create and then specifying *poolsize* as
-zero. In this case !pmemobj_create will take the pool size from the size of the existing file and will verify that the file appears to be empty by
-searching for any non-zero data in the pool header at the beginning of the file. The minimum net pool size allowed by the library for a local transactional object store is defined in **\<libpmemobj.h\>** as **PMEMOBJ_MIN_POOL**.
-!ifndef{WIN32}{For remote replicas the minimum file size is defined in **\<librpmem.h\>** as **RPMEM_MIN_PART**.}
+caller may choose to take responsibility for creating the memory pool file by creating it before calling _UW(pmemobj_create) and then specifying *poolsize* as
+zero. In this case _UW(pmemobj_create) will take the pool size from the size of the existing file and will verify that the file appears to be empty by
+searching for any non-zero data in the pool header at the beginning of the file. The minimum net pool size allowed by the library for a local transactional object store
+is defined in **\<libpmemobj.h\>** as **PMEMOBJ_MIN_POOL**.
+_WINUX(,For remote replicas the minimum file size is defined in **\<librpmem.h\>** as **RPMEM_MIN_PART**.)
 
 ```c
 void pmemobj_close(PMEMobjpool *pop);
 ```
 
 The **pmemobj_close**() function closes the memory pool indicated by *pop* and deletes the memory pool handle. The object store itself lives on in the file
-that contains it and may be re-opened at a later time using !pmemobj_open as described above.
+that contains it and may be re-opened at a later time using _UW(pmemobj_open) as described above.
 
 
 # LOW-LEVEL MEMORY MANIPULATION #
@@ -599,28 +546,28 @@ object stores spanning multiple memory devices by creation of persistent memory 
 stored on different pmem-aware filesystem.
 
 To improve reliability and eliminate the single point of failure, all the changes of the data stored in the persistent memory pool could be also automatically
-written to local !ifndef{WIN32}{or remote} pool replicas, thereby providing a backup for a persistent memory pool by producing a *mirrored pool set*. In practice, the pool
+written to local _WINUX(,or remote) pool replicas, thereby providing a backup for a persistent memory pool by producing a *mirrored pool set*. In practice, the pool
 replicas may be considered as binary copies of the "master" pool set.
 
-Creation of all the parts of the pool set and the associated replica sets can be done with the !pmemobj_create function or by using the **pmempool**(1)
+Creation of all the parts of the pool set and the associated replica sets can be done with the _UW(pmemobj_create) function or by using the **pmempool**(1)
 utility.
 
-Restoring data from a local !ifndef{WIN32}{or remote} replica can be done by using the
-**pmempool-sync**(1) command or !pmempool_sync API from the
+Restoring data from a local _WINUX(,or remote) replica can be done by using the
+**pmempool-sync**(1) command or _UW(pmempool_sync) API from the
 **libpmempool**(3) library.
 
 Modifications of a pool set file configuration can be done by using the
-**pmempool-transform**(1) command or !pmempool_transform API from the
+**pmempool-transform**(1) command or _UW(pmempool_transform) API from the
 **libpmempool**(3) library.
 
-When creating the pool set consisting of multiple files, or when creating the replicated pool set, the *path* argument passed to !pmemobj_create must
+When creating the pool set consisting of multiple files, or when creating the replicated pool set, the *path* argument passed to _UW(pmemobj_create) must
 point to the special *set* file that defines the pool layout and the location of all the parts of the pool set. The *poolsize* argument must be 0. The meaning
 of *layout* and *mode* arguments doesn't change, except that the same *mode* is used for creation of all the parts of the pool set and replicas. If the error
-prevents any of the pool set files from being created, !pmemobj_create returns NULL and sets *errno* appropriately.
+prevents any of the pool set files from being created, _UW(pmemobj_create) returns NULL and sets *errno* appropriately.
 
-When opening the pool set consisting of multiple files, or when opening the replicated pool set, the *path* argument passed to !pmemobj_open must not
+When opening the pool set consisting of multiple files, or when opening the replicated pool set, the *path* argument passed to _UW(pmemobj_open) must not
 point to the pmemobj memory pool file, but to the same *set* file that was used for the pool set creation. If an error prevents any of the pool set files from
-being opened, or if the actual size of any file does not match the corresponding part size defined in *set* file !pmemobj_open returns NULL and sets
+being opened, or if the actual size of any file does not match the corresponding part size defined in *set* file _UW(pmemobj_open) returns NULL and sets
 *errno* appropriately.
 
 The set file is a plain text file, which must start with the line containing a *PMEMPOOLSET* string, followed by the specification of all the pool parts in the
@@ -659,9 +606,8 @@ Device DAX is the device-centric analogue of Filesystem DAX. It allows memory
 ranges to be allocated and mapped without need of an intervening file system.
 For more information please see **ndctl-create-namespace**(1).
 
-!ifndef{WIN32}
-{
-In case of a remote replica, the *REPLICA* keyword has to be followed by
+_WINUX(,
+_q_In case of a remote replica, the *REPLICA* keyword has to be followed by
 an address of a remote host (in the format recognized by the **ssh**(1)
 remote login client) and a relative path to a remote pool set file (located
 in the root config directory on the target node - see **librpmem**(3)):
@@ -688,7 +634,7 @@ REPLICA
 # remote replica
 REPLICA user@example.com remote-objpool.set
 ```
-}
+_e_)
 The files in the set may be created by running the following command:
 
 ```
@@ -2218,26 +2164,16 @@ resources associated with that thread might not be cleaned up properly.
 This section describes how the library API is versioned, allowing applications to work with an evolving API.
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemobj_check_versionU(
+_UWFUNC(pmemobj_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmemonj_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmemobj_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !pmemobj_check_version function is used to see if the installed **libpmemobj** supports the version of the library API required by an application. The
+The _UW(pmemobj_check_version) function is used to see if the installed **libpmemobj** supports the version of the library API required by an application. The
 easiest way to do this is for the application to supply the compile-time version information, supplied by defines in **\<libpmemobj.h\>**, like this:
 
 ```c
-reason = pmemobj_check_version!U{}(PMEMOBJ_MAJOR_VERSION,
+reason = _U(pmemobj_check_version)(PMEMOBJ_MAJOR_VERSION,
                                PMEMOBJ_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -2251,8 +2187,8 @@ An application can also check specifically for the existence of an interface by 
 are documented in this man page as follows: unless otherwise specified, all interfaces described here are available in version 1.0 of the library. Interfaces
 added after version 1.0 will contain the text *introduced in version x.y* in the section of this manual describing the feature.
 
-When the version check performed by !pmemobj_check_version is successful, the return value is NULL. Otherwise the return value is a static string
-describing the reason for failing the version check. The string returned by !pmemobj_check_version must not be modified or freed.
+When the version check performed by _UW(pmemobj_check_version) is successful, the return value is NULL. Otherwise the return value is a static string
+describing the reason for failing the version check. The string returned by _UW(pmemobj_check_version) must not be modified or freed.
 
 
 # MANAGING LIBRARY BEHAVIOR #
@@ -2272,53 +2208,41 @@ the handlers will cause the **libpmemobj** default function to be used. The libr
 allocate approximately 4-8 kilobytes for each memory pool in use.
 
 ```c
-!ifdef{WIN32}
-{
-int pmemobj_checkU(const char *path, const char *layout);
-int pmemobj_checkW(const wchar_t *path, const wchar_t *layout);
-}{
-int pmemobj_check(const char *path, const char *layout);
-}
+_UWFUNCR1(int, pmemobj_check, *path, const char *layout)
 ```
 
-The !pmemobj_check function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
-inconsistencies found will cause !pmemobj_check to return 0, in which case the use of the file with **libpmemobj** will result in undefined behavior. The
+The _UW(pmemobj_check) function performs a consistency check of the file indicated by *path* and returns 1 if the memory pool is found to be consistent. Any
+inconsistencies found will cause _UW(pmemobj_check) to return 0, in which case the use of the file with **libpmemobj** will result in undefined behavior. The
 debug version of **libpmemobj** will provide additional details on inconsistencies when **PMEMOBJ_LOG_LEVEL** is at least 1, as described in the **DEBUGGING AND
-ERROR HANDLING** section below. !pmemobj_check will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
-!pmemobj_check opens the given *path* read-only so it never makes any changes to the file. This function is not supported on Device DAX.
+ERROR HANDLING** section below. _UW(pmemobj_check) will return -1 and set *errno* if it cannot perform the consistency check due to other errors.
+_UW(pmemobj_check) opens the given *path* read-only so it never makes any changes to the file. This function is not supported on Device DAX.
 
 
 # DEBUGGING AND ERROR HANDLING #
 
-!ifndef{WIN32}
-{Two versions of **libpmemobj** are typically available on a development system. The normal version, accessed when a program is linked using the **-lpmemobj**
+_WINUX(,
+_q_Two versions of **libpmemobj** are typically available on a development system. The normal version, accessed when a program is linked using the **-lpmemobj**
 option, is optimized for performance. That version skips checks that impact performance and never logs any trace information or performs any run-time
-assertions.}
+assertions._e_)
 If an error is detected during the call to **libpmemobj** function, an application may retrieve an error message describing the reason of failure
 using the following function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmemobj_errormsgU(void);
-const wchar_t *pmemobj_errormsgW(void);
-}{
-const char *pmemobj_errormsg(void);
-}
+_UWFUNC(pmemobj_errormsg, void)
 ```
 
-The !pmemobj_errormsg function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
+The _UW(pmemobj_errormsg) function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
 include description of the corresponding error code (if *errno* was set), as returned by **strerror**(3). The error message buffer is thread-local; errors
 encountered in one thread do not affect its value in other threads. The buffer is never cleared by any library function; its content is significant only when
 the return value of the immediately preceding call to **libpmemobj** function indicated an error, or if *errno* was set. The application must not modify or
 free the error message string, but it may be modified by subsequent calls to other library functions.
 
 A second version of **libpmemobj**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
+the libraries under _WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**), contains
 run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to _WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**), depending on where the debug
 libraries are installed on the system.
 The trace points in the debug version of the library are enabled using the environment
 variable **PMEMOBJ_LOG_LEVEL** which can be set to the following values:
@@ -2326,7 +2250,7 @@ variable **PMEMOBJ_LOG_LEVEL** which can be set to the following values:
 + **0** - This is the default level when **PMEMOBJ_LOG_LEVEL** is not set. No log messages are emitted at this level.
 
 + **1** - Additional details on any errors detected are logged (in addition to returning the *errno*-based errors as usual). The same information may be
-retrieved using !pmemobj_errormsg.
+retrieved using _UW(pmemobj_errormsg).
 
 + **2** - A trace of basic operations is logged.
 
@@ -2353,16 +2277,10 @@ well as reason about its internals.
 There are two main functions to that interface:
 
 ```c
-!ifdef{WIN32}
-{
-int pmemobj_ctl_getU(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_getW(PMEMobjpool *pop, const wchar_t *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_setU(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_setW(PMEMobjpool *pop, const wchar_t *name, void *arg); (EXPERIMENTAL)
-}{
-int pmemobj_ctl_get(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-int pmemobj_ctl_set(PMEMobjpool *pop, const char *name, void *arg); (EXPERIMENTAL)
-}
+_UWFUNCR2(int, pmemobj_ctl_get, PMEMobjpool *pop, *name, void *arg,
+	_q_ (EXPERIMENTAL)_e_)
+_UWFUNCR2(int, pmemobj_ctl_set, PMEMobjpool *pop, *name, void *arg,
+	_q_ (EXPERIMENTAL)_e_)
 ```
 
 The *name* argument specifies an entry point as defined in the CTL namespace
@@ -2400,13 +2318,13 @@ prefault.at_create | rw | global | int | int | boolean
 
 If set, every single page of the pool will be touched and written to, in order
 to trigger page allocation. This can be used to minimize performance impact of
-pagefaults. Affects only the !pmemobj_create function.
+pagefaults. Affects only the _UW(pmemobj_create) function.
 
 Always returns 0.
 
 prefault.at_open | rw | global | int | int | boolean
 
-As above, but affects !pmemobj_open function.
+As above, but affects _UW(pmemobj_open) function.
 
 tx.debug.skip_expensive_checks | rw | - | int | int | boolean
 

--- a/doc/libpmempool.3.md
+++ b/doc/libpmempool.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBPMEMPOOL!3
+title: _MP(LIBPMEMPOOL, 3)
 header: NVM Library
 date: pmempool API version 1.1
 ...
@@ -60,88 +60,47 @@ date: pmempool API version 1.1
 cc -std=gnu99 ... -lpmempool -lpmem
 ```
 
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Health check functions: #####
 
 ```c
-!ifdef{WIN32}
-{
-PMEMpoolcheck *pmempool_check_initU(struct pmempool_check_argsU *args,
-	size_t args_size);
-PMEMpoolcheck *pmempool_check_initW(struct pmempool_check_argsW *args,
-	size_t args_size);
-struct pmempool_check_statusU *pmempool_checkU(PMEMpoolcheck *ppc);
-struct pmempool_check_statusW *pmempool_checkW(PMEMpoolcheck *ppc);
-}{
-PMEMpoolcheck *pmempool_check_init(struct pmempool_check_args *args,
-	size_t args_size);
-struct pmempool_check_status *pmempool_check(PMEMpoolcheck *ppc);
-}
+_UWFUNCR1UW(PMEMpoolcheck, *pmempool_check_init, struct pmempool_check_args, *args,_q_
+	size_t args_size_e_)
+_UWFUNCRUW(struct pmempool_check_status, *pmempool_check, PMEMpoolcheck *ppc)
 enum pmempool_check_result pmempool_check_end(PMEMpoolcheck *ppc);
 ```
 
 ##### Pool set synchronization and transformation: #####
 
 ```c
-!ifdef{WIN32}
-{
-int pmempool_syncU(const char *poolset_file, unsigned flags); (EXPERIMENTAL)
-int pmempool_syncW(const wchar_t *poolset_file, unsigned flags); (EXPERIMENTAL)
-int pmempool_transformU(const char *poolset_file_src, (EXPERIMENTAL)
-	const char *poolset_file_dst, unsigned flags);
-int pmempool_transformW(const wchar_t *poolset_file_src, (EXPERIMENTAL)
-	const wchar_t *poolset_file_dst, unsigned flags);
-}{
-int pmempool_sync(const char *poolset_file, unsigned flags); (EXPERIMENTAL)
-int pmempool_transform(const char *poolset_file_src,
-	const char *poolset_file_dst,
-	unsigned flags); (EXPERIMENTAL)
-}
+_UWFUNCR1(int, pmempool_sync, *poolset_file,_q_
+	unsigned flags_e_, _q_ (EXPERIMENTAL)_e_)
+_UWFUNCR12(int, pmempool_transform, *poolset_file_src,
+	*poolset_file_dst, unsigned flags, _q_ (EXPERIMENTAL)_e_)
 ```
 
 ##### Pool set management functions: #####
 
 ```c
-!ifdef{WIN32}
-{
-int pmempool_rmU(const char *path, int flags);
-int pmempool_rmW(const wchar_t *path, int flags);
-}{
-int pmempool_rm(const char *path, int flags);
-}
+_UWFUNCR1(int, pmempool_rm, *path, int flags)
 ```
 
 ##### Library API versioning: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmempool_check_versionU(unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmempool_check_versionW(unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmempool_check_version(unsigned major_required,
-	unsigned minor_required);
-}
+_UWFUNC(pmempool_check_version, _q_
+	unsigned major_required,
+	unsigned minor_required_e_)
 ```
 
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmempool_errormsgU(void);
-const wchar_t *pmempool_errormsgW(void);
-}{
-const char *pmempool_errormsg(void);
-}
+_UWFUNC(pmempool_errormsg, void)
 ```
 
 
@@ -151,10 +110,10 @@ const char *pmempool_errormsg(void);
 provides a set of utilities for off-line analysis and
 manipulation of a *pool*. By *pool* in this
 manpage we mean pmemobj pool, pmemblk pool, pmemlog pool or
-BTT layout, independent of the underlying storage. Some of
+BTT layout, independent of the underlying storage. Some
 **libpmempool** functions are required to work without
-any impact on processed *pool* but some of them may
-create a new or modify an existing one.
+any impact on the *pool* but some may create a new or modify
+an existing *pool*.
 
 **libpmempool**
 is for applications that need high reliability or built-in
@@ -164,48 +123,39 @@ purposes also.
 
 # POOL CHECKING FUNCTIONS #
 
-To perform check provided by **libpmempool**, a *check context*
-must be first initialized using !pmempool_check_init
-function described in this section. Once initialized
-*check context* is represented by an opaque handle, of
+To perform the checks provided by **libpmempool**, a *check context*
+must first be initialized using the _UW(pmempool_check_init)
+function described in this section. Once initialized, the
+*check context* is represented by an opaque handle of
 type *PMEMpoolcheck\**, which is passed to all of the
 other functions described in this section.
 
-To execute check !pmempool_check must be called iteratively.
-Each call resumes check till new status will be generated.
-Each status is represented by !pmempool_check_status_ptr structure.
-It may carry various
-types of messages described in this section.
+To execute checks, _UW(pmempool_check) must be called iteratively.
+Each call generates a new check status, represented by a
+_UWS(pmempool_check_status) structure. Status messages are described
+later in this section.
 
-When check is completed !pmempool_check returns NULL pointer.
-Check must be finalized using **pmempool_check_end**().
-It returns *enum pmempool_check_result* describing
-result of the whole check.
+When the checks are completed, _UW(pmempool_check) returns NULL.
+The check must be finalized using **pmempool_check_end**(), which
+returns an *enum pmempool_check_result* describing the results of
+the entire check.
 
 > NOTE: Currently, checking the consistency of a *pmemobj* pool is
 **not** supported.
 
 ```c
-!ifdef{WIN32}
-{
-PMEMpoolcheck *pmempool_check_initU(struct pmempool_check_argsU *args,
-	size_t args_size);
-PMEMpoolcheck *pmempool_check_initW(struct pmempool_check_argsW *args,
-	size_t args_size);
-}{
-PMEMpoolcheck *pmempool_check_init(struct pmempool_check_args *args,
-	size_t args_size);
-}
+_UWFUNCR1UW(PMEMpoolcheck, *pmempool_check_init, struct pmempool_check_args,
+	*args,_q_
+	size_t args_size_e_)
 ```
 
-The !pmempool_check_init initializes check
+_UW(pmempool_check_init) initializes the check
 context. *args* describes parameters of the
 check context. *args_size* should be equal to
-the size of the !pmempool_check_args.
-!pmempool_check_args is defined as follows:
+the size of the _UWS(pmempool_check_args).
+_UWS(pmempool_check_args) is defined as follows:
 
-!ifdef{WIN32}
-{
+_WINUX(_q_
 ```c
 struct pmempool_check_argsU
 {
@@ -237,7 +187,7 @@ struct pmempool_check_argsW
 	int flags;
 };
 ```
-}{
+_e_,_q_
 ```c
 struct pmempool_check_args
 {
@@ -254,7 +204,7 @@ struct pmempool_check_args
 	int flags;
 };
 ```
-}
+_e_)
 The *flags* argument accepts any combination of the following values (ORed):
 
 + **PMEMPOOL_CHECK_REPAIR** - perform repairs
@@ -264,35 +214,31 @@ The *flags* argument accepts any combination of the following values (ORed):
 + **PMEMPOOL_CHECK_VERBOSE** - generate info statuses
 + **PMEMPOOL_CHECK_FORMAT_STR** - generate string format statuses
 
-If provided parameters are invalid or initialization process fails
-!pmempool_check_init returns NULL and sets *errno*
-appropriately. *pool_type* has to match type of the
+If any of the provided parameters are invalid, or the initialization process
+fails, _UW(pmempool_check_init) returns NULL and sets *errno*
+appropriately. *pool_type* must match the type of the
 *pool* being processed. You can turn on pool type
 detection by setting *pool_type* to **PMEMPOOL_POOL_TYPE_DETECT**.
-Pool type detection fail ends check.
+A pool type detection failure ends the check.
 
-*backup_path* argument can either be:
+*backup_path* may be:
 
-+ NULL. It indicates no backup will be performed.
++ NULL: No backup will be performed.
 
-+ a non existing file. It is valid only in case *path* is a single file
-*pool*. It indicates a *backup_path* file will be created and backup will be
-performed.
++ a non-existent file: *backup_path* will be created and backup will be performed. *path* must be a single file *pool*.
 
-+ an existing *pool set* file of the same structure (the same number of parts
-with exactly the same size) as the source *pool set*. It is valid only in case
-*path* is a *pool set*. It indicates backup will be performed in a form
-described by the *backup_path* *pool set*.
++ an existing pool set file: Backup will be performed
+as defined by the *backup_path* pool set. *backup_path* must have the same structure (the same number of parts with exactly the same size) as the
+*path* pool set.
 
-Backup is supported only if the source *pool set* has no defined replicas.
+Backup is supported only if the source pool set has no defined replicas.
 
-Pool sets with remote replicas are not supported neither as *path* nor as
-*backup_path*.
+Neither *path* nor *backup_path* may specify a pool set with remote replicas.
 
 This is an example of a *check context* initialization:
 
 ```c
-struct pmempool_check_args!U args =
+struct _U(pmempool_check_args) args =
 {
 	.path = "/path/to/blk.pool",
 	.backup_path = NULL,
@@ -303,13 +249,13 @@ struct pmempool_check_args!U args =
 ```
 
 ```c
-PMEMpoolcheck *ppc = pmempool_check_init!U{}(&args, sizeof(args));
+PMEMpoolcheck *ppc = _U(pmempool_check_init)(&args, sizeof(args));
 ```
 
 The check will process a *pool* of type **PMEMPOOL_POOL_TYPE_BLK**
 located in the path */path/to/blk.pool*. Before check it will
 not create a backup of the *pool* (*backup_path == NULL*).
-If the check will find any issues it will try to
+If the check finds any issues it will try to
 perform repair steps (**PMEMPOOL_CHECK_REPAIR**), but it
 will not make any changes to the *pool*
 (**PMEMPOOL_CHECK_DRY_RUN**) and it will not perform any
@@ -319,27 +265,19 @@ The check will ask before performing any repair steps (no
 detailed information about the check (**PMEMPOOL_CHECK_VERBOSE**).
 **PMEMPOOL_CHECK_FORMAT_STR** flag indicates string
 format statuses (*struct pmempool_check_status*).
-Currently it is the only supported status format so this flag is required.
+Currently this is the only supported status format so this flag is required.
 
-!ifdef{WIN32}
-{
 ```c
-struct pmempool_check_statusU *pmempool_checkU(PMEMpoolcheck *ppc);
-struct pmempool_check_statusW *pmempool_checkW(PMEMpoolcheck *ppc);
+_UWFUNCRUW(struct pmempool_check_status, *pmempool_check, PMEMpoolcheck *ppc)
 ```
-}{
-```c
-struct pmempool_check_status *pmempool_check(PMEMpoolcheck *ppc);
-```
-}
 
-The !pmempool_check function starts or resumes the check
+The _UW(pmempool_check) function starts or resumes the check
 indicated by *ppc*. When next status will be generated
 it pauses the check and returns a pointer to the
-!pmempool_check_status structure:
+_UWS(pmempool_check_status) structure:
 
-!ifdef{WIN32}
-{
+_WINUX(
+_q_
 ```c
 struct pmempool_check_statusU
 {
@@ -361,7 +299,7 @@ struct pmempool_check_statusW
 	} str;
 };
 ```
-}{
+_e_,_q_
 ```c
 struct pmempool_check_status
 {
@@ -373,21 +311,21 @@ struct pmempool_check_status
 	} str;
 };
 ```
-}
+_e_)
 
 This structure can describe three types of statuses:
 
 + **PMEMPOOL_CHECK_MSG_TYPE_INFO** - detailed information about the check.
   Generated only if a **PMEMPOOL_CHECK_VERBOSE** flag was set.
 + **PMEMPOOL_CHECK_MSG_TYPE_ERROR** - encountered error
-+ **PMEMPOOL_CHECK_MSG_TYPE_QUESTION** - question. Generated only if an
++ **PMEMPOOL_CHECK_MSG_TYPE_QUESTION** - question. Generated only if the
   **PMEMPOOL_CHECK_ALWAYS_YES** flag was not set. It requires *answer* to be
   set to "yes" or "no" before continuing.
 
-After calling !pmempool_check again the previously provided
-!pmempool_check_status_ptr pointer must be
-considered invalid. When the check completes
-!pmempool_check returns NULL pointer.
+After calling _UW(pmempool_check) again, the previously provided
+_UWS(pmempool_check_status) pointer must be
+considered invalid. When the check completes,
+_UW(pmempool_check) returns NULL.
 
 ```c
 enum pmempool_check_result pmempool_check_end(PMEMpoolcheck* ppc);
@@ -396,7 +334,7 @@ enum pmempool_check_result pmempool_check_end(PMEMpoolcheck* ppc);
 The **pmempool_check_end**() function finalizes the check and
 releases all related resources. *ppc* is not a valid
 pointer after calling **pmempool_check_end**(). It
-returns *enum pmempool_check_result* summarizing result
+returns *enum pmempool_check_result* summarizing the results
 of the finalized check. **pmempool_check_end**() can
 return one of the following values:
 
@@ -407,7 +345,7 @@ return one of the following values:
 + **PMEMPOOL_CHECK_RESULT_CANNOT_REPAIR** - the *pool* has issues which
   can not be repaired
 + **PMEMPOOL_CHECK_RESULT_ERROR** - the *pool* has errors or the check
-  encountered issue
+  encountered issues
 
 
 # POOL SET SYNCHRONIZATION AND TRANSFORMATION #
@@ -419,19 +357,14 @@ Currently, the following operations are allowed only for **pmemobj** pools (see
 ### POOL SET SYNC ###
 
 ```c
-!ifdef{WIN32}
-{
-int pmempool_syncU(const char *poolset_file, unsigned flags); (EXPERIMENTAL)
-int pmempool_syncW(const wchar_t *poolset_file, unsigned flags); (EXPERIMENTAL)
-}{
-int pmempool_sync(const char *poolset_file, unsigned flags); (EXPERIMENTAL)
-}
+_UWFUNCR1(int, pmempool_sync, *poolset_file,_q_
+	unsigned flags_e_, _q_ (EXPERIMENTAL)_e_)
 ```
 
-The !pmempool_sync function synchronizes data between replicas within
+The _UW(pmempool_sync) function synchronizes data between replicas within
 a pool set.
 
-!pmempool_sync accepts two arguments:
+_UW(pmempool_sync) accepts two arguments:
 
 * *poolset_file* - a path to a pool set file,
 
@@ -446,36 +379,25 @@ The following flags are available:
 * **PMEMPOOL_DRY_RUN** - do not apply changes, only check for viability of
 synchronization.
 
-!pmempool_sync function checks if metadata of all replicas in a pool set
+The _UW(pmempool_sync) function checks if metadata of all replicas in a pool set
 are consistent, i.e. all parts are healthy, and if any of them is not,
 the corrupted or missing parts are recreated and filled with data from one of
 the healthy replicas.
 
 The function returns either 0 on success or -1 in case of error
-with proper errno set accordingly.
+with errno set accordingly.
 
->NOTE: The !pmempool_sync API is experimental and it may change in future
+>NOTE: The _UW(pmempool_sync) API is experimental and it may change in future
 versions of the library.
 
 ### POOL SET TRANSFORM ###
 
 ```c
-!ifdef{WIN32}
-{
-int pmempool_transformU(const char *poolset_file_src,
-	const char *poolset_file_dst,
-	unsigned flags); (EXPERIMENTAL)
-int pmempool_transformW(const wchar_t *poolset_file_src,
-	const wchar_t *poolset_file_dst,
-	unsigned flags); (EXPERIMENTAL)
-}{
-int pmempool_transform(const char *poolset_file_src,
-	const char *poolset_file_dst,
-	unsigned flags); (EXPERIMENTAL)
-}
+_UWFUNCR12(int, pmempool_transform, *poolset_file_src,
+	*poolset_file_dst, unsigned flags, _q_ (EXPERIMENTAL)_e_)
 ```
 
-The !pmempool_transform function modifies internal structure of a pool set.
+The _UW(pmempool_transform) function modifies the internal structure of a pool set.
 It supports the following operations:
 
 * adding one or more replicas,
@@ -485,7 +407,7 @@ It supports the following operations:
 * reordering of replicas.
 
 
-!pmempool_transform accepts three arguments:
+_UW(pmempool_transform) accepts three arguments:
 
 * *poolset_file_src* - a path to a pool set file which defines the source
 pool set to be changed,
@@ -512,9 +434,9 @@ by 4096 bytes per each part file. The 4096 bytes of each part file is
 utilized for storing internal metadata of the pool part files.
 
 The function returns either 0 on success or -1 in case of error
-with proper *errno* set accordingly.
+with *errno* set accordingly.
 
->NOTE: The !pmempool_transform API is experimental and it may change in future
+>NOTE: The _UW(pmempool_transform) API is experimental and it may change in future
 versions of the library.
 
 
@@ -523,23 +445,16 @@ versions of the library.
 ### Removing pool ###
 
 ```c
-!ifdef{WIN32}
-{
-int pmempool_rmU(const char *path, int flags);
-int pmempool_rmW(const wchar_t *path, int flags);
-}{
-int pmempool_rm(const char *path, int flags);
-}
+_UWFUNCR1(int, pmempool_rm, *path, int flags)
 ```
 
-The !pmempool_rm function removes pool pointed by *path*. The *path* can
-point to either a regular file, device dax or pool set file. In case of pool
-set file the !pmempool_rm will remove all part files from local replicas
-using **unlink**(3) and all remote replicas (supported on Linux)
-using **rpmem_remove**() function (see **librpmem**(3)),
-before removing the pool set file itself.
+The _UW(pmempool_rm) function removes the pool pointed to by *path*. The *path* can
+point to a regular file, device dax or pool set file. If *path* is a pool
+set file, _UW(pmempool_rm) will remove all part files from local replicas
+using **unlink**(3), _WINUX(,_q_and all remote replicas using **rpmem_remove**()
+(see **librpmem**(3)),_e_) before removing the pool set file itself.
 
-The *flags* argument determines the behavior of !pmempool_rm function.
+The *flags* argument determines the behavior of _UW(pmempool_rm).
 It is either 0 or the bitwise OR of one or more of the following flags:
 
 + **PMEMPOOL_RM_FORCE**
@@ -567,29 +482,19 @@ This section describes how the library API is versioned, allowing
 applications to work with an evolving API.
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmempool_check_versionU(
+_UWFUNC(pmempool_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *pmempool_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *pmempool_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !pmempool_check_version function is used to see if
+The _UW(pmempool_check_version) function is used to see if
 the installed **libpmempool** supports the version of the
 library API required by an application. The easiest way to
 do this for the application is to supply the compile-time
 version information, supplied by defines in **\<libpmempool.h\>**, like this:
 
 ```c
-reason = pmempool_check_version!U{}(PMEMPOOL_MAJOR_VERSION,
+reason = _U(pmempool_check_version)(PMEMPOOL_MAJOR_VERSION,
                                 PMEMPOOL_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -609,11 +514,11 @@ Interfaces added after version 1.0 will contain the text
 *introduced in version x.y* in the section of this manual
 describing the feature.
 
-When the version check performed by !pmempool_check_version
+When the version check performed by _UW(pmempool_check_version)
 is successful, the return value is NULL. Otherwise the
 return value is a static string describing the reason for
 failing the version check. The string returned by
-!pmempool_check_version must not be modified or freed.
+_UW(pmempool_check_version) must not be modified or freed.
 
 
 # DEBUGGING AND ERROR HANDLING #
@@ -629,16 +534,10 @@ application may retrieve an error message describing the
 reason of failure using the following function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *pmempool_errormsgU(void);
-const wchar_t *pmempool_errormsgW(void);
-}{
-const char *pmempool_errormsg(void);
-}
+_UWFUNC(pmempool_errormsg, void)
 ```
 
-The !pmempool_errormsg function returns a pointer to a
+The _UW(pmempool_errormsg) function returns a pointer to a
 static buffer containing the last error message logged for
 current thread. The error message may include description of
 the corresponding error code (if *errno* was set), as returned
@@ -653,11 +552,11 @@ message string, but it may be modified by subsequent calls
 to other library functions.
 
 A second version of **libpmempool**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
+the libraries under _WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**), contains
 run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to _WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**), depending on where the debug
 libraries are installed on the system.
 The trace points in
 the debug version of the library are enabled using the
@@ -669,7 +568,7 @@ No log messages are emitted at this level.
 
 + **1** - Additional details on any errors detected are logged (in addition to
 returning the *errno*-based errors as usual). The same information may be
-retrieved using !pmempool_errormsg.
+retrieved using _UW(pmempool_errormsg).
 
 + **2** - A trace of basic operations is logged.
 
@@ -697,9 +596,8 @@ The program detects the type and checks consistency of given pool.
 If there are any issues detected, the pool is automatically repaired.
 
 ```c
-#include <stddef.h>
-!ifdef{WIN32}{}
-{#include <unistd.h>}
+#include <stddef.h>_WINUX(,_q_
+#include <unistd.h>_e_)
 #include <stdlib.h>
 #include <stdio.h>
 #include <libpmempool.h>
@@ -712,11 +610,11 @@ int
 main(int argc, char *argv[])
 {
 	PMEMpoolcheck *ppc;
-	struct pmempool_check_status!U *status;
+	struct _U(pmempool_check_status) *status;
 	enum pmempool_check_result ret;
 
 	/* arguments for check */
-	struct pmempool_check_args!U args = {
+	struct _U(pmempool_check_args) args = {
 		.path		= PATH,
 		.backup_path	= NULL,
 		.pool_type	= PMEMPOOL_POOL_TYPE_DETECT,
@@ -724,13 +622,13 @@ main(int argc, char *argv[])
 	};
 
 	/* initialize check context */
-	if ((ppc = pmempool_check_init!U{}(&args, sizeof(args))) == NULL) {
-		perror("pmempool_check_init!U");
+	if ((ppc = _U(pmempool_check_init)(&args, sizeof(args))) == NULL) {
+		perror("_U(pmempool_check_init)");
 		exit(EXIT_FAILURE);
 	}
 
 	/* perform check and repair, answer 'yes' for each question */
-	while ((status = pmempool_check!U{}(ppc)) != NULL) {
+	while ((status = _U(pmempool_check)(ppc)) != NULL) {
 		switch (status->type) {
 		case PMEMPOOL_CHECK_MSG_TYPE_ERROR:
 			printf("%s\n", status->str.msg);

--- a/doc/librpmem.3.md
+++ b/doc/librpmem.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBRPMEM!3
+title: _MP(LIBRPMEM, 3)
 header: NVM Library
 date: rpmem API version 1.1
 ...

--- a/doc/libvmem.3.md
+++ b/doc/libvmem.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBVMEM!3
+title: _MP(LIBVMEM, 3)
 header: NVM Library
 date: vmem API version 1.1
 ...
@@ -60,23 +60,15 @@ date: vmem API version 1.1
 cc ... -lvmem
 ```
 
-!ifdef{WIN32}
-{
->NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
+_WINUX(
+_q_>NOTE: NVML API supports UNICODE. If **NVML_UTF8_API** macro is defined then
 basic API functions are expanded to UTF-8 API with postfix *U*,
-otherwise they are expanded to UNICODE API with postfix *W*.
-}
+otherwise they are expanded to UNICODE API with postfix *W*._e_)
 
 ##### Memory pool management: #####
 
 ```c
-!ifdef{WIN32}
-{
-VMEM *vmem_createU(const char *dir, size_t size);
-VMEM *vmem_createW(const wchar_t *dir, size_t size);
-}{
-VMEM *vmem_create(const char *dir, size_t size);
-}
+_UWFUNCR1(VMEM, *vmem_create, *dir, size_t size)
 VMEM *vmem_create_in_region(void *addr, size_t size);
 void vmem_delete(VMEM *vmp);
 int vmem_check(VMEM *vmp);
@@ -99,19 +91,9 @@ size_t vmem_malloc_usable_size(VMEM *vmp, void *ptr);
 ##### Managing overall library behavior: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *vmem_check_versionU(
+_UWFUNC(vmem_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *vmem_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *vmem_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 void vmem_set_funcs(
 	void *(*malloc_func)(size_t size),
 	void (*free_func)(void *ptr),
@@ -123,13 +105,7 @@ void vmem_set_funcs(
 ##### Error handling: #####
 
 ```c
-!ifdef{WIN32}
-{
-const char *vmem_errormsgU(void);
-const wchar_t *vmem_errormsgW(void);
-}{
-const char *vmem_errormsg(void);
-}
+_UWFUNC(vmem_errormsg, void)
 ```
 
 
@@ -157,29 +133,23 @@ interfaces less commonly used for managing the overall library behavior. These g
 
 # MANAGING MEMORY POOLS #
 
-To use **libvmem**, a *memory pool* is first created. This is most commonly done with the !vmem_create function described in this section. The other
+To use **libvmem**, a *memory pool* is first created. This is most commonly done with the _UW(vmem_create) function described in this section. The other
 functions described in this section are for less common cases, where applications have special needs for creating pools or examining library state.
 
 Once created, a memory pool is represented by an opaque pool handle, of type *VMEM\**, which is passed to the functions for memory allocation described in the
 next section.
 
 ```c
-!ifdef{WIN32}
-{
-VMEM *vmem_createU(const char *dir, size_t size);
-VMEM *vmem_createW(const wchar_t *dir, size_t size);
-}{
-VMEM *vmem_create(const char *dir, size_t size);
-}
+_UWFUNCR1(VMEM, *vmem_create, *dir, size_t size)
 ```
 
-The !vmem_create function creates a memory pool. The resulting pool is then used with functions like **vmem_malloc**() and **vmem_free**() to provide the
-familiar *malloc-like* programming model for the memory pool. !vmem_create creates the pool by allocating a temporary file in the given directory *dir*.
+The _UW(vmem_create) function creates a memory pool. The resulting pool is then used with functions like **vmem_malloc**() and **vmem_free**() to provide the
+familiar *malloc-like* programming model for the memory pool. _UW(vmem_create) creates the pool by allocating a temporary file in the given directory *dir*.
 The file is created in a fashion similar to **tmpfile**(3), so that the file name does not appear when the directory is listed and the space is automatically
 freed when the program terminates. *size* bytes are allocated and the resulting space is memory-mapped. The minimum *size* value allowed by the library is
-defined in **\<libvmem.h\>** as **VMEM_MIN_POOL**. Calling !vmem_create with a size smaller than that will return an error. The maximum allowed size is not
+defined in **\<libvmem.h\>** as **VMEM_MIN_POOL**. Calling _UW(vmem_create) with a size smaller than that will return an error. The maximum allowed size is not
 limited by **libvmem**, but by the file system specified by the *dir* argument. The *size* passed in is the raw size of the memory pool and **libvmem** will
-use some of that space for its own metadata. !vmem_create returns an opaque memory pool handle or NULL if an error occurred (in which case *errno* is set
+use some of that space for its own metadata. _UW(vmem_create) returns an opaque memory pool handle or NULL if an error occurred (in which case *errno* is set
 appropriately). The opaque memory pool handle is then used with the other functions described in this man page that operate on a specific memory pool.
 
 This function can also be called with the **dir** argument pointing to a device
@@ -195,7 +165,7 @@ VMEM *vmem_create_in_region(void *addr, size_t size);
 The **vmem_create_in_region**() is an alternate **libvmem** entry point for creating a memory pool. It is for the rare case where an application needs to
 create a memory pool from an already memory-mapped region. Instead of allocating space from a given file system, **vmem_create_in_region**() is given the
 memory region explicitly via the *addr* and *size* arguments. Any data in the region is lost by calling **vmem_create_in_region**(), which will immediately
-store its own data structures for managing the pool there. Like !vmem_create above, the minimum *size* allowed is defined as **VMEM_MIN_POOL**. The *addr*
+store its own data structures for managing the pool there. Like _UW(vmem_create) above, the minimum *size* allowed is defined as **VMEM_MIN_POOL**. The *addr*
 argument must be page aligned. **vmem_create_in_region**() returns an opaque memory pool handle or NULL if an error occurred (in which case *errno* is set
 appropriately). Undefined behavior occurs if *addr* does not point to the contiguous memory region in the virtual address space of the calling process, or if
 the *size* is larger than the actual size of the memory region pointed by *addr*.
@@ -204,7 +174,7 @@ the *size* is larger than the actual size of the memory region pointed by *addr*
 void vmem_delete(VMEM *vmp);
 ```
 
-The **vmem_delete**() function releases the memory pool *vmp*. If the memory pool was created using !vmem_create, deleting it allows the space to be
+The **vmem_delete**() function releases the memory pool *vmp*. If the memory pool was created using _UW(vmem_create), deleting it allows the space to be
 reclaimed.
 
 ```c
@@ -319,26 +289,16 @@ default library behavior.
 
 
 ```c
-!ifdef{WIN32}
-{
-const char *vmem_check_versionU(
+_UWFUNC(vmem_check_version, _q_
 	unsigned major_required,
-	unsigned minor_required);
-const wchar_t *vmem_check_versionW(
-	unsigned major_required,
-	unsigned minor_required);
-}{
-const char *vmem_check_version(
-	unsigned major_required,
-	unsigned minor_required);
-}
+	unsigned minor_required_e_)
 ```
 
-The !vmem_check_version function is used to see if the installed **libvmem** supports the version of the library API required by an application. The
+The _UW(vmem_check_version) function is used to see if the installed **libvmem** supports the version of the library API required by an application. The
 easiest way to do this is for the application to supply the compile-time version information, supplied by defines in **\<libvmem.h\>**, like this:
 
 ```c
-reason = vmem_check_version!U{}(VMEM_MAJOR_VERSION,
+reason = _U(vmem_check_version)(VMEM_MAJOR_VERSION,
                             VMEM_MINOR_VERSION);
 if (reason != NULL) {
 	/* version check failed, reason string tells you why */
@@ -352,8 +312,8 @@ An application can also check specifically for the existence of an interface by 
 are documented in this man page as follows: unless otherwise specified, all interfaces described here are available in version 1.0 of the library. Interfaces
 added after version 1.0 will contain the text *introduced in version x.y* in the section of this manual describing the feature.
 
-When the version check performed by !vmem_check_version is successful, the return value is NULL. Otherwise the return value is a static string describing
-the reason for failing the version check. The string returned by !vmem_check_version must not be modified or freed.
+When the version check performed by _UW(vmem_check_version) is successful, the return value is NULL. Otherwise the return value is a static string describing
+the reason for failing the version check. The string returned by _UW(vmem_check_version) must not be modified or freed.
 
 ```c
 void vmem_set_funcs(
@@ -388,27 +348,21 @@ error is detected during the call to **libvmem** function, an application may re
 function:
 
 ```c
-!ifdef{WIN32}
-{
-const char *vmem_errormsgU(void);
-const wchar_t *vmem_errormsgW(void);
-}{
-const char *vmem_errormsg(void);
-}
+_UWFUNC(vmem_errormsg, void)
 ```
 
-The !vmem_errormsg function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
+The _UW(vmem_errormsg) function returns a pointer to a static buffer containing the last error message logged for current thread. The error message may
 include description of the corresponding error code (if *errno* was set), as returned by **strerror**(3). The error message buffer is thread-local; errors
 encountered in one thread do not affect its value in other threads. The buffer is never cleared by any library function; its content is significant only when
 the return value of the immediately preceding call to **libvmem** function indicated an error, or if *errno* was set. The application must not modify or free
 the error message string, but it may be modified by subsequent calls to other library functions.
 
 A second version of **libvmem**, accessed when a program uses
-the libraries under !ifdef{WIN32}{**/nvml/src/x64/Debug**}{**/usr/lib/nvml_debug**}, contains
+the libraries under _WINUX(**/nvml/src/x64/Debug**,**/usr/lib/nvml_debug**), contains
 run-time assertions and trace points. The typical way to
 access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to !ifdef{WIN32}{**/nvml/src/x64/Debug** or other location}
-{**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**} depending on where the debug
+**LD_LIBRARY_PATH** to _WINUX(**/nvml/src/x64/Debug** or other location,
+**/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug**), depending on where the debug
 libraries are installed on the system.
 The trace points in the debug version of the library are enabled using the environment variable
 **VMEM_LOG_LEVEL**, which can be set to the following values:
@@ -416,7 +370,7 @@ The trace points in the debug version of the library are enabled using the envir
 + **0** - This is the default level when **VMEM_LOG_LEVEL** is not set. Only statistics are logged, and then only in response to a call to **vmem_stats_print**().
 
 + **1** - Additional details on any errors detected are logged (in addition to returning the *errno*-based errors as usual). The same information may be
-retrieved using !vmem_errormsg.
+retrieved using _UW(vmem_errormsg).
 
 + **2** - A trace of basic operations including allocations and deallocations is logged.
 
@@ -449,9 +403,9 @@ main(int argc, char *argv[])
 	char *ptr;
 
 	/* create minimum size pool of memory */
-	if ((vmp = vmem_create!U{}("/pmem-fs",
+	if ((vmp = _U(vmem_create)("/pmem-fs",
 			VMEM_MIN_POOL)) == NULL) {
-		perror("vmem_create!U");
+		perror("_U(vmem_create)");
 		exit(1);
 	}
 

--- a/doc/libvmmalloc.3.md
+++ b/doc/libvmmalloc.3.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: LIBVMMALLOC!3
+title: _MP(LIBVMMALLOC, 3)
 header: NVM Library
 date: vmmalloc API version 1.0
 ...
@@ -61,7 +61,7 @@ or
 
 ```c
 #include <stdlib.h>
-#include <malloc.h>
+#include _BSDWX(<malloc_np.h>,<malloc.h>)
 #include <libvmmalloc.h>
 
 cc [ flag... ] file... -lvmmalloc [ library... ]
@@ -157,6 +157,7 @@ In case of large memory pools, creating a copy of the pool file may stall the fo
 + **3** - The library first attempts to create a copy of the memory pool (as for option #2), but if it fails (i.e. because of insufficient amount of free space
 on the file system), it will fall back to option #1.
 
+>NOTE: Options **2** and **3** are not currently supported on FreeBSD.
 
 # CAVEATS #
 
@@ -171,7 +172,7 @@ resources associated with that thread might not be cleaned up properly.
 Two versions of **libvmmalloc** are typically available on a development system. The normal version is optimized for performance. That version skips checks
 that impact performance and never logs any trace information or performs any run-time assertions. A second version, accessed when using the libraries under
 **/usr/lib/nvml_debug**, contains run-time assertions and trace points. The typical way to access the debug version is to set the environment variable
-**LD_LIBRARY_PATH** to **/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug** depending on where the debug libraries are installed on the system. The trace points
+**LD_LIBRARY_PATH** to **/usr/local/lib/nvml_debug**, **/usr/lib/nvml_debug** or **/usr/lib64/nvml_debug** depending on where the debug libraries are installed on the system. The trace points
 in the debug version of the library are enabled using the environment variable **VMMALLOC_LOG_LEVEL** which can be set to the following values:
 
 + **0** - Tracing is disabled. This is the default level when **VMMALLOC_LOG_LEVEL** is not set.
@@ -203,7 +204,7 @@ attempts to grow or shrink that memory pool.
 
 # BUGS #
 
-**libvmmalloc** may not work properly with the programs that perform **fork**(3) and do not call **exec**(3) immediately afterwards. See **ENVIRONMENT**
+**libvmmalloc** may not work properly with programs that perform **fork**(3) and do not call **exec**(3) immediately afterwards. See **ENVIRONMENT**
 section for more details about the experimental **fork**() support.
 
 If the trace points in the debug version of the library are enabled and the process performs fork, there is no new log file created for the child process, even

--- a/doc/macros.man
+++ b/doc/macros.man
@@ -28,53 +28,100 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# These macros are defined for the m4 preprocessor and are controlled by
+# the FREEBSD, WIN32 and WEB variables. These MUST be explicitly defined or
+# undefined on the m4 command line.
+#
+# This solution allows the maintenance of Windows, Linux and FreeBSD
+# documentation in the same file.
+#
+# The macros are:
+#
+#	_BSDWX(FreeBSD,WinLinux):
+#		Choose text based on FREEBSD. Both arguments are optional
+#		(although the comma must be present if FreeBSD is omitted).
+#		Bracket string with (_q_, _e_) if it contains commas.
+#	_MP(man_page_name, section):
+#		Include the man page section number if not building for WEB.
+#	_U(func_name):
+#		Append "U" to func_name if WIN32.
+# 	_UW(func_name):
+#		Emit **func_nameU**()/**func_nameW**() if WIN32.
+#	_UWFUNC(func_name, args):
+#		Define U and W prototypes of char/wchar_t *func_name if WIN32.
+#		Bracket args string with (_q_, _e_) if it is a comma-separated
+#		list.
+#	_UWFUNCR(ret_type, func_name, char_arg):
+#		Define U and W prototypes of ret_type func_name if WIN32.
+#		Single char/wchar_t argument is char_arg.
+#	_UWFUNCRUW(ret_type, func_name, args):
+#		Define U and W prototypes of ret_type[U/W] func_name if WIN32.
+#		Bracket args string with (_q_, _e_) if it is a comma-separated
+#		list.
+#	_UWFUNCR1(ret_type, func_name, char_arg, rest_of_args, comment):
+#		Define U and W prototypes of ret_type func_name if WIN32.
+#		First char/wchar_t argument is char_arg. Bracket rest_of_args
+#		string with (_q_, _e_) if it is a comma-separated list.
+#		Comment is added after prototype definition if present.
+#	_UWFUNCR12(ret_type, func_name, char_arg1, char_arg2, rest_of_args,
+#		   comment):
+#		Define U and W prototypes of ret_type func_name if WIN32.
+#		Two char/wchar_t arguments are char_arg1-2. Bracket
+#		rest_of_args string with (_q_, _e_) if it is a comma-separated
+#		list. Comment is added after prototype definition if present.
+#	_UWFUNCR1UW(ret_type, func_name, arg1_type, arg1, rest_of_args):
+#		Define U and W prototypes of ret_type func_name, append [U/W]
+#		to arg1_type arg1. Bracket rest_of_args string with (_q_, _e_)
+#		if it is a comma-separated list.
+#	_UWFUNCR2(ret_type, func_name, arg1, char_arg, rest_of_args, comment):
+#		Define U and W prototypes of ret_type func_name if WIN32.
+#		Second char/wchar_t argument is char_arg. Bracket rest_of_args
+#		string with (_q_, _e_) if it is a comma-separated list.
+#		Comment is added after prototype definition if present.
+#	_UWS(struct_name):
+#		Emit *struct struct_nameU*/*struct struct_nameW* if WIN32.
+#	_WINUX(Windows,UX):
+#		Choose text based on WIN32. Both arguments are optional
+#		(although the comma must be present if Windows is omitted).
+#		Bracket string with (_q_, _e_) if it contains commas.
 
-# Those macros are defined for pp - generic preprocessor
-# and they are imported while preprocessor execution, for example:
-# pp -DWIN32 -DWEB -import macros.man <input_md_file>
-
-# This solution allows the maintenance of Windows and Linux documentation in the same file.
-
-!def{pmem_map_file}{!ifdef{WIN32}{**pmem_map_fileU**()/**pmem_map_fileW**()}{**pmem_map_file**()}}
-!def{pmem_check_version}{!ifdef{WIN32}{**pmem_check_versionU**()/**pmem_check_versionW**()}{**pmem_check_version**()}}
-!def{pmem_errormsg}{!ifdef{WIN32}{**pmem_errormsgU**()/**pmem_errormsgW**()}{**pmem_errormsg**()}}
-
-!def{pmemlog_create}{!ifdef{WIN32}{**pmemlog_createU**()/**pmemlog_createW**()}{**pmemlog_create**()}}
-!def{pmemlog_open}{!ifdef{WIN32}{**pmemlog_openU**()/**pmemlog_openW**()}{**pmemlog_open**()}}
-!def{pmemlog_check}{!ifdef{WIN32}{**pmemlog_checkU**()/**pmemlog_checkW**()}{**pmemlog_check**()}}
-!def{pmemlog_check_version}{!ifdef{WIN32}{**pmemlog_check_versionU**()/**pmemlog_check_versionW**()}{**pmemlog_check_version**()}}
-!def{pmemlog_errormsg}{!ifdef{WIN32}{**pmemlog_errormsgU**()/**pmemlog_errormsgW**()}{**pmemlog_errormsg**()}}
-
-!def{pmemblk_create}{!ifdef{WIN32}{**pmemblk_createU**()/**pmemblk_createW**()}{**pmemblk_create**()}}
-!def{pmemblk_open}{!ifdef{WIN32}{**pmemblk_openU**()/**pmemblk_openW**()}{**pmemblk_open**()}}
-!def{pmemblk_check}{!ifdef{WIN32}{**pmemblk_checkU**()/**pmemblk_checkW**()}{**pmemblk_check**()}}
-!def{pmemblk_check_version}{!ifdef{WIN32}{**pmemblk_check_versionU**()/**pmemblk_check_versionW**()}{**pmemblk_check_version**()}}
-!def{pmemblk_errormsg}{!ifdef{WIN32}{**pmemblk_errormsgU**()/**pmemblk_errormsgW**()}{**pmemblk_errormsg**()}}
-
-!def{vmem_create}{!ifdef{WIN32}{**vmem_createU**()/**vmem_createW**()}{**vmem_create**()}}
-!def{vmem_errormsg}{!ifdef{WIN32}{**vmem_errormsgU**()/**vmem_errormsgW**()}{**vmem_errormsg**()}}
-!def{vmem_check_version}{!ifdef{WIN32}{**vmem_check_versionU**()/**vmem_check_versionW**()}{**vmem_check_version**()}}
-
-!def{pmempool_check}{!ifdef{WIN32}{**pmempool_checkU**()/**pmempool_checkW**()}{**pmempool_check**()}}
-!def{pmempool_sync}{!ifdef{WIN32}{**pmempool_syncU**()/**pmempool_syncW**()}{**pmempool_sync**()}}
-!def{pmempool_rm}{!ifdef{WIN32}{**pmempool_rmU**()/**pmempool_rmW**()}{**pmempool_rm**()}}
-!def{pmempool_transform}{!ifdef{WIN32}{**pmempool_transformU**()/**pmempool_transformW**()}{**pmempool_transform**()}}
-!def{pmempool_check_init}{!ifdef{WIN32}{**pmempool_check_initU**()/**pmempool_check_initW**()}{**pmempool_check_init**()}}
-!def{pmempool_check_version}{!ifdef{WIN32}{**pmempool_check_versionU**()/**pmempool_check_versionW**()}{**pmempool_check_version**()}}
-!def{pmempool_errormsg}{!ifdef{WIN32}{**pmempool_errormsgU**()/**pmempool_errormsgW**()}{**pmempool_errormsg**()}}
-!def{pmempool_check_status_ptr}{!ifdef{WIN32}{*struct pmempool_check_statusU\**/*struct pmempool_check_statusW\**}{*struct pmempool_check_status\**}}
-!def{pmempool_check_status}{!ifdef{WIN32}{*struct pmempool_check_statusU*/*struct pmempool_check_statusW*}{*struct pmempool_check_status*}}
-!def{pmempool_check_args}{!ifdef{WIN32}{*struct pmempool_check_argsU*/*struct pmempool_check_argsW*}{*struct pmempool_check_args*}}
-
-!def{pmemobj_check_version}{!ifdef{WIN32}{**pmemobj_check_versionU**()/**pmemobj_check_versionW**()}{**pmemobj_check_version**()}}
-!def{pmemobj_errormsg}{!ifdef{WIN32}{**pmemobj_errormsgU**()/**pmemobj_errormsgW**()}{**pmemobj_errormsg**()}}
-!def{pmemobj_create}{!ifdef{WIN32}{**pmemobj_createU**()/**pmemobj_createW**()}{**pmemobj_create**()}}
-!def{pmemobj_open}{!ifdef{WIN32}{**pmemobj_openU**()/**pmemobj_openW**()}{**pmemobj_open**()}}
-!def{pmemobj_check}{!ifdef{WIN32}{**pmemobj_checkU**()/**pmemobj_checkW**()}{**pmemobj_check**()}}
-!def{pmemobj_ctl_get}{!ifdef{WIN32}{**pmemobj_ctl_getU**()/**pmemobj_ctl_getW**()}{**pmemobj_ctl_get**()}}
-!def{pmemobj_ctl_set}{!ifdef{WIN32}{**pmemobj_ctl_setU**()/**pmemobj_ctl_setW**()}{**pmemobj_ctl_set**()}}
-
-!def{U}{!ifdef{WIN32}{U}}
-
-!def{3}{!ifdef{WEB}{}{(3)}}
-!def{1}{!ifdef{WEB}{}{(1)}}
+changequote(_q_,_e_)
+changecom()
+define(_BSDWX, ifdef(_q_FREEBSD_e_,$1,$2))
+define(_MP, ifdef(_q_WEB_e_,$1,$1($2)))
+define(_U, ifdef(_q_WIN32_e_,$1U,$1))
+define(_UW, ifdef(_q_WIN32_e_,**$1U**()/**$1W**(),**$1**()))
+define(_UWFUNC, ifdef(_q_WIN32_e_,
+const char *$1U($2);
+const wchar_t *$1W($2);,
+const char *$1($2);))
+define(_UWFUNCR, ifdef(_q_WIN32_e_,
+$1 $2U(const char $3);
+$1 $2W(const wchar_t $3);,
+$1 $2(const char $3);))
+define(_UWFUNCRUW, ifdef(_q_WIN32_e_,
+$1U $2U($3);
+$1W $2W($3);,
+$1 $2($3);))
+define(_UWFUNCR1, ifdef(_q_WIN32_e_,
+$1 $2U(const char $3, $4);$5
+$1 $2W(const wchar_t $3, $4);$5,
+$1 $2(const char $3, $4);$5))
+define(_UWFUNCR12, ifdef(_q_WIN32_e_,
+$1 $2U(const char $3,
+	const char $4, $5);$6
+$1 $2W(const wchar_t $3,
+	const wchar_t $4, $5);$6,
+$1 $2(const char $3,
+	const char $4, $5);$6))
+define(_UWFUNCR1UW, ifdef(_q_WIN32_e_,
+$1 $2U($3U $4, $5);
+$1 $2W($3W $4, $5);,
+$1 $2($3 $4, $5);))
+define(_UWFUNCR2, ifdef(_q_WIN32_e_,
+$1 $2U($3, const char $4, $5);$6
+$1 $2W($3, const wchar_t $4, $5);$6,
+$1 $2($3, const char $4, $5);$6))
+define(_UWS, ifdef(_q_WIN32_e_,*struct $1U*/*struct $1W*,*struct $1*))
+define(_WINUX, ifdef(_q_WIN32_e_,$1,$2))

--- a/doc/pmempool-check.1.md
+++ b/doc/pmempool-check.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-CHECK!1
+title: _MP(PMEMPOOL-CHECK, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-convert.1.md
+++ b/doc/pmempool-convert.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-CONVERT!1
+title: _MP(PMEMPOOL-CONVERT, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-create.1.md
+++ b/doc/pmempool-create.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-CREATE!1
+title: _MP(PMEMPOOL-CREATE, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-dump.1.md
+++ b/doc/pmempool-dump.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-DUMP!1
+title: _MP(PMEMPOOL-DUMP, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-info.1.md
+++ b/doc/pmempool-info.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-INFO!1
+title: _MP(PMEMPOOL-INFO, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-rm.1.md
+++ b/doc/pmempool-rm.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-RM!1
+title: _MP(PMEMPOOL-RM, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-sync.1.md
+++ b/doc/pmempool-sync.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-SYNC!1
+title: _MP(PMEMPOOL-SYNC, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool-transform.1.md
+++ b/doc/pmempool-transform.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL-TRANSFORM!1
+title: _MP(PMEMPOOL-TRANSFORM, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/pmempool.1.md
+++ b/doc/pmempool.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: PMEMPOOL!1
+title: _MP(PMEMPOOL, 1)
 header: NVM Library
 date: pmem Tools version 1.3
 ...

--- a/doc/rpmemd.1.md
+++ b/doc/rpmemd.1.md
@@ -1,7 +1,7 @@
 ---
 layout: manual
 Content-Style: 'text/css'
-title: RPMEMD!1
+title: _MP(RPMEMD, 1)
 header: NVM Library
 date: version 1.3
 ...

--- a/utils/md2man.sh
+++ b/utils/md2man.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -42,20 +42,37 @@
 #   section and version
 # - cut-off metadata block and license
 # - unindent code blocks
-# - cut-off windows and web specific parts of documentation using pp
+# - cut-off windows and web specific parts of documentation
 #
 
+set -e
 set -o pipefail
 
 filename=$1
 template=$2
 outfile=$3
-title=`sed -n 's/^title:\ *\([A-Za-z_-]*\).*$/\1/p' $filename`
-section=`sed -n 's/^title:.*\!\([0-9]\).*$/\1/p' $filename`
+title=`sed -n 's/^title:\ _MP(*\([A-Za-z_-]*\).*$/\1/p' $filename`
+section=`sed -n 's/^title:.*\([0-9]\))$/\1/p' $filename`
 version=`sed -n 's/^date:\ *\(.*\)$/\1/p' $filename`
 
-cat $filename | sed -n -e '/# NAME #/,$p' |\
-pp -import macros.man |\
+OPTS=
+if [ -v WIN32 ]; then
+OPTS="$OPTS -DWIN32"
+else
+OPTS="$OPTS -UWIN32"
+fi
+if [ "$(uname -s)" == "FreeBSD" ]; then
+OPTS="$OPTS -DFREEBSD"
+else
+OPTS="$OPTS -UFREEBSD"
+fi
+if [ -v WEB ]; then
+OPTS="$OPTS -DWEB"
+else
+OPTS="$OPTS -UWEB"
+fi
+
+m4 $OPTS macros.man $filename | sed -n -e '/# NAME #/,$p' |\
 pandoc -s -t man -o $outfile --template=$template \
     -V title=$title -V section=$section \
     -V date=$(date +"%F") -V version="$version" \


### PR DESCRIPTION
Use m4 for preprocessing docs.

Split from FreeBSD port. This PR should be merged after PR #2233.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2292)
<!-- Reviewable:end -->
