### PR TITLE
test: Disable drd, helgrind in vmmalloc_fork tests

### DIFF
--- a/src/test/vmmalloc_fork/TEST1
+++ b/src/test/vmmalloc_fork/TEST1
@@ -47,6 +47,11 @@ require_fs_type any
 require_build_type debug nondebug
 require_no_asan
 
+# This test uses pthread mutexes across fork, and recreates them in the child
+# process.
+configure_valgrind helgrind force-disable
+configure_valgrind drd force-disable
+
 setup
 
 export VMMALLOC_POOL_SIZE=$((64 * 1024 * 1024))

--- a/src/test/vmmalloc_fork/TEST3
+++ b/src/test/vmmalloc_fork/TEST3
@@ -47,6 +47,11 @@ require_fs_type any
 require_build_type debug nondebug
 require_no_asan
 
+# This test uses pthread mutexes across fork, and recreates them in the child
+# process.
+configure_valgrind helgrind force-disable
+configure_valgrind drd force-disable
+
 setup
 
 export VMMALLOC_POOL_SIZE=$((64 * 1024 * 1024))


### PR DESCRIPTION
Ref: pmem/issues#639
Ref: pmem/issues#665

Apparently valgrind just can't handle the way jemalloc
uses mutexes across forks, as demonstrated by this
dummy program:

```
$ cat dummy.c
pthread_mutex_t dummy = PTHREAD_MUTEX_INITIALIZER;

static void prefork(void)
{
	pthread_mutex_lock(&dummy);
}

static void postfork_child(void)
{
	pthread_mutexattr_t attr;

	if (pthread_mutexattr_init(&attr) != 0)
	        abort();
	if (pthread_mutex_init(&dummy, &attr) != 0) {
	        pthread_mutexattr_destroy(&attr);
	        abort();
	}
	pthread_mutexattr_destroy(&attr);
}

static void postfork_parent(void)
{
	pthread_mutex_unlock(&dummy);
}

int main()
{
	pthread_atfork(prefork,
	    postfork_parent, postfork_child);
	fork();
	pthread_mutex_lock(&dummy);
	pthread_mutex_unlock(&dummy);
}
$ cc -pthread dummy.c -o dummy
$ valgrind --tool=helgrind ./dummy 2>&1 | grep holds
==26890== Thread #1: Exiting thread still holds 1 lock
$ valgrind --tool=drd ./dummy 2>&1 | grep -i mutex
==26898== Mutex reinitialization:
		mutex 0x30a040, recursion count 1, owner 1.
==26898==    at 0x4C385F0: pthread_mutex_init
==26898== mutex 0x30a040 was first observed at:
==26898==    at 0x4C390D3: pthread_mutex_lock
==26898== Recursive locking not allowed:
		mutex 0x30a040, recursion count 1, owner 1.
==26898==    at 0x4C390D3: pthread_mutex_lock
==26898== mutex 0x30a040 was first observed at:
==26898==    at 0x4C390D3: pthread_mutex_lock
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2328)
<!-- Reviewable:end -->
