### PR TITLE
test: disable Valgrind in vmem_multiple_pools #1

### DIFF
--- a/src/test/vmem_multiple_pools/TEST1
+++ b/src/test/vmem_multiple_pools/TEST1
@@ -45,6 +45,10 @@ require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
 
+# TEST2/TEST3 are specifically for helgrind/drd tests
+configure_valgrind helgrind force-disable
+configure_valgrind drd force-disable
+
 setup
 
 expect_normal_exit ./vmem_multiple_pools$EXESUFFIX $DIR 16 16


### PR DESCRIPTION
Tests #2/#3 are specifically for helgrind/drd tests.
Test #1 should never be executed under valgrind, even if force-enabled
via command-line options.

Ref: pmem/issues#664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2299)
<!-- Reviewable:end -->
