### PR TITLE
pmem: fix using O_TMPFILE

### DIFF
--- a/src/common/os_linux.c
+++ b/src/common/os_linux.c
@@ -34,6 +34,8 @@
  * os_linux.c -- Linux abstraction layer
  */
 
+#define _GNU_SOURCE
+
 #include <fcntl.h>
 #include <stdarg.h>
 #include <sys/file.h>
@@ -55,7 +57,13 @@
 int
 os_open(const char *pathname, int flags, ...)
 {
-	if (flags & O_CREAT) {
+	int mode_required = (flags & O_CREAT) == O_CREAT;
+
+#ifdef O_TMPFILE
+	mode_required |= (flags & O_TMPFILE) == O_TMPFILE;
+#endif
+
+	if (mode_required) {
 		va_list arg;
 		va_start(arg, flags);
 		/* Clang requires int due to auto-promotion */

--- a/src/libpmem/pmem.c
+++ b/src/libpmem/pmem.c
@@ -536,14 +536,6 @@ pmem_is_pmem(const void *addr, size_t len)
 #define PMEM_DAX_VALID_FLAGS\
 	(PMEM_FILE_CREATE|PMEM_FILE_SPARSE)
 
-#ifndef USE_O_TMPFILE
-#ifdef O_TMPFILE
-#define USE_O_TMPFILE 1
-#else
-#define USE_O_TMPFILE 0
-#endif
-#endif
-
 /*
  * pmem_map_fileU -- create or open the file and map it to memory
  */
@@ -624,18 +616,6 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 		return NULL;
 	}
 
-#if USE_O_TMPFILE
-
-	if (flags & PMEM_FILE_TMPFILE)
-		open_flags |= O_TMPFILE;
-
-	if ((fd = os_open(path, open_flags, mode)) < 0) {
-		ERR("!open %s", path);
-		return NULL;
-	}
-
-#else
-
 	if (flags & PMEM_FILE_TMPFILE) {
 		if ((fd = util_tmpfile(path,
 					OS_DIR_SEP_STR"pmem.XXXXXX")) < 0) {
@@ -651,8 +631,6 @@ pmem_map_fileU(const char *path, size_t len, int flags,
 		if ((flags & PMEM_FILE_CREATE) && (flags & PMEM_FILE_EXCL))
 			delete_on_err = 1;
 	}
-
-#endif
 
 	if (flags & PMEM_FILE_CREATE) {
 		if (flags & PMEM_FILE_SPARSE) {


### PR DESCRIPTION
Since util_tmpfile() already uses O_TMPFILE flag if it's supported,
there is no need to deal with O_TMPFILE in pmem.c anymore.

If O_CREAT or O_TMPFILE flag is specified then mode argument is
mandatory and os_open() must pass it to open().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2324)
<!-- Reviewable:end -->
