### PR TITLE
obj: Allow building with memcheck or DRD

### DIFF
--- a/src/libpmemobj/bucket.c
+++ b/src/libpmemobj/bucket.c
@@ -83,7 +83,7 @@ bucket_insert_block(struct bucket *b, const struct memory_block *m)
 	if (On_valgrind) {
 		size_t size = m->m_ops->get_real_size(m);
 		void *data = m->m_ops->get_real_data(m);
-		VALGRIND_MAKE_MEM_NOACCESS(data, size);
+		VALGRIND_DO_MAKE_MEM_NOACCESS(data, size);
 		VALGRIND_ANNOTATE_NEW_MEMORY(data, size);
 	}
 #endif


### PR DESCRIPTION
Building with both worked, but building with only one of them meant trying to use a macro that was never defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2309)
<!-- Reviewable:end -->
