### PR TITLE
common: FreeBSD cto port

### DIFF
--- a/src/common/set.h
+++ b/src/common/set.h
@@ -208,6 +208,7 @@ void util_poolset_close(struct pool_set *set, enum del_parts_mode del);
 void util_poolset_free(struct pool_set *set);
 int util_poolset_chmod(struct pool_set *set, mode_t mode);
 void util_poolset_fdclose(struct pool_set *set);
+void util_poolset_fdclose_always(struct pool_set *set);
 int util_is_poolset_file(const char *path);
 int util_poolset_foreach_part(const char *path,
 	int (*cb)(struct part_file *pf, void *arg), void *arg);

--- a/src/examples/libpmemcto/libart/Makefile
+++ b/src/examples/libpmemcto/libart/Makefile
@@ -48,11 +48,11 @@
 
 PROGS = arttree
 LIBRARIES = art
+LIBS = -lpmem -lpmemcto
 
 include ../../Makefile.inc
 
 CFLAGS += -ggdb -O0
-LIBS = -lpmem -lpmemcto
 
 $(PROGS): | $(DYNAMIC_LIBRARIES)
 $(PROGS): LDFLAGS += -Wl,-rpath=. -L. -lart

--- a/src/examples/libpmemcto/libart/arttree.c
+++ b/src/examples/libpmemcto/libart/arttree.c
@@ -55,6 +55,9 @@
 #include <ctype.h>
 #include <string.h>
 #include <strings.h>
+#ifdef __FreeBSD__
+#define _WITH_GETLINE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -561,7 +564,7 @@ arttree_fill_func(char *appname, struct ds_context *ctx, int ac, char *av[])
 
 	(void) appname;
 
