### PR TITLE
obj: fix pool's C++ persist and flush functions

### DIFF
--- a/src/include/libpmemobj++/pool.hpp
+++ b/src/include/libpmemobj++/pool.hpp
@@ -305,7 +305,7 @@ public:
 	void
 	persist(const persistent_ptr<Y> &ptr) noexcept
 	{
-		pmemobj_persist(this->pop, ptr.get(), sizeof(Y));
+		pmemobj_persist(this->pop, &ptr, sizeof(ptr));
 	}
 
 	/**
@@ -341,7 +341,7 @@ public:
 	void
 	flush(const persistent_ptr<Y> &ptr) noexcept
 	{
-		pmemobj_flush(this->pop, ptr.get(), sizeof(Y));
+		pmemobj_flush(this->pop, &ptr, sizeof(ptr));
 	}
 
 	/**

--- a/src/include/libpmemobj++/pool.hpp
+++ b/src/include/libpmemobj++/pool.hpp
@@ -305,7 +305,7 @@ public:
 	void
 	persist(const persistent_ptr<Y> &ptr) noexcept
 	{
-		pmemobj_persist(this->pop, &ptr, sizeof(ptr));
+		pmemobj_persist(this->pop, ptr.get(), sizeof(Y));
 	}
 
 	/**
@@ -341,7 +341,7 @@ public:
 	void
 	flush(const persistent_ptr<Y> &ptr) noexcept
 	{
-		pmemobj_flush(this->pop, &ptr, sizeof(ptr));
+		pmemobj_flush(this->pop, ptr.get(), sizeof(Y));
 	}
 
 	/**

--- a/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
+++ b/src/test/obj_cpp_ptr/obj_cpp_ptr.cpp
@@ -143,7 +143,7 @@ test_ptr_atomic(nvobj::pool<root> &pop)
 	UT_ASSERTne(pfoo.get(), nullptr);
 
 	(*pfoo).bar = TEST_INT;
-	pop.persist(pfoo);
+	pop.persist(&pfoo->bar, sizeof(pfoo->bar));
 	pop.memset_persist(pfoo->arr, TEST_CHAR, sizeof(pfoo->arr));
 
 	for (auto c : pfoo->arr) {


### PR DESCRIPTION
Persist and flush functions should be performed on the persistent
object, not the smart pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2319)
<!-- Reviewable:end -->
