### PR TITLE
benchmark: add mixed allocator workload

### DIFF
--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -61,15 +61,16 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-
 #include <util.h>
 
 #include "benchmark_time.hpp"
+#include "os.h"
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #endif
 #define RRAND(max, min) (rand() % ((max) - (min)) + (min))
+#define RRAND_R(seed, max, min) (os_rand_r(seed) % ((max) - (min)) + (min))
 
 struct benchmark;
 


### PR DESCRIPTION
A simple benchmark that mixes allocations and deallocations in a single run. This workload puts a strain on the memory reuse mechanisms in the heap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2314)
<!-- Reviewable:end -->
