### PR TITLE
test: reduce number of pools in vmem_multi_pools

### DIFF
--- a/src/test/vmem_multiple_pools/TEST1
+++ b/src/test/vmem_multiple_pools/TEST1
@@ -47,7 +47,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit ./vmem_multiple_pools$EXESUFFIX $DIR 16 16
+expect_normal_exit ./vmem_multiple_pools$EXESUFFIX $DIR 4 16
 
 check
 

--- a/src/test/vmem_multiple_pools/TEST1.PS1
+++ b/src/test/vmem_multiple_pools/TEST1.PS1
@@ -49,7 +49,7 @@ require_build_type debug nondebug
 
 setup
 
-expect_normal_exit $Env:EXE_DIR\vmem_multiple_pools$Env:EXESUFFIX $DIR 16 16
+expect_normal_exit $Env:EXE_DIR\vmem_multiple_pools$Env:EXESUFFIX $DIR 4 16
 
 check
 

--- a/src/test/vmem_multiple_pools/out1.log.match
+++ b/src/test/vmem_multiple_pools/out1.log.match
@@ -1,4 +1,4 @@
 vmem_multiple_pools$(nW)TEST1: START: vmem_multiple_pools
- $(nW)vmem_multiple_pools$(nW) $(nW) 16 16
-create 16 pools in 16 thread(s)
+ $(nW)vmem_multiple_pools$(nW) $(nW) 4 16
+create 4 pools in 16 thread(s)
 vmem_multiple_pools$(nW)TEST1: DONE


### PR DESCRIPTION
Originally, there could be 256 pools created simultaneously (>3.6GB).
Now, it is only 64 pools (900MB).

Ref: pmem/issues#670

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2300)
<!-- Reviewable:end -->
