### PR TITLE
common: util_map_proc asan compatibility

### DIFF
--- a/src/common/mmap.h
+++ b/src/common/mmap.h
@@ -51,6 +51,7 @@ extern "C" {
 
 extern int Mmap_no_random;
 extern void *Mmap_hint;
+extern char *Mmap_mapfile;
 
 void *util_map(int fd, size_t len, int flags, int rdonly, size_t req_align);
 int util_unmap(void *addr, size_t len);

--- a/src/common/mmap_linux.c
+++ b/src/common/mmap_linux.c
@@ -43,6 +43,8 @@
 
 #define PROCMAXLEN 2048 /* maximum expected line length in /proc files */
 
+char *Mmap_mapfile = OS_MAPFILE; /* Should be modified only for testing */
+
 #ifdef __FreeBSD__
 static const char *sscanf_os = "%p %p";
 #else
@@ -67,12 +69,11 @@ char *
 util_map_hint_unused(void *minaddr, size_t len, size_t align)
 {
 	LOG(3, "minaddr %p len %zu align %zu", minaddr, len, align);
-
 	ASSERT(align > 0);
 
 	FILE *fp;
-	if ((fp = os_fopen(OS_MAPFILE, "r")) == NULL) {
-		ERR("!%s", OS_MAPFILE);
+	if ((fp = os_fopen(Mmap_mapfile, "r")) == NULL) {
+		ERR("!%s", Mmap_mapfile);
 		return MAP_FAILED;
 	}
 

--- a/src/test/util_map_proc/TEST6
+++ b/src/test/util_map_proc/TEST6
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Copyright 2015-2017, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#
+# src/test/util_map_proc/TEST6 -- unit test for util_map /proc parsing
+#
+export UNITTEST_NUM=6
+export UNITTEST_NAME=util_map_proc/TEST$UNITTEST_NUM
+
+# standard unit test setup
+. ../unittest/unittest.sh
+
+require_test_type medium
+
+require_fs_type none
+require_procfs
+configure_valgrind memcheck force-disable
+
+setup
+
+export PMEM_MMAP_HINT=0
+
+mapfile="mapfile_nonexistent"
+expect_normal_exit ./util_map_proc$EXESUFFIX $mapfile 0x12345678
+
+check
+
+pass

--- a/src/test/util_map_proc/out0.log.match
+++ b/src/test/util_map_proc/out0.log.match
@@ -2,12 +2,8 @@ util_map_proc/TEST0: START: util_map_proc
  ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
 redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x$(X)
-redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0x$(X)
-redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x$(X)
-redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x$(X)
-redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x$(X)
 util_map_proc/TEST0: DONE

--- a/src/test/util_map_proc/out1.log.match
+++ b/src/test/util_map_proc/out1.log.match
@@ -2,12 +2,8 @@ util_map_proc/TEST1: START: util_map_proc
  ./util_map_proc$(nW) maps_none$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
 redirecting /proc/$(*) to maps_none$(*)
 len 1048576: (nil) 0x$(X)
-redirecting /proc/$(*) to maps_none$(*)
 len 16777216: (nil) 0x$(X)
-redirecting /proc/$(*) to maps_none$(*)
 len 1073741824: (nil) 0x$(X)
-redirecting /proc/$(*) to maps_none$(*)
 len 17179869184: (nil) 0x$(X)
-redirecting /proc/$(*) to maps_none$(*)
 len 274877906944: (nil) 0x$(X)
 util_map_proc/TEST1: DONE

--- a/src/test/util_map_proc/out2.log.match
+++ b/src/test/util_map_proc/out2.log.match
@@ -2,12 +2,8 @@ util_map_proc/TEST2: START: util_map_proc
  ./util_map_proc$(nW) maps_align$(*) 0x0001000000 0x0001100000 0x0001110000 0x0001110800 0x0001111000
 redirecting /proc/$(*) to maps_align$(*)
 len 16777216: 0x10080000000 0x$(X)
-redirecting /proc/$(*) to maps_align$(*)
 len 17825792: 0x10080000000 0x$(X)
-redirecting /proc/$(*) to maps_align$(*)
 len 17891328: 0x10080000000 0x$(X)
-redirecting /proc/$(*) to maps_align$(*)
 len 17893376: (nil) 0x$(X)
-redirecting /proc/$(*) to maps_align$(*)
 len 17895424: (nil) 0x$(X)
 util_map_proc/TEST2: DONE

--- a/src/test/util_map_proc/out3.log.match
+++ b/src/test/util_map_proc/out3.log.match
@@ -2,12 +2,8 @@ util_map_proc/TEST3: START: util_map_proc
  ./util_map_proc$(nW) maps_end$(*) 0x0000100000 0x0001000000 0x003F000000 0x003FFFF000 0x0040000000
 redirecting /proc/$(*) to maps_end$(*)
 len 1048576: 0xffffffffc0000000 0x$(X)
-redirecting /proc/$(*) to maps_end$(*)
 len 16777216: 0xffffffffc0000000 0x$(X)
-redirecting /proc/$(*) to maps_end$(*)
 len 1056964608: 0xffffffffc0000000 0x$(X)
-redirecting /proc/$(*) to maps_end$(*)
 len 1073737728: 0xffffffffc0000000 0x$(X)
-redirecting /proc/$(*) to maps_end$(*)
 len 1073741824: 0xffffffffffffffff 0x$(X)
 util_map_proc/TEST3: DONE

--- a/src/test/util_map_proc/out4.log.match
+++ b/src/test/util_map_proc/out4.log.match
@@ -1,18 +1,9 @@
 util_map_proc/TEST4: START: util_map_proc
  ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
 redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x2e000000000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0x2e000000000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x2e000000000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x2e000000000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x800000000000
 util_map_proc/TEST4: DONE

--- a/src/test/util_map_proc/out5.log.match
+++ b/src/test/util_map_proc/out5.log.match
@@ -1,18 +1,9 @@
 util_map_proc/TEST5: START: util_map_proc
  ./util_map_proc$(nW) maps_all$(*) 0x0000100000 0x0001000000 0x0040000000 0x0400000000 0x4000000000
 redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 1048576: 0x100c0000000 0x1000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 16777216: 0x10100000000 0xa00000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 1073741824: 0x10240000000 0x2800000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 17179869184: 0x102c0000000 0x40000000
-redirecting /proc/$(*) to maps_all$(*)
-redirecting /proc/$(*) to maps_all$(*)
 len 274877906944: 0x10800000000 0x3300000000
 util_map_proc/TEST5: DONE

--- a/src/test/util_map_proc/out6.log.match
+++ b/src/test/util_map_proc/out6.log.match
@@ -1,0 +1,5 @@
+util_map_proc/TEST6: START: util_map_proc
+ ./util_map_proc$(nW) mapfile_nonexistent 0x12345678
+redirecting /proc/$(*) to mapfile_nonexistent
+len 305419896: 0xffffffffffffffff 0xffffffffffffffff
+util_map_proc/TEST6: DONE

--- a/src/test/util_map_proc/util_map_proc.c
+++ b/src/test/util_map_proc/util_map_proc.c
@@ -47,30 +47,6 @@
 #define GIGABYTE ((uintptr_t)1 << 30)
 #define TERABYTE ((uintptr_t)1 << 40)
 
-static char *Sfile;
-
-/*
- * fopen -- interpose on libc fopen()
- *
- * This catches opens to /proc/self/maps and sends them to the fake maps
- * file being tested.
- */
-FILE *
-fopen(const char *path, const char *mode)
-{
-	static FILE *(*fopen_ptr)(const char *path, const char *mode);
-
-	if (strcmp(path, OS_MAPFILE) == 0) {
-		UT_OUT("redirecting " OS_MAPFILE " to %s", Sfile);
-		path = Sfile;
-	}
-
-	if (fopen_ptr == NULL)
-		fopen_ptr = dlsym(RTLD_NEXT, "fopen");
-
-	return (*fopen_ptr)(path, mode);
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -82,7 +58,8 @@ main(int argc, char *argv[])
 	if (argc < 3)
 		UT_FATAL("usage: %s maps_file len [len]...", argv[0]);
 
-	Sfile = argv[1];
+	Mmap_mapfile = argv[1];
+	UT_OUT("redirecting " OS_MAPFILE " to %s", Mmap_mapfile);
 
 	for (int arg = 2; arg < argc; arg++) {
 		size_t len = (size_t)strtoull(argv[arg], NULL, 0);


### PR DESCRIPTION
Support llvm address sanitizer in test/util_map_proc.
Llvm address sanitizer interposes fopen, so util_map_proc
cannot also interpose it. It is not possible to address
this at runtime.
Change util_map_hint* to take alternate map file argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2335)
<!-- Reviewable:end -->
