### PR TITLE
test: disable drd in libpmempool_api/TEST11

### DIFF
--- a/src/test/libpmempool_api/TEST11
+++ b/src/test/libpmempool_api/TEST11
@@ -46,6 +46,7 @@ require_fs_type any
 configure_valgrind memcheck force-disable
 configure_valgrind pmemcheck force-disable
 configure_valgrind helgrind force-disable
+configure_valgrind drd force-disable
 
 setup
 


### PR DESCRIPTION
The test calls mmap with a size argument specifying one
terabyte, which just apprently DRD is not happy about.

Fixes pmem/issues#668

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2310)
<!-- Reviewable:end -->
