### PR TITLE
Jemalloc lock order fixes

### DIFF
--- a/src/jemalloc/include/jemalloc/internal/chunk.h
+++ b/src/jemalloc/include/jemalloc/internal/chunk.h
@@ -48,9 +48,12 @@ void	chunk_record(pool_t *pool, extent_tree_t *chunks_szad,
 	extent_tree_t *chunks_ad, void *chunk, size_t size, bool zeroed);
 bool	chunk_global_boot();
 bool	chunk_boot(pool_t *pool);
-void	chunk_prefork(pool_t *pool);
-void	chunk_postfork_parent(pool_t *pool);
-void	chunk_postfork_child(pool_t *pool);
+void	chunk_prefork0(pool_t *pool);
+void	chunk_prefork1(pool_t *pool);
+void	chunk_postfork_parent0(pool_t *pool);
+void	chunk_postfork_parent1(pool_t *pool);
+void	chunk_postfork_child0(pool_t *pool);
+void	chunk_postfork_child1(pool_t *pool);
 
 #endif /* JEMALLOC_H_EXTERNS */
 /******************************************************************************/

--- a/src/jemalloc/src/chunk.c
+++ b/src/jemalloc/src/chunk.c
@@ -437,26 +437,42 @@ chunk_boot(pool_t *pool)
 }
 
 void
-chunk_prefork(pool_t *pool)
+chunk_prefork0(pool_t *pool)
 {
 
-	malloc_mutex_prefork(&pool->chunks_mtx);
 	if (config_ivsalloc)
 		rtree_prefork(pool->chunks_rtree);
 }
 
 void
-chunk_postfork_parent(pool_t *pool)
+chunk_prefork1(pool_t *pool)
+{
+
+	malloc_mutex_prefork(&pool->chunks_mtx);
+}
+
+void
+chunk_postfork_parent0(pool_t *pool)
 {
 	if (config_ivsalloc)
 		rtree_postfork_parent(pool->chunks_rtree);
+}
+
+void
+chunk_postfork_parent1(pool_t *pool)
+{
 	malloc_mutex_postfork_parent(&pool->chunks_mtx);
 }
 
 void
-chunk_postfork_child(pool_t *pool)
+chunk_postfork_child0(pool_t *pool)
 {
 	if (config_ivsalloc)
 		rtree_postfork_child(pool->chunks_rtree);
+}
+
+void
+chunk_postfork_child1(pool_t *pool)
+{
 	malloc_mutex_postfork_child(&pool->chunks_mtx);
 }

--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -2974,10 +2974,11 @@ _malloc_prefork(void)
 		}
 	}
 
-	FOREACH_POOL(chunk_prefork);
+	FOREACH_POOL(chunk_prefork0);
+	FOREACH_POOL(base_prefork);
+	FOREACH_POOL(chunk_prefork1);
 	chunk_dss_prefork();
 
-	FOREACH_POOL(base_prefork);
 
 	FOREACH_POOL(huge_prefork);
 }
@@ -3002,10 +3003,11 @@ _malloc_postfork(void)
 	/* Release all mutexes, now that fork() has completed. */
 	FOREACH_POOL(huge_postfork_parent);
 
-	FOREACH_POOL(base_postfork_parent);
 
 	chunk_dss_postfork_parent();
-	FOREACH_POOL(chunk_postfork_parent);
+	FOREACH_POOL(chunk_postfork_parent1);
+	FOREACH_POOL(base_postfork_parent);
+	FOREACH_POOL(chunk_postfork_parent0);
 
 	for (i = 0; i < npools; i++) {
 		pool = pools[i];
@@ -3034,10 +3036,11 @@ jemalloc_postfork_child(void)
 	/* Release all mutexes, now that fork() has completed. */
 	FOREACH_POOL(huge_postfork_child);
 
-	FOREACH_POOL(base_postfork_child);
 
 	chunk_dss_postfork_child();
-	FOREACH_POOL(chunk_postfork_child);
+	FOREACH_POOL(chunk_postfork_child1);
+	FOREACH_POOL(base_postfork_child);
+	FOREACH_POOL(chunk_postfork_child0);
 
 	for (i = 0; i < npools; i++) {
 		pool = pools[i];


### PR DESCRIPTION
Ref: pmem/issues#665
Ref: pmem/issues#639

There are some more bugs around fork in vmmalloc/jemalloc, so the vmmalloc_fork tests still fail with helgrind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2318)
<!-- Reviewable:end -->
