### PR TITLE
common: extend the travis' timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 before_install:
   - export HOST_WORKDIR=`pwd`
   - cd utils/docker
-  - ./pull-or-rebuild-image.sh
+  - travis_wait 20 ./pull-or-rebuild-image.sh
   - if [[ -f push_image_to_repo_flag ]]; then PUSH_THE_IMAGE=1; fi
   - rm -f push_image_to_repo_flag
 


### PR DESCRIPTION
Sometimes pulling a docker image doesn't produce any output to the Travis log for more than 10 minutes. 10 minutes is the default time Travis waits for a new log entry and fails the build if no entry appears.
This path extends the timeout to 20 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2317)
<!-- Reviewable:end -->