-	optind = 0;
+	RESET_GETOPT;
 	while ((opt = getopt(ac, av, "n:")) != -1) {
 		switch (opt) {
 		case 'n': {

--- a/src/examples/libpmemcto/libart/arttree.h
+++ b/src/examples/libpmemcto/libart/arttree.h
@@ -54,6 +54,12 @@ extern "C" {
 
 #include "art.h"
 
+#ifdef __FreeBSD__
+#define RESET_GETOPT optreset = 1; optind = 1
+#else
+#define RESET_GETOPT optind = 0
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -455,13 +455,7 @@ pmemblk_createU(const char *path, size_t bsize, size_t poolsize, mode_t mode)
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
 	util_poolset_fdclose(set);
-#endif
 
 	LOG(3, "pbp %p", pbp);
 	return pbp;
@@ -562,13 +556,7 @@ blk_open_common(const char *path, size_t bsize, int cow)
 		goto err;
 	}
 
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
 	util_poolset_fdclose(set);
-#endif
 
 	LOG(3, "pbp %p", pbp);
 	return pbp;

--- a/src/libpmemcto/Makefile
+++ b/src/libpmemcto/Makefile
@@ -36,20 +36,10 @@
 LIBRARY_NAME = pmemcto
 LIBRARY_SO_VERSION = 1
 LIBRARY_VERSION = 0.0
-SOURCE =\
-	$(COMMON)/file.c\
-	$(COMMON)/file_linux.c\
-	$(COMMON)/mmap.c\
-	$(COMMON)/mmap_linux.c\
-	$(COMMON)/os_linux.c\
-	$(COMMON)/os_thread_linux.c\
-	$(COMMON)/out.c\
-	$(COMMON)/util_linux.c\
-	$(COMMON)/util.c\
-	$(COMMON)/pool_hdr.c\
-	$(COMMON)/set.c\
-	$(COMMON)/uuid.c\
-	$(COMMON)/uuid_linux.c\
+
+include ../common/pmemcommon.inc
+
+SOURCE +=\
 	libpmemcto.c\
 	cto.c
 

--- a/src/libpmemlog/log.c
+++ b/src/libpmemlog/log.c
@@ -214,13 +214,7 @@ pmemlog_createU(const char *path, size_t poolsize, mode_t mode)
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
 	util_poolset_fdclose(set);
-#endif
 
 	LOG(3, "plp %p", plp);
 	return plp;
@@ -317,13 +311,7 @@ log_open_common(const char *path, int cow)
 		goto err;
 	}
 
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
 	util_poolset_fdclose(set);
-#endif
 
 	LOG(3, "plp %p", plp);
 	return plp;

--- a/src/libpmemobj/obj.c
+++ b/src/libpmemobj/obj.c
@@ -1275,13 +1275,8 @@ pmemobj_createU(const char *path, const char *layout,
 	if (util_poolset_chmod(set, mode))
 		goto err;
 
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
 	util_poolset_fdclose(set);
-#endif
+
 	LOG(3, "pop %p", pop);
 
 	return pop;
@@ -1651,16 +1646,13 @@ obj_open_common(const char *path, const char *layout, int cow, int boot)
 	if (boot)
 		obj_vg_boot(pop);
 #endif
-	/*
-	 * XXX On FreeBSD, mmap()ing a file does not increment the flock()
-	 *     reference count, so we need to keep the files open.
-	 */
-#ifndef __FreeBSD__
+
 	util_poolset_fdclose(set);
-#endif
+
 	LOG(3, "pop %p", pop);
 
 	return pop;
+
 err_runtime_init:
 err_replicas_check_basic:
 err_check_basic:

--- a/src/libpmempool/replica.c
+++ b/src/libpmempool/replica.c
@@ -954,12 +954,12 @@ replica_check_poolset_health(struct pool_set *set,
 	}
 
 	unmap_all_headers(set);
-	util_poolset_fdclose(set);
+	util_poolset_fdclose_always(set);
 	return 0;
 
 err:
 	unmap_all_headers(set);
-	util_poolset_fdclose(set);
+	util_poolset_fdclose_always(set);
 	replica_free_poolset_health_status(set_hs);
 	return -1;
 }
@@ -1119,7 +1119,7 @@ replica_open_poolset_part_files(struct pool_set *set)
 	return 0;
 
 err:
-	util_poolset_fdclose(set);
+	util_poolset_fdclose_always(set);
 	return -1;
 }
 

--- a/src/test/cto_valgrind/TEST1
+++ b/src/test/cto_valgrind/TEST1
@@ -53,10 +53,6 @@ configure_valgrind memcheck force-enable
 
 setup
 
-# disable debug traces to avoid unnecessary allocations
-unset PMEMCTO_LOG_LEVEL
-unset PMEMCTO_LOG_FILE
-
-expect_normal_exit ./cto_valgrind$EXESUFFIX $DIR/testfile 1
+expect_abnormal_exit ./cto_valgrind$EXESUFFIX $DIR/testfile 1
 
 pass

--- a/src/test/cto_valgrind/TEST3
+++ b/src/test/cto_valgrind/TEST3
@@ -47,6 +47,7 @@ export VALGRIND_OPTS="--suppressions=excluded-errors.supp\
 require_test_type medium
 require_fs_type any
 require_build_type debug nondebug
+require_no_freebsd
 
 require_valgrind_dev_version 3.7
 configure_valgrind memcheck force-enable

--- a/src/test/cto_valgrind/cto_valgrind.c
+++ b/src/test/cto_valgrind/cto_valgrind.c
@@ -68,10 +68,11 @@ main(int argc, char *argv[])
 			break;
 		}
 		case 1: {
-			UT_OUT("only remove allocations");
+			UT_OUT("free after close");
 			ptr = pmemcto_malloc(pcp, sizeof(int));
 			UT_ASSERTne(ptr, NULL);
 
+			pmemcto_close(pcp);
 			pmemcto_free(pcp, ptr);
 			break;
 		}

--- a/src/test/cto_valgrind/memcheck2.log.match
+++ b/src/test/cto_valgrind/memcheck2.log.match
@@ -6,7 +6,7 @@
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
 ==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
 ==$(N)== 
 ==$(N)== $(N) bytes in 1 blocks are definitely lost in loss record 1 of $(N)
@@ -19,7 +19,7 @@ $(OPT)==$(N)==    by 0x$(X): pmemcto_malloc $(*)
 ==$(N)==    indirectly lost: 0 bytes in 0 blocks
 ==$(N)==      possibly lost: 0 bytes in 0 blocks
 ==$(N)==    still reachable: 0 bytes in 0 blocks
-==$(N)==         suppressed: $(N) bytes in $(N) blocks
+==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/cto_valgrind/memcheck4.log.match
+++ b/src/test/cto_valgrind/memcheck4.log.match
@@ -13,7 +13,7 @@ $(OPT)==$(N)==    by 0x$(X): pmemcto_malloc $(*)
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: $(N) bytes in $(N) blocks
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
 ==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
 ==$(N)== 
 $(OPT)==$(N)== All heap blocks were freed -- no leaks are possible
@@ -22,7 +22,7 @@ $(OPT)==$(N)==    definitely lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    indirectly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==      possibly lost: 0 bytes in 0 blocks
 $(OPT)==$(N)==    still reachable: 0 bytes in 0 blocks
-$(OPT)==$(N)==         suppressed: $(N) bytes in $(N) blocks
+$(OPT)==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: $(N) from $(N))

