### PR TITLE
rpmem: do not use tabs in rpmemd log

### DIFF
--- a/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
+++ b/src/test/obj_rpmem_basic_integration/node_0_rpmemd20.log.match
@@ -2,22 +2,22 @@ rpmemd version $(nW)
 ssh connection: $(*)
 user: $(nW)
 configuration
-	pool set directory: '$(*)'
-	persist method: $(*)
-	number of threads: $(*)
+    pool set directory: '$(*)'
+    persist method: $(*)
+    number of threads: $(*)
 create request:
-	pool descriptor: 'testset_remote'
-	pool size: 18837504
-	nlanes: $(nW)
-	provider: $(nW)
+    pool descriptor: 'testset_remote'
+    pool size: 18837504
+    nlanes: $(nW)
+    provider: $(nW)
 pool attributes:
-	signature: 'PMEMOBJ'
-	major: 4
-	compat_features: 0x0
-	incompat_features: 0x0
-	ro_compat_features: 0x0
-	poolset_uuid: $(nW)
-	uuid: $(nW)
-	next_uuid: $(nW)
-	prev_uuid: $(nW)
+    signature: 'PMEMOBJ'
+    major: 4
+    compat_features: 0x0
+    incompat_features: 0x0
+    ro_compat_features: 0x0
+    poolset_uuid: $(nW)
+    uuid: $(nW)
+    next_uuid: $(nW)
+    prev_uuid: $(nW)
 cannot create pool set -- '$(nW)/test_obj_rpmem_basic_integration/testset_remote': Invalid argument

--- a/src/test/rpmem_basic/out10.log.match
+++ b/src/test/rpmem_basic/out10.log.match
@@ -1,6 +1,6 @@
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_msync
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_msync
 persistency policy:
-	persist method: Appliance Persistency Method
-	persist flush: none
+    persist method: Appliance Persistency Method
+    persist flush: none

--- a/src/test/rpmem_basic/out11.log.match
+++ b/src/test/rpmem_basic/out11.log.match
@@ -1,6 +1,6 @@
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_msync
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_msync
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_persist
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_persist

--- a/src/test/rpmemd_util/stdout0.log.match
+++ b/src/test/rpmemd_util/stdout0.log.match
@@ -1,13 +1,13 @@
 rpmemd_util/TEST0: START: rpmemd_util
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_msync
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_msync
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_persist
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_persist
 persistency policy:
-	persist method: General Purpose Server Persistency Method
-	persist flush: pmem_msync
+    persist method: General Purpose Server Persistency Method
+    persist flush: pmem_msync
 persistency policy:
-	persist method: Appliance Persistency Method
-	persist flush: none
+    persist method: Appliance Persistency Method
+    persist flush: none

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -234,10 +234,11 @@ err_fip_init:
 static void
 rpmemd_print_req_attr(const struct rpmem_req_attr *req)
 {
-	RPMEMD_LOG(NOTICE, "\tpool descriptor: '%s'", _str(req->pool_desc));
-	RPMEMD_LOG(NOTICE, "\tpool size: %lu", req->pool_size);
-	RPMEMD_LOG(NOTICE, "\tnlanes: %u", req->nlanes);
-	RPMEMD_LOG(NOTICE, "\tprovider: %s",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "pool descriptor: '%s'",
+			_str(req->pool_desc));
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "pool size: %lu", req->pool_size);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "nlanes: %u", req->nlanes);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "provider: %s",
 			rpmem_provider_to_str(req->provider));
 }
 
@@ -247,16 +248,22 @@ rpmemd_print_req_attr(const struct rpmem_req_attr *req)
 static void
 rpmemd_print_pool_attr(const struct rpmem_pool_attr *attr)
 {
-	RPMEMD_LOG(INFO, "\tsignature: '%s'", _str(attr->signature));
-	RPMEMD_LOG(INFO, "\tmajor: %u", attr->major);
-	RPMEMD_LOG(INFO, "\tcompat_features: 0x%x", attr->compat_features);
-	RPMEMD_LOG(INFO, "\tincompat_features: 0x%x", attr->incompat_features);
-	RPMEMD_LOG(INFO, "\tro_compat_features: 0x%x",
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "signature: '%s'",
+			_str(attr->signature));
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "major: %u", attr->major);
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "compat_features: 0x%x",
+			attr->compat_features);
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "incompat_features: 0x%x",
+			attr->incompat_features);
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "ro_compat_features: 0x%x",
 			attr->ro_compat_features);
