### PR TITLE
common: Fix FreeBSD breakage

### DIFF
--- a/src/common/os_linux.c
+++ b/src/common/os_linux.c
@@ -221,6 +221,20 @@ os_setenv(const char *name, const char *value, int overwrite)
 }
 
 /*
+ * secure_getenv -- provide GNU secure_getenv for FreeBSD
+ */
+#ifdef __FreeBSD__
+static char *
+secure_getenv(const char *name)
+{
+	if (issetugid() != 0)
+		return NULL;
+
+	return getenv(name);
+}
+#endif
+
+/*
  * os_getenv -- getenv abstraction layer
  */
 char *

--- a/src/test/vmmalloc_dummy_funcs/Makefile
+++ b/src/test/vmmalloc_dummy_funcs/Makefile
@@ -40,7 +40,12 @@ BUILD_STATIC=n
 
 include ../Makefile.inc
 
-libvmmalloc_dummy_funcs.so: $(OBJS)
-	$(CC) $(CFLAGS) -fPIC -shared -Wl,-soname,libvmmalloc_dummy_funcs.so -o $@
+libvmmalloc_dummy_funcs.so: vmmalloc_dummy_funcs.c
+	$(CC) $(CFLAGS) -fPIC -shared -Wl,-soname,libvmmalloc_dummy_funcs.so -o $@ $^
 
 all: libvmmalloc_dummy_funcs.so
+
+clobber: libvmmalloc_dummy_funcs_clean
+
+libvmmalloc_dummy_funcs_clean:
+	$(RM) libvmmalloc_dummy_funcs.so


### PR DESCRIPTION
Address issues introduced in PR #2357 and #2384.
Add secure_getenv function in os_linux.c (not in FreeBSD).
Fix dependencies, add clean/clobber in vmmalloc_dummy_funcs
Makefile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2391)
<!-- Reviewable:end -->
