### PR TITLE
common: use O_TMPFILE to create temporary files

### DIFF
--- a/src/test/vmmalloc_init/TEST3
+++ b/src/test/vmmalloc_init/TEST3
@@ -55,7 +55,7 @@ export TEST_LD_PRELOAD=libvmmalloc.so
 
 expect_abnormal_exit ./vmmalloc_init$EXESUFFIX 2> stderr$UNITTEST_NUM.log
 
-$GREP -E 'VMMALLOC_POOL_SIZE|VMMALLOC_POOL_DIR|TMPDIR|mkstemp|size\ 4321' \
+$GREP -E 'VMMALLOC_POOL_SIZE|VMMALLOC_POOL_DIR|TMPDIR|mkstemp|open|size\ 4321' \
     vmmalloc$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 
 check

--- a/src/test/vmmalloc_init/TEST4
+++ b/src/test/vmmalloc_init/TEST4
@@ -55,7 +55,7 @@ export TEST_LD_PRELOAD=libvmmalloc.so
 
 expect_abnormal_exit ./vmmalloc_init$EXESUFFIX 2> stderr$UNITTEST_NUM.log
 
-$GREP -E 'VMMALLOC_POOL_SIZE|VMMALLOC_POOL_DIR|TMPDIR|mkstemp|size\ 4321' \
+$GREP -E 'VMMALLOC_POOL_SIZE|VMMALLOC_POOL_DIR|TMPDIR|mkstemp|open|size\ 4321' \
     vmmalloc$UNITTEST_NUM.log > grep$UNITTEST_NUM.log
 
 check

--- a/src/test/vmmalloc_init/grep3.log.match
+++ b/src/test/vmmalloc_init/grep3.log.match
@@ -1,1 +1,2 @@
-<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)mkstemp: No such file or directory
+$(OPT)<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)mkstemp: No such file or directory
+$(OPX)<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)open: No such file or directory

--- a/src/test/vmmalloc_init/grep4.log.match
+++ b/src/test/vmmalloc_init/grep4.log.match
@@ -1,1 +1,2 @@
-<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)mkstemp: $(*)
+$(OPT)<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)mkstemp: $(*)
+$(OPX)<libvmmalloc>: <1> [$(*) util_tmpfile]$(W)open: $(*)


### PR DESCRIPTION
This affects vmem, vmmalloc and pmemdetect (tool we use in tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2322)
<!-- Reviewable:end -->