-	RPMEMD_LOG(INFO, "\tpoolset_uuid: %s", uuid2str(attr->poolset_uuid));
-	RPMEMD_LOG(INFO, "\tuuid: %s", uuid2str(attr->uuid));
-	RPMEMD_LOG(INFO, "\tnext_uuid: %s", uuid2str(attr->next_uuid));
-	RPMEMD_LOG(INFO, "\tprev_uuid: %s", uuid2str(attr->prev_uuid));
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "poolset_uuid: %s",
+			uuid2str(attr->poolset_uuid));
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "uuid: %s", uuid2str(attr->uuid));
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "next_uuid: %s",
+			uuid2str(attr->next_uuid));
+	RPMEMD_LOG(INFO, RPMEMD_LOG_INDENT "prev_uuid: %s",
+			uuid2str(attr->prev_uuid));
 }
 
 /*
@@ -265,11 +272,11 @@ rpmemd_print_pool_attr(const struct rpmem_pool_attr *attr)
 static void
 rpmemd_print_resp_attr(const struct rpmem_resp_attr *attr)
 {
-	RPMEMD_LOG(NOTICE, "\tport: %u", attr->port);
-	RPMEMD_LOG(NOTICE, "\trkey: 0x%lx", attr->rkey);
-	RPMEMD_LOG(NOTICE, "\traddr: 0x%lx", attr->raddr);
-	RPMEMD_LOG(NOTICE, "\tnlanes: %u", attr->nlanes);
-	RPMEMD_LOG(NOTICE, "\tpersist method: %s",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "port: %u", attr->port);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "rkey: 0x%lx", attr->rkey);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "raddr: 0x%lx", attr->raddr);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "nlanes: %u", attr->nlanes);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "persist method: %s",
 			rpmem_persist_method_to_str(attr->persist_method));
 }
 
@@ -683,11 +690,12 @@ rpmemd_print_info(struct rpmemd *rpmemd)
 			_str(os_getenv("SSH_CONNECTION")));
 	RPMEMD_LOG(NOTICE, "user: %s", _str(os_getenv("USER")));
 	RPMEMD_LOG(NOTICE, "configuration");
-	RPMEMD_LOG(NOTICE, "\tpool set directory: '%s'",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "pool set directory: '%s'",
 			_str(rpmemd->config.poolset_dir));
-	RPMEMD_LOG(NOTICE, "\tpersist method: %s",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "persist method: %s",
 			rpmem_persist_method_to_str(rpmemd->persist_method));
-	RPMEMD_LOG(NOTICE, "\tnumber of threads: %lu", rpmemd->nthreads);
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "number of threads: %lu",
+			rpmemd->nthreads);
 	RPMEMD_DBG("\tpersist APM: %s",
 		bool2str(rpmemd->config.persist_apm));
 	RPMEMD_DBG("\tpersist GPSPM: %s",

--- a/src/tools/rpmemd/rpmemd_log.h
+++ b/src/tools/rpmemd/rpmemd_log.h
@@ -34,18 +34,30 @@
  * rpmemd_log.h -- rpmemd logging functions declarations
  */
 
+#include <string.h>
+#include "util.h"
+
 #define FORMAT_PRINTF(a, b) __attribute__((__format__(__printf__, (a), (b))))
+
+/*
+ * A tab character is not allowed in rpmemd log because it is not well handled
+ * by syslog. Please use RPMEMD_LOG_INDENT instead.
+ */
+#define RPMEMD_LOG_INDENT "    "
 
 #ifdef DEBUG
 #define RPMEMD_LOG(level, fmt, arg...)\
+	COMPILE_ERROR_ON(strchr(fmt, '\t') != 0);\
 	rpmemd_log(RPD_LOG_##level, __FILE__, __LINE__, fmt, ## arg)
 #else
 #define RPMEMD_LOG(level, fmt, arg...)\
+	COMPILE_ERROR_ON(strchr(fmt, '\t') != 0);\
 	rpmemd_log(RPD_LOG_##level, NULL, 0, fmt, ## arg)
 #endif
 
 #ifdef DEBUG
 #define RPMEMD_DBG(fmt, arg...)\
+	COMPILE_ERROR_ON(strchr(fmt, '\t') != 0);\
 	rpmemd_log(_RPD_LOG_DBG, __FILE__, __LINE__, fmt, ## arg)
 #else
 #define RPMEMD_DBG(fmt, arg...) do {} while (0)

--- a/src/tools/rpmemd/rpmemd_util.c
+++ b/src/tools/rpmemd/rpmemd_util.c
@@ -87,9 +87,9 @@ static void
 rpmem_print_pm_policy(enum rpmem_persist_method persist_method,
 		int (*persist)(const void *addr, size_t len))
 {
-	RPMEMD_LOG(NOTICE, "\tpersist method: %s",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "persist method: %s",
 			rpmem_persist_method_to_str(persist_method));
-	RPMEMD_LOG(NOTICE, "\tpersist flush: %s",
+	RPMEMD_LOG(NOTICE, RPMEMD_LOG_INDENT "persist flush: %s",
 			rpmemd_persist_to_str(persist));
 }
 


### PR DESCRIPTION
rpmemd log may end in syslog which does not handle a tab character properly.

Ref: pmem/issues#622

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2297)
<!-- Reviewable:end -->
