### PR TITLE
common: Shebang cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -74,6 +74,9 @@ ifeq ($(BUILD_RPMEM),y)
 	INSTALL_TARGETS += librpmem
 endif
 
+rwildcard=$(strip $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2)\
+	$(filter $(subst *,%,$2),$d)))
+
 SCOPE_SRC_DIRS = $(SCOPE_DIRS) include jemalloc/src
 SCOPE_HDR_DIRS = $(SCOPE_DIRS) include jemalloc/src\
 		jemalloc/include/jemalloc\
@@ -107,6 +110,8 @@ HEADERS =\
 ifneq ($(filter 1 2, $(CSTYLEON)),)
 TMP_HEADERS := $(addprefix debug/, $(addsuffix tmp, $(HEADERS)))
 endif
+
+SCRIPTS = $(call rwildcard,,*.sh)
 
 debug/%.htmp: %.h
 	$(call check-cstyle, $<, $@)
@@ -210,6 +215,7 @@ uninstall:
 
 cstyle:
 	$(STYLE_CHECK) check $(HEADERS)
+	$(CHECK_SHEBANG) $(SCRIPTS)
 
 format:
 	$(STYLE_CHECK) format $(HEADERS)

--- a/src/common.inc
+++ b/src/common.inc
@@ -41,6 +41,7 @@ CP = cp
 CSTYLE = $(TOP)/utils/cstyle
 CSTYLEON = 0
 STYLE_CHECK = $(TOP)/utils/style_check.sh
+CHECK_SHEBANG = $(TOP)/utils/check-shebang.sh
 CHECK_OS = $(TOP)/utils/check-os.sh
 OS_BANNED = $(TOP)/utils/os-banned
 COVERAGE = 0

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -374,7 +374,10 @@ sparse  : TARGET = sparse
 DIR_SYNC=$(TOP)/src/test/.sync-dir
 SYNC_EXT=synced
 
-all test cstyle format sparse: $(TESTS_BUILD)
+all test format sparse: $(TESTS_BUILD)
+
+cstyle: $(TESTS_BUILD)
+	$(CHECK_SHEBANG) $(foreach dir,$(TESTS_BUILD),$(dir)/TEST? $(dir)/TEST??)
 
 clean clobber: $(TESTS_BUILD)
 	$(RM) -r $(DIR_SYNC)

--- a/src/test/rpmem_basic/TEST12
+++ b/src/test/rpmem_basic/TEST12
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright 2016, Intel Corporation
+# Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +30,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+rwildcard=$(strip $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2)\
+	$(filter $(subst *,%,$2),$d)))
+
+SCRIPTS = $(call rwildcard,,*.sh)
+
 all:
 	$(MAKE) -C check_license $@
 
@@ -44,6 +49,7 @@ clobber:
 
 cstyle:
 	$(MAKE) -C check_license $@
+	./check-shebang.sh $(SCRIPTS)
 
 format:
 	$(MAKE) -C check_license $@

--- a/utils/build-dpkg.sh
+++ b/utils/build-dpkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # build-dpkg.sh - Script for building deb packages
 #
+
+set -e
 
 SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/pkg-common.sh

--- a/utils/build-rpm.sh
+++ b/utils/build-rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2014-2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # build-rpm.sh - Script for building rpm packages
 #
+
+set -e
 
 SCRIPT_DIR=$(dirname $0)
 source $SCRIPT_DIR/pkg-common.sh

--- a/utils/check-shebang.sh
+++ b/utils/check-shebang.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2017, Intel Corporation
+# Copyright 2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,40 +30,32 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
+# utils/check-shebang.sh -- interpreter directive check script
 #
-# md2man.sh -- convert markdown to groff man pages
-#
-# usage: md2man.sh file template outfile
-#
-# This script converts markdown file into groff man page using pandoc.
-# It performs some pre- and post-processing for better results:
-# - parse input file for YAML metadata block and read man page title,
-#   section and version
-# - cut-off metadata block and license
-# - unindent code blocks
-# - cut-off windows and web specific parts of documentation using pp
-#
-
 set -e
-set -o pipefail
 
-filename=$1
-template=$2
-outfile=$3
-title=`sed -n 's/^title:\ *\([A-Za-z_-]*\).*$/\1/p' $filename`
-section=`sed -n 's/^title:.*\!\([0-9]\).*$/\1/p' $filename`
-version=`sed -n 's/^date:\ *\(.*\)$/\1/p' $filename`
+err_count=0
 
