### PR TITLE
obj: fix definition of SIZEOF_RUN macro

### DIFF
--- a/src/libpmemobj/heap.c
+++ b/src/libpmemobj/heap.c
@@ -52,7 +52,8 @@
 #include "os_thread.h"
 
 /* calculates the size of the entire run, including any additional chunks */
-#define SIZEOF_RUN(runp, size_idx) (sizeof(*run) + ((size_idx - 1) * CHUNKSIZE))
+#define SIZEOF_RUN(runp, size_idx)\
+	(sizeof(*(runp)) + (((size_idx) - 1) * CHUNKSIZE))
 
 #define MAX_RUN_LOCKS 1024
 


### PR DESCRIPTION
Ref: pmem/issues#694

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2389)
<!-- Reviewable:end -->
