### PR TITLE
pmem: fix pmem_map_file behavior

### DIFF
--- a/src/common/file.h
+++ b/src/common/file.h
@@ -79,7 +79,7 @@ ssize_t util_file_pread(const char *path, void *buffer, size_t size,
 ssize_t util_file_pwrite(const char *path, const void *buffer, size_t size,
 	os_off_t offset);
 
-int util_tmpfile(const char *dir, const char *templ);
+int util_tmpfile(const char *dir, const char *templ, int flags);
 int util_is_absolute_path(const char *path);
 
 int util_file_create(const char *path, size_t size, size_t minsize);

--- a/src/common/file_linux.c
+++ b/src/common/file_linux.c
@@ -54,7 +54,8 @@
 #define MAX_SIZE_LENGTH 64
 
 /*
- * util_tmpfile --  (internal) create the temporary file
+ * util_tmpfile_mkstemp --  (internal) create temporary file
+ *                          if O_TMPFILE not supported
  */
 static int
 util_tmpfile_mkstemp(const char *dir, const char *templ)
@@ -101,15 +102,18 @@ err:
 }
 
 /*
- * util_tmpfile --  (internal) create the temporary file
+ * util_tmpfile -- create temporary file
  */
 int
-util_tmpfile(const char *dir, const char *templ)
+util_tmpfile(const char *dir, const char *templ, int flags)
 {
-	LOG(3, "dir \"%s\" template \"%s\"", dir, templ);
+	LOG(3, "dir \"%s\" template \"%s\" flags %x", dir, templ, flags);
+
+	/* only O_EXCL is allowed here */
+	ASSERT(flags == 0 || flags == O_EXCL);
 
 #ifdef O_TMPFILE
-	int fd = open(dir, O_TMPFILE | O_RDWR, S_IRUSR | S_IWUSR);
+	int fd = open(dir, O_TMPFILE | O_RDWR | flags, S_IRUSR | S_IWUSR);
 	/*
 	 * Open can fail if underlying file system does not support O_TMPFILE
 	 * flag.

--- a/src/common/file_windows.c
+++ b/src/common/file_windows.c
@@ -58,9 +58,12 @@
  * util_tmpfile -- create a temporary file
  */
 int
-util_tmpfile(const char *dir, const char *templ)
+util_tmpfile(const char *dir, const char *templ, int flags)
 {
-	LOG(3, "dir \"%s\" template \"%s\"", dir, templ);
+	LOG(3, "dir \"%s\" template \"%s\" flags %x", dir, templ, flags);
+
+	/* only O_EXCL is allowed here */
+	ASSERT(flags == 0 || flags == O_EXCL);
 
 	int oerrno;
 	int fd = -1;

--- a/src/common/mmap.c
+++ b/src/common/mmap.c
@@ -196,7 +196,7 @@ util_map_tmpfile(const char *dir, size_t size, size_t req_align)
 		return NULL;
 	}
 
-	int fd = util_tmpfile(dir, OS_DIR_SEP_STR "vmem.XXXXXX");
+	int fd = util_tmpfile(dir, OS_DIR_SEP_STR "vmem.XXXXXX", O_EXCL);
 	if (fd == -1) {
 		LOG(2, "cannot create temporary file in dir %s", dir);
 		goto err;

--- a/src/libvmmalloc/libvmmalloc.c
+++ b/src/libvmmalloc/libvmmalloc.c
@@ -404,7 +404,7 @@ libvmmalloc_create(const char *dir, size_t size)
 	/* silently enforce multiple of page size */
 	size = roundup(size, Pagesize);
 
-	Fd = util_tmpfile(dir, "/vmem.XXXXXX");
+	Fd = util_tmpfile(dir, "/vmem.XXXXXX", O_EXCL);
 	if (Fd == -1)
 		return NULL;
 
@@ -457,7 +457,7 @@ libvmmalloc_clone(void)
 {
 	LOG(3, NULL);
 	int err;
-	Fd_clone = util_tmpfile(Dir, "/vmem.XXXXXX");
+	Fd_clone = util_tmpfile(Dir, "/vmem.XXXXXX", O_EXCL);
 	if (Fd_clone == -1)
 		return -1;
 

--- a/src/test/pmem_map_file/TEST0
+++ b/src/test/pmem_map_file/TEST0
@@ -66,7 +66,10 @@ expect_normal_exit ./pmem_map_file$EXESUFFIX \
     $DIR/testfile1 0 E 0 1 1 \
     $DIR/testfile1 4096 T 0644 1 1 \
     $DIR/testfile1 4096 E 0644 1 1 \
-    $DIR/testfile1 0 - 0644 1 1
+    $DIR/testfile1 0 - 0644 1 1 \
+    $DIR/testfile1 4096 C 0644 1 1 \
+    $DIR/testfile1 8192 C 0644 1 1 \
+    $DIR/testfile1 4096 CS 0644 1 1
 
 check_files $DIR/testfile1
 

--- a/src/test/pmem_map_file/TEST0.PS1
+++ b/src/test/pmem_map_file/TEST0.PS1
@@ -71,7 +71,10 @@ expect_normal_exit $Env:EXE_DIR\pmem_map_file$Env:EXESUFFIX `
     $DIR\testfile1 0 E 0 1 1 `
     $DIR\testfile1 4096 T 0644 1 1 `
     $DIR\testfile1 4096 E 0644 1 1 `
-    $DIR\testfile1 0 - 0644 1 1
+    $DIR\testfile1 0 - 0644 1 1 `
+    $DIR\testfile1 4096 C 0644 1 1 `
+    $DIR\testfile1 8192 C 0644 1 1 `
+    $DIR\testfile1 4096 CS 0644 1 1
 
 check_files $DIR\testfile1
 

--- a/src/test/pmem_map_file/mocks_linux.c
+++ b/src/test/pmem_map_file/mocks_linux.c
@@ -53,10 +53,9 @@ posix_fallocate(int fd, os_off_t offset, off_t len)
 	if (posix_fallocate_ptr == NULL)
 		posix_fallocate_ptr = dlsym(RTLD_NEXT, "posix_fallocate");
 
-	if (len > MAX_LEN) {
-		errno = ENOSPC;
-		return -1;
-	}
+	if (len > MAX_LEN)
+		return ENOSPC;
+
 	return (*posix_fallocate_ptr)(fd, offset, len);
 }
 
@@ -72,6 +71,11 @@ ftruncate(int fd, os_off_t len)
 
 	if (ftruncate_ptr == NULL)
 		ftruncate_ptr = dlsym(RTLD_NEXT, "ftruncate");
+
+	if (len > MAX_LEN) {
+		errno = ENOSPC;
+		return -1;
+	}
 
 	return (*ftruncate_ptr)(fd, len);
 }

--- a/src/test/pmem_map_file/mocks_windows.c
+++ b/src/test/pmem_map_file/mocks_windows.c
@@ -45,10 +45,8 @@
 FUNC_MOCK(os_posix_fallocate, int, int fd, os_off_t offset, os_off_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	UT_OUT("posix_fallocate: off %ju len %ju", offset, len);
-	if (len > MAX_LEN) {
-		errno = ENOSPC;
-		return -1;
-	}
+	if (len > MAX_LEN)
+		return ENOSPC;
 	return _FUNC_REAL(os_posix_fallocate)(fd, offset, len);
 }
 FUNC_MOCK_END
@@ -59,6 +57,10 @@ FUNC_MOCK_END
 FUNC_MOCK(os_ftruncate, int, int fd, os_off_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	UT_OUT("ftruncate: len %ju", len);
+	if (len > MAX_LEN) {
+		errno = ENOSPC;
+		return -1;
+	}
 	return _FUNC_REAL(os_ftruncate)(fd, len);
 }
 FUNC_MOCK_END

--- a/src/test/pmem_map_file/out0.log.match
+++ b/src/test/pmem_map_file/out0.log.match
@@ -1,5 +1,5 @@
 pmem_map_file$(nW)TEST0: START: pmem_map_file$(nW)
- $(nW)pmem_map_file$(nW) $(nW)testfile1 0 - 0 1 1 $(nW)testfile1 -1 - 0 1 1 $(nW)testfile1 0 - 0 0 0 $(nW)testfile1 0 X 0 0 0 $(nW)testfile1 0 - 0644 1 1 $(nW)testfile1 1024 - 0 1 1 $(nW)testfile1 0 C 0 1 1 $(nW)testfile1 0 E 0 1 1 $(nW)testfile1 4096 T 0644 1 1 $(nW)testfile1 4096 E 0644 1 1 $(nW)testfile1 0 - 0644 1 1
+ $(nW)pmem_map_file$(nW) $(*)
 $(nW)testfile1 0 - 0 1 1
 mapped_len 2147483648
 unmap successful
@@ -25,5 +25,19 @@ $(nW)testfile1 4096 E 644 1 1
 pmem_map_file: Invalid argument
 $(nW)testfile1 0 - 644 1 1
 mapped_len 2147483648
+unmap successful
+$(nW)testfile1 4096 C 644 1 1
+ftruncate: len 4096
+posix_fallocate: off 0 len 4096
+mapped_len 4096
+unmap successful
+$(nW)testfile1 8192 C 644 1 1
+ftruncate: len 8192
+posix_fallocate: off 0 len 8192
+mapped_len 8192
+unmap successful
+$(nW)testfile1 4096 CS 644 1 1
+ftruncate: len 4096
+mapped_len 4096
 unmap successful
 pmem_map_file$(nW)TEST0: DONE

--- a/src/test/pmem_map_file/out1.log.match
+++ b/src/test/pmem_map_file/out1.log.match
@@ -1,10 +1,11 @@
 pmem_map_file$(nW)TEST1: START: pmem_map_file$(nW)
- $(nW)pmem_map_file$(nW) $(nW)testfile1 0 - 0666 1 1 $(nW)testfile2 0 C 0666 0 0 $(nW)testfile3 4096 C 0666 1 1 $(nW)testfile4 0 E 0666 1 1 $(nW)testfile5 4096 E 0666 1 1 $(nW)testfile6 4096 CE 0666 1 1 $(nW)testfile7 4096 CES 0666 1 1 $(nW)testfile8 4096 CS 0666 1 1 $(nW)testfile9 -1 C 0666 1 1 $(nW)testfile10 4096 X 0666 1 1 $(nW)testfile11 4096 CX 0666 1 1 $(nW)testfile12 0x1FFFFFFFFFFFFFFF CE 0666 1 1 $(nW) 0 T 0666 1 1 $(nW) 4096 T 0666 1 1 $(nW) 4096 TC 0666 1 1 $(nW) 4096 TE 0666 1 1 $(nW) 4096 TS 0666 1 1 $(nW) 4096 TSE 0666 1 1 $(nW) 4096 TCE 0666 1 1 $(nW) 4096 TSEC 0666 1 1 $(nW)nonexistingdir 4096 T 0666 1 1
+ $(nW)pmem_map_file$(nW) $(*)
 $(nW)testfile1 0 - 666 1 1
 pmem_map_file: No such file or directory
 $(nW)testfile2 0 C 666 0 0
 pmem_map_file: Invalid argument
 $(nW)testfile3 4096 C 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
@@ -13,6 +14,7 @@ pmem_map_file: No such file or directory
 $(nW)testfile5 4096 E 666 1 1
 pmem_map_file: Invalid argument
 $(nW)testfile6 4096 CE 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
@@ -31,13 +33,14 @@ pmem_map_file: Invalid argument
 $(nW)testfile11 4096 CX 666 1 1
 pmem_map_file: Invalid argument
 $(nW)testfile12 2305843009213693951 CE 666 1 1
-posix_fallocate: off 0 len 2305843009213693951
+ftruncate: len 2305843009213693951
 pmem_map_file: $(*)
 $(nW) 0 T 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 T 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 TC 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 $(nW) 4096 TE 666 1 1
@@ -47,6 +50,7 @@ pmem_map_file: Invalid argument
 $(nW) 4096 TSE 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 TCE 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 $(nW) 4096 TSEC 666 1 1

--- a/src/test/pmem_map_file_win/mocks_windows.c
+++ b/src/test/pmem_map_file_win/mocks_windows.c
@@ -45,10 +45,8 @@
 FUNC_MOCK(os_posix_fallocate, int, int fd, os_off_t offset, os_off_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	UT_OUT("posix_fallocate: off %ju len %ju", offset, len);
-	if (len > MAX_LEN) {
-		errno = ENOSPC;
-		return -1;
-	}
+	if (len > MAX_LEN)
+		return ENOSPC;
 	return _FUNC_REAL(os_posix_fallocate)(fd, offset, len);
 }
 FUNC_MOCK_END
@@ -59,6 +57,10 @@ FUNC_MOCK_END
 FUNC_MOCK(os_ftruncate, int, int fd, os_off_t len)
 FUNC_MOCK_RUN_DEFAULT {
 	UT_OUT("ftruncate: len %ju", len);
+	if (len > MAX_LEN) {
+		errno = ENOSPC;
+		return -1;
+	}
 	return _FUNC_REAL(os_ftruncate)(fd, len);
 }
 FUNC_MOCK_END

--- a/src/test/pmem_map_file_win/out1.log.match
+++ b/src/test/pmem_map_file_win/out1.log.match
@@ -5,6 +5,7 @@ pmem_map_file: No such file or directory
 $(nW)testfile2 0 C 666 0 0
 pmem_map_file: Invalid argument
 $(nW)testfile3 4096 C 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
@@ -13,6 +14,7 @@ pmem_map_file: No such file or directory
 $(nW)testfile5 4096 E 666 1 1
 pmem_map_file: Invalid argument
 $(nW)testfile6 4096 CE 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 unmap successful
@@ -31,13 +33,14 @@ pmem_map_file: Invalid argument
 $(nW)testfile11 4096 CX 666 1 1
 pmem_map_file: Invalid argument
 $(nW)testfile12 2305843009213693951 CE 666 1 1
-posix_fallocate: off 0 len 2305843009213693951
+ftruncate: len 2305843009213693951
 pmem_map_file: $(*)
 $(nW) 0 T 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 T 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 TC 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 $(nW) 4096 TE 666 1 1
@@ -47,6 +50,7 @@ pmem_map_file: Invalid argument
 $(nW) 4096 TSE 666 1 1
 pmem_map_file: Invalid argument
 $(nW) 4096 TCE 666 1 1
+ftruncate: len 4096
 posix_fallocate: off 0 len 4096
 mapped_len 4096
 $(nW) 4096 TSEC 666 1 1


### PR DESCRIPTION
If PMEM_FILE_CREATE is specified without PMEM_FILE_EXCL and
PMEM_FILE_SPARSE, the file already exists, and len is less than the
existing file length, always truncate the file to the desired length
using ftruncate(3).

Make PMEM_FILE_TMPFILE specified with PMEM_FILE_EXCL behave the same
as O_TMPFILE specified with O_EXCL for open(2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2402)
<!-- Reviewable:end -->