-cat $filename | sed -n -e '/# NAME #/,$p' |\
-pp -import macros.man |\
-pandoc -s -t man -o $outfile --template=$template \
-    -V title=$title -V section=$section \
-    -V date=$(date +"%F") -V version="$version" \
-    -V year=$(date +"%Y") |
-sed '/^\.IP/{
-N
-/\n\.nf/{
-	s/IP/PP/
-    }
-}'
+for file in $@ ; do
+        [ ! -f $file ] && continue
+	SHEBANG=`head -n1 $file | cut -d" " -f1`
+	[ "${SHEBANG:0:2}" != "#!" ] && continue
+	if [ "$SHEBANG" != "#!/usr/bin/env" -a $SHEBANG != "#!/bin/sh" ]; then
+		INTERP=`echo $SHEBANG | rev | cut -d"/" -f1 | rev`
+		echo "$file:1: error: invalid interpreter directive:" >&2
+		echo "	(is: \"$SHEBANG\", should be: \"#!/usr/bin/env $INTERP\")" >&2
+		((err_count+=1))
+	fi
+done
+
+if [ "$err_count" == "0" ]; then
+	echo "Interpreter directives are OK."
+else
+	echo "Found $err_count errors in interpreter directives!" >&2
+	err_count=1
+fi
+
+exit $err_count
+
+
+

--- a/utils/docker/build-local.sh
+++ b/utils/docker/build-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -47,6 +47,8 @@
 # - tests with Device Dax are not supported by pcheck yet, so do not provide
 #   these devices in your configuration
 #
+
+set -e
 
 # Environment variables that can be customized (default values are after dash):
 export KEEP_CONTAINER=${KEEP_CONTAINER:-0}

--- a/utils/docker/build-travis.sh
+++ b/utils/docker/build-travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -36,6 +36,8 @@
 #
 # this script is for building NVML on Travis only
 #
+
+set -e
 
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
 	&& "$COVERITY" -eq 1 ]]; then

--- a/utils/docker/configure-tests.sh
+++ b/utils/docker/configure-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -34,6 +34,8 @@
 # configure-tests.sh - is called inside a Docker container; configures tests
 #                      and ssh server for use during build of NVML project.
 #
+
+set -e
 
 # Configure tests
 cat << EOF > $WORKDIR/src/test/testconfig.sh

--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -38,6 +38,8 @@
 #
 # The script can be run locally.
 #
+
+set -e
 
 function usage {
 	echo "Usage:"

--- a/utils/docker/images/install-libcxx.sh
+++ b/utils/docker/images/install-libcxx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # install-libcxx.sh - installs a customized version of libcxx
 #
+
+set -e
 
 llvm_url=https://github.com/llvm-mirror/llvm.git
 libcxxabi_url=https://github.com/llvm-mirror/libcxxabi.git

--- a/utils/docker/images/install-libfabric.sh
+++ b/utils/docker/images/install-libfabric.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # install-libfabric.sh - installs a customized version of libfabric
 #
+
+set -e
 
 # Keep in sync with requirements in src/common.inc.
 libfabric_ver=1.4.2

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # install-valgrind.sh - installs valgrind for persistent memory
 #
+
+set -e
 
 git clone --recursive --depth 1 https://github.com/pmem/valgrind.git
 cd valgrind

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -38,6 +38,8 @@
 # Docker Hub. The variables can be set in the Travis project's configuration
 # for automated builds.
 #
+
+set -e
 
 function usage {
 	echo "Usage:"

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -35,6 +35,8 @@
 #                        the environment inside a Docker container for
 #                        running build of NVML project.
 #
+
+set -e
 
 # Mount filesystem for tests
 echo $USERPASS | sudo -S mount -t tmpfs none /tmp -osize=6G

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -46,6 +46,8 @@
 # If the Docker image does not have to be rebuilt, it will be pulled from
 # Docker Hub.
 #
+
+set -e
 
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
 	&& "$COVERITY" -eq 1 ]]; then

--- a/utils/docker/run-build-package.sh
+++ b/utils/docker/run-build-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -34,6 +34,8 @@
 # run-build-package.sh - is called inside a Docker container; prepares
 #                        the environment and starts a build of NVML project.
 #
+
+set -e
 
 # Prepare build enviromnent
 ./prepare-for-build.sh

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2016-2017, Intel Corporation
 #
@@ -34,6 +34,8 @@
 # run-build.sh - is called inside a Docker container; prepares the environment
 #                and starts a build of NVML project.
 #
+
+set -e
 
 # Prepare build environment
 ./prepare-for-build.sh

--- a/utils/docker/run-coverage.sh
+++ b/utils/docker/run-coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -34,6 +34,8 @@
 # run-coverage.sh - is called inside a Docker container; runs the coverage
 #                   test
 #
+
+set -e
 
 # Get and prepare NVML source
 ./prepare-for-build.sh

--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright 2017, Intel Corporation
 #
@@ -33,6 +33,8 @@
 #
 # run-coverity.sh - runs the Coverity scan build
 #
+
+set -e
 
 # Prepare build environment
 ./prepare-for-build.sh

--- a/utils/pkg-common.sh
+++ b/utils/pkg-common.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Copyright 2014-2017, Intel Corporation
 #

--- a/utils/pkg-config.sh
+++ b/utils/pkg-config.sh
@@ -1,6 +1,5 @@
-#!/bin/bash
 #
-# Copyright 2014-2016, Intel Corporation
+# Copyright 2014-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/utils/style_check.sh
+++ b/utils/style_check.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#
 # Copyright 2016-2017, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Change all remaining shell scripts to use #!/usr/bin/env bash.
Remove #! and execute permission from scripts not desgined to
be run directly.
Add utils/check-shebang.sh and call from cstyle target.