### PR TITLE
common: pmemcheck fixes for FreeBSD

### DIFF
--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1097,6 +1097,12 @@ obj_runtime_init(PMEMobjpool *pop, int rdonly, int boot, unsigned nlanes)
 		return -1;
 	}
 
+	VALGRIND_REMOVE_PMEM_MAPPING(&pop->mutex_head,
+		sizeof(pop->mutex_head));
+	VALGRIND_REMOVE_PMEM_MAPPING(&pop->rwlock_head,
+		sizeof(pop->rwlock_head));
+	VALGRIND_REMOVE_PMEM_MAPPING(&pop->cond_head,
+		sizeof(pop->cond_head));
 	pop->mutex_head = NULL;
 	pop->rwlock_head = NULL;
 	pop->cond_head = NULL;

--- a/src/test/obj_list/obj_list_mocks.c
+++ b/src/test/obj_list/obj_list_mocks.c
@@ -34,6 +34,7 @@
  * obj_list_mocks.c -- mocks for redo/lane/heap/obj modules
  */
 
+#include "valgrind_internal.h"
 #include "obj_list.h"
 
 /*
@@ -123,6 +124,16 @@ FUNC_MOCK_RUN_DEFAULT
 	Pop->is_pmem = is_pmem;
 	Pop->rdonly = 0;
 	Pop->uuid_lo = 0x12345678;
+
+	VALGRIND_REMOVE_PMEM_MAPPING(&Pop->mutex_head,
+		sizeof(Pop->mutex_head));
+	VALGRIND_REMOVE_PMEM_MAPPING(&Pop->rwlock_head,
+		sizeof(Pop->rwlock_head));
+	VALGRIND_REMOVE_PMEM_MAPPING(&Pop->cond_head,
+		sizeof(Pop->cond_head));
+	Pop->mutex_head = NULL;
+	Pop->rwlock_head = NULL;
+	Pop->cond_head = NULL;
 
 	if (Pop->is_pmem) {
 		Pop->persist_local = pmem_persist;

--- a/src/test/pmem_valgr_simple/pmemcheck0.log.match
+++ b/src/test/pmem_valgr_simple/pmemcheck0.log.match
@@ -5,14 +5,37 @@
 ==$(N)== Parent PID: $(N)
 ==$(N)== 
 ==$(N)== 
-==$(N)== Number of stores not made persistent: 3
+$(OPT)==$(N)== Number of stores not made persistent: 3
+$(OPX)==$(N)== Number of stores not made persistent: 10
 ==$(N)== Stores not made persistent properly:
 ==$(N)== [0]    at 0x$(X): main (pmem_valgr_simple.c:$(N))
 ==$(N)== 	Address: 0x$(X)	size: 4	state: DIRTY
 ==$(N)== [1]    at 0x$(X): $(nW)memset$(nW) ($(*))
 ==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
-==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
-==$(N)== [2]    at 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
+$(OPX)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+$(OPT)==$(N)== [$(N)]    at 0x$(X): $(nW)memset$(nW) ($(*))
+$(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
+$(OPT)==$(N)== 	Address: 0x$(X)	size: 1	state: DIRTY
+==$(N)== [$(N)]    at 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FLUSHED
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 2	state: FENCED
 ==$(N)== Total memory not made persistent: 14
@@ -22,4 +45,5 @@ $(OPT)==$(N)== Overwritten stores before they were made persistent:
 $(OPT)==$(N)== [0]    at 0x$(X): $(nW)memset ($(*))
 $(OPT)==$(N)==    by 0x$(X): main (pmem_valgr_simple.c:$(N))
 $(OPT)==$(N)== 	Address: 0x$(X)	size: 8	state: DIRTY
-==$(N)== ERROR SUMMARY: 3 errors
+$(OPT)==$(N)== ERROR SUMMARY: 3 errors
+$(OPX)==$(N)== ERROR SUMMARY: 10 errors


### PR DESCRIPTION
Need to mark lock list heads as non-persistent.
Memset on FreeBSD does 8 1-byte writes in pmem_valgr_simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2316)
<!-- Reviewable:end -->