--- a/src/test/cto_valgrind/memcheck5.log.match
+++ b/src/test/cto_valgrind/memcheck5.log.match
@@ -26,10 +26,10 @@ $(OPT)==$(N)==    by 0x$(X): pmemcto_malloc (cto.c:$(N))
 ==$(N)== 
 ==$(N)== 
 ==$(N)== HEAP SUMMARY:
-==$(N)==     in use at exit: 8,388,608 bytes in 1 blocks
+==$(N)==     in use at exit: $(NC) bytes in $(N) blocks
 ==$(N)==   total heap usage: $(N) allocs, $(N) frees, $(*) bytes allocated
 ==$(N)== 
-==$(N)== 8,388,608 bytes in 1 blocks are definitely lost in loss record 1 of 1
+==$(N)== 8,388,608 bytes in 1 blocks are definitely lost in loss record $(N) of $(N)
 ==$(N)==    at 0x$(X): je_cto_pool_malloc ($(*))
 $(OPT)==$(N)==    by 0x$(X): pmemcto_malloc (cto.c:$(N))
 ==$(N)==    by 0x$(X): main (cto_valgrind.c:$(N))
@@ -39,7 +39,7 @@ $(OPT)==$(N)==    by 0x$(X): pmemcto_malloc (cto.c:$(N))
 ==$(N)==    indirectly lost: 0 bytes in 0 blocks
 ==$(N)==      possibly lost: 0 bytes in 0 blocks
 ==$(N)==    still reachable: 0 bytes in 0 blocks
-==$(N)==         suppressed: 0 bytes in 0 blocks
+==$(N)==         suppressed: $(NC) bytes in $(N) blocks
 ==$(N)== 
 ==$(N)== For counts of detected and suppressed errors, rerun with: -v
 ==$(N)== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)

--- a/src/test/cto_valgrind/out1.log.match
+++ b/src/test/cto_valgrind/out1.log.match
@@ -1,0 +1,3 @@
+cto_valgrind/TEST1: START: cto_valgrind
+ ./cto_valgrind $(*)testfile 1
+free after close

--- a/src/test/freebsd.supp
+++ b/src/test/freebsd.supp
@@ -73,6 +73,36 @@ helgrind_FreeBSD_flockfile
    ...
 }
 {
+drd_FreeBSD_fopen
+   drd:ConflictingAccess
+   obj:/lib/libc.so.7
+   fun:fopen
+   ...
+}
+{
+helgrind_FreeBSD_fopen
+   Helgrind:Race
+   obj:/lib/libc.so.7
+   fun:fopen
+   ...
+}
+{
+drd_FreeBSD_fputs
+   drd:ConflictingAccess
+   obj:/lib/libc.so.7
+   ...
+   fun:fputs
+   ...
+}
+{
+helgrind_FreeBSD_fputs
+   Helgrind:Race
+   obj:/lib/libc.so.7
+   ...
+   fun:fputs
+   ...
+}
+{
 drd_FreeBSD_funlockfile
    drd:ConflictingAccess
    fun:funlockfile

--- a/src/test/unittest/unittest.sh
+++ b/src/test/unittest/unittest.sh
@@ -590,7 +590,7 @@ function create_poolset() {
 }
 
 function dump_last_n_lines() {
-	if [ -f $1 ]; then
+	if [ "$1" != "" -a -f "$1" ]; then
 		ln=`wc -l < $1`
 		if [ $ln -gt $UT_DUMP_LINES ]; then
 			echo -e "Last $UT_DUMP_LINES lines of $1 below (whole file has $ln lines)." >&2

--- a/src/tools/Makefile.inc
+++ b/src/tools/Makefile.inc
@@ -156,7 +156,7 @@ STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemobj.a
 endif
 
 ifeq ($(LIBPMEMCTO), y)
-LIBS += -ldl
+LIBS += $(LIBDL)
 DYNAMIC_LIBS += -lpmemcto
 STATIC_DEBUG_LIBS += $(LIBSDIR_DEBUG)/libpmemcto.a
 STATIC_NONDEBUG_LIBS += $(LIBSDIR_NONDEBUG)/libpmemcto.a


### PR DESCRIPTION
Fix libpmemcto/Makefile to use pmemcommon.inc.
Add util_poolset_fdclose_always; remove #ifdef __FreeBSD__ guards
around util_poolset_fdclose.
Fix definition order in examples/libpmemcto/libart/Makefile.
Add RESET_GETOPT macro in examples/libpmemcto/libart.
Lock around pool creation/deletion in test/cto_multiple_pools
to prevent mmap race.
Compatibility fixes to test/cto_valgrind.
Fix dump_last_n_lines when argument is blank (unittest.sh).
Use $(LIBDL) in src/tools/Makefile.inc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2415)
<!-- Reviewable:end -->

Ref: #1979