### PR TITLE
test: obj_lane test fix

### DIFF
--- a/src/test/obj_lane/obj_lane.c
+++ b/src/test/obj_lane/obj_lane.c
@@ -50,6 +50,9 @@
 #define MOCK_RUNTIME (void *)(0xABC)
 #define MOCK_RUNTIME_2 (void *)(0xBCD)
 
+#define MOCK_LAYOUT (void *)(0xAAA)
+#define MOCK_LAYOUT_2 (void *)(0xBBB)
+
 #define LOG_PREFIX "trace"
 #define LOG_LEVEL_VAR "TRACE_LOG_LEVEL"
 #define LOG_FILE_VAR "TRACE_LOG_FILE"
@@ -223,10 +226,12 @@ test_lane_hold_release(void)
 	struct lane mock_lane = {
 		.sections = {
 			[LANE_SECTION_ALLOCATOR] = {
-				.runtime = MOCK_RUNTIME
+				.runtime = MOCK_RUNTIME,
+				.layout = MOCK_LAYOUT
 			},
 			[LANE_SECTION_LIST] = {
-				.runtime = MOCK_RUNTIME_2
+				.runtime = MOCK_RUNTIME_2,
+				.layout = MOCK_LAYOUT_2
 			}
 		}
 	};


### PR DESCRIPTION
set lane layout to non-null value because drd gives assertion fail
when calling VALGRIND_ANNOTATE_NEW_MEMORY with null pointer

Ref pmem/issues#661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2343)
<!-- Reviewable:end -->
