### PR TITLE
test: force-disable drd in vmmalloc_init tests

### DIFF
--- a/src/test/vmmalloc_init/TEST16
+++ b/src/test/vmmalloc_init/TEST16
@@ -52,6 +52,7 @@ require_no_freebsd
 # loaded with RTLD_DEEPBIND.
 configure_valgrind memcheck force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 configure_valgrind helgrind force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
+configure_valgrind drd force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 
 setup
 

--- a/src/test/vmmalloc_init/TEST6
+++ b/src/test/vmmalloc_init/TEST6
@@ -52,6 +52,7 @@ require_no_freebsd
 # loaded with RTLD_DEEPBIND.
 configure_valgrind memcheck force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 configure_valgrind helgrind force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
+configure_valgrind drd force-disable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 
 setup
 


### PR DESCRIPTION
All valgrind tools should be disabled for this tests.

Ref pmem/issues#666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2331)
<!-- Reviewable:end -->
