### PR TITLE
jemalloc and vmmalloc fixes

### DIFF
--- a/src/jemalloc/src/jemalloc.c
+++ b/src/jemalloc/src/jemalloc.c
@@ -2914,7 +2914,7 @@ je_malloc_usable_size(JEMALLOC_USABLE_SIZE_CONST void *ptr)
  * trigger the deadlock described above, but doing so would involve forking via
  * a library constructor that runs before jemalloc's runs.
  */
-JEMALLOC_ATTR(constructor)
+JEMALLOC_ATTR(constructor(102))
 static void
 jemalloc_constructor(void)
 {
@@ -2922,7 +2922,7 @@ jemalloc_constructor(void)
 	malloc_init();
 }
 
-JEMALLOC_ATTR(destructor)
+JEMALLOC_ATTR(destructor(101))
 static void
 jemalloc_destructor(void)
 {

--- a/src/test/unittest/ut.c
+++ b/src/test/unittest/ut.c
@@ -198,6 +198,11 @@ unsigned long Ut_pagesize;
 unsigned long long Ut_mmap_align;
 os_mutex_t Sigactions_lock;
 
+static char Buff_out[MAXPRINT];
+static char Buff_err[MAXPRINT];
+static char Buff_trace[MAXPRINT];
+static char Buff_stdout[MAXPRINT];
+
 /*
  * flags that control output
  */
@@ -779,10 +784,10 @@ ut_start_common(const char *file, int line, const char *func,
 		exit(1);
 	}
 
-	setlinebuf(Outfp);
-	setlinebuf(Errfp);
-	setlinebuf(Tracefp);
-	setlinebuf(stdout);
+	setvbuf(Outfp, Buff_out, _IOLBF, MAXPRINT);
+	setvbuf(Errfp, Buff_err, _IOLBF, MAXPRINT);
+	setvbuf(Tracefp, Buff_trace, _IOLBF, MAXPRINT);
+	setvbuf(stdout, Buff_stdout, _IOLBF, MAXPRINT);
 
 	prefix(file, line, func, 0);
 	vout(OF_LOUD|OF_NAME, "START", fmt, ap);


### PR DESCRIPTION
fixed proper library destruction order (before this patch
jemalloc destructor was called before vmmalloc's) and ignore
calls to free after vmmalloc is destroyed

Ref pmem/issues#659

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2368)
<!-- Reviewable:end -->
