### PR TITLE
test: disable obj_basic_integration/10 under asan

### DIFF
--- a/src/test/obj_basic_integration/TEST10
+++ b/src/test/obj_basic_integration/TEST10
@@ -40,6 +40,7 @@ export UNITTEST_NUM=10
 require_test_type medium
 require_command $STRACE
 require_dax_devices 1
+require_no_asan
 
 # covered by TEST5
 configure_valgrind memcheck force-disable


### PR DESCRIPTION
This test verifies that there are no msync issued on the device
dax mapped region, but it seems that asan calls msync on its own
and pollutes the strace output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2378)
<!-- Reviewable:end -->
