### PR TITLE
doc: Doc cleanup, Ref pmem/issues#701

### DIFF
--- a/doc/libpmemblk/pmemblk_create.3.md
+++ b/doc/libpmemblk/pmemblk_create.3.md
@@ -111,7 +111,7 @@ parts of the pool set.
 For more information on pool set format, see **poolset**(5).
 
 The _UW(pmemblk_open) function opens an existing block memory pool.
-As with _UW(pmemlog_create), *path* must identify either an existing
+As with _UW(pmemblk_create), *path* must identify either an existing
 block memory pool file, or the *set* file used to create a pool set.
 The application must have permission to open the file and memory map the
 file or pool set with read/write permissions. If *bsize* is non-zero,
@@ -172,4 +172,6 @@ fail if the underlying file system does not support **posix_fallocate**(3).
 
 
 # SEE ALSO #
-**pmempool**(1), **posix_fallocate**(3), **libpmemblk**(7) and **<http://pmem.io>**
+**pmempool**(1), **creat**(2), **pmemblk_nblock**(3),
+**posix_fallocate**(3), **poolset**(5),
+**libpmemblk**(7) and **<http://pmem.io>**

--- a/doc/libpmemobj/pmemobj_mutex_zero.3.md
+++ b/doc/libpmemobj/pmemobj_mutex_zero.3.md
@@ -94,18 +94,20 @@ int pmemobj_cond_wait(PMEMobjpool *pop, PMEMcond *restrict condp,
 
 **libpmemobj**(7) provides several types of synchronization primitives
 designed to be used with persistent memory. The pmem-aware lock implementation
-is based on the standard POSIX Thread Library, as described in
-**pthread_mutex**(3), **pthread_rwlock**(3) and **pthread_cond**(3).
-Pmem-aware locks provide semantics similar to standard **pthread** locks,
-except that they are embedded in pmem-resident objects and
-are considered initialized by zeroing them. Therefore, locks allocated
-with **pmemobj_zalloc**(3) or **pmemobj_tx_zalloc**(3) do not require another
-initialization step. For performance reasons, they are also padded up to 64
-bytes (cache line size). _BSDWX(=q=Since all **pthread** locks are dynamically
-allocated on FreeBSD, while the lock object is still padded up to 64 bytes
+is based on the standard POSIX Threads Library, as described in
+**pthread_mutex_init**(3), **pthread_rwlock_init**(3) and
+**pthread_cond_init**(3). Pmem-aware locks provide semantics similar to
+standard **pthread** locks, except that they are embedded in pmem-resident
+objects and are considered initialized by zeroing them. Therefore, locks
+allocated with **pmemobj_zalloc**(3) or **pmemobj_tx_zalloc**(3) do not require
+another initialization step. For performance reasons, they are also padded up
+to 64 bytes (cache line size).
+
+On FreeBSD, since all **pthread** locks are dynamically
+allocated, while the lock object is still padded up to 64 bytes
 for consistency with Linux, only the pointer to the lock is embedded in the
 pmem-resident object. **libpmemobj**(7) transparently manages freeing of the
-locks when the pool is closed.=e=)
+locks when the pool is closed.
 
 The fundamental property of pmem-aware locks is their automatic
 reinitialization every time the persistent object store pool is opened. Thus,
@@ -222,6 +224,6 @@ number will be returned to indicate the error.
 
 # SEE ALSO #
 
-**pmemobj_tx_zalloc**(3), **pmemobj_zalloc**(3), **pthread_cond**(3),
-**pthread_mutex**(3), **pthread_rwlock**(3), **libpmem**(7), **libpmemobj**(7)
-and **<http://pmem.io>**
+**pmemobj_tx_zalloc**(3), **pmemobj_zalloc**(3), **pthread_cond_init**(3),
+**pthread_mutex_init**(3), **pthread_rwlock_init**(3), **libpmem**(7),
+**libpmemobj**(7) and **<http://pmem.io>**

--- a/doc/libvmem/libvmem.7.md
+++ b/doc/libvmem/libvmem.7.md
@@ -115,7 +115,7 @@ of those pools.
 Under normal usage, **libvmem** will never print messages or intentionally
 cause the process to exit. Exceptions to this are prints caused by calls to
 **vmem_stats_print**(3), or by enabling debugging as described under
-**DEBUGGING AND ERROR HANDLING** below. The library uses **pthreads**(7) to be
+**DEBUGGING AND ERROR HANDLING** below. The library uses **pthreads** to be
 fully MT-safe, but never creates or destroys threads itself. The library does
 not make use of any signals, networking, and never calls **select**(2) or
 **poll**(2). The system memory allocation routines like **malloc**(3) and
@@ -299,6 +299,14 @@ by the SNIA NVM Programming Technical Work Group:
 
 # SEE ALSO #
 
-**mmap**(2), **dlclose**(3), **malloc**(3), **jemalloc**(3),
+**mmap**(2), **dlclose**(3), **malloc**(3),
 **strerror**(3), **vmem_create**(3), **vmem_malloc**(3),
-**pthreads**(7) and **<http://pmem.io>**
+and **<http://pmem.io>**
+
+On Linux:
+
+**jemalloc**(3), **pthreads**(7)
+
+On FreeBSD:
+
+**pthread**(3)

--- a/doc/libvmmalloc/libvmmalloc.7.md
+++ b/doc/libvmmalloc/libvmmalloc.7.md
@@ -63,7 +63,11 @@ or
 
 ```c
 #include <stdlib.h>
-#include _BSDWX(<malloc_np.h>,<malloc.h>)
+#ifndef __FreeBSD__
+    #include <malloc.h>
+#else
+    #include <malloc_np.h>
+#endif
 #include <libvmmalloc.h>
 
 cc [ flag... ] file... -lvmmalloc [ library... ]
@@ -284,8 +288,14 @@ lifting of managing dynamic memory allocation. See:
 
 # SEE ALSO #
 
-**fork**(2), **dlclose(3)**, **exec**(3), **jemalloc**(3),
-**malloc**(3), **malloc_hook**(3),
+**fork**(2), **dlclose(3)**, **exec**(3), **malloc**(3),
 **malloc_usable_size**(3), **posix_memalign**(3),
-**libpmem**(7), **libvmem**(7), **pthreads**(7),
-**ld.so**(_BSDWX(1,8)) and **<http://pmem.io>**
+**libpmem**(7), **libvmem**(7) and **<http://pmem.io>**
+
+On Linux:
+
+**jemalloc**(3), **malloc_hook**(3), **pthreads**(7), **ld.so**(8)
+
+On FreeBSD:
+
+**ld.so**(1), **pthread**(3)


### PR DESCRIPTION
Merge Linux and FreeBSD man pages.
Remove _BSDWX macros from pmemobj_mutex_zero.3.md
and libvmmalloc.7.md.
Fix cross references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2398)
<!-- Reviewable:end -->
