### PR TITLE
obj: check for null in ringbuf_dequeue_s

### DIFF
--- a/src/libpmemobj/ringbuf.c
+++ b/src/libpmemobj/ringbuf.c
@@ -318,7 +318,8 @@ ringbuf_dequeue_s(struct ringbuf *rbuf, size_t data_size)
 	LOG(4, NULL);
 
 	void *r = ringbuf_dequeue(rbuf);
-	VALGRIND_ANNOTATE_NEW_MEMORY(r, data_size);
+	if (r != NULL)
+		VALGRIND_ANNOTATE_NEW_MEMORY(r, data_size);
 
 	return r;
 }


### PR DESCRIPTION
check if pointer is null before calling VALGRIND_ANNOTATE_NEW_MEMORY

Ref pmem/issues#660

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2344)
<!-- Reviewable:end -->
