### PR TITLE
test: Required build types in ex_libpmemobj/TEST17

### DIFF
--- a/src/test/ex_libpmemobj/TEST17
+++ b/src/test/ex_libpmemobj/TEST17
@@ -40,6 +40,7 @@ export UNITTEST_NUM=17
 # standard unit test setup
 . ../unittest/unittest.sh
 
+require_build_type debug nondebug
 require_test_type medium
 
 setup


### PR DESCRIPTION
The test only executes the same executable with all
test-build-types, there is no statically linked version
examples/libpmemobj/list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2350)
<!-- Reviewable:end -->
