### PR TITLE
obj: fix memcheck tx_abort instrumentation

### DIFF
--- a/src/libpmemobj/memblock.c
+++ b/src/libpmemobj/memblock.c
@@ -813,7 +813,7 @@ memblock_detect_type(const struct memory_block *m, struct heap_layout *h)
  *	originates from the heap
  */
 struct memory_block
-memblock_from_offset(struct palloc_heap *heap, uint64_t off)
+memblock_from_offset_opt(struct palloc_heap *heap, uint64_t off, int size)
 {
 	struct memory_block m = MEMORY_BLOCK_NONE;
 	m.heap = heap;
@@ -851,12 +851,21 @@ memblock_from_offset(struct palloc_heap *heap, uint64_t off)
 		off -= m.block_off * unit_size;
 	}
 
-	m.size_idx = CALC_SIZE_IDX(unit_size,
+	m.size_idx = !size ? 0 : CALC_SIZE_IDX(unit_size,
 		memblock_header_ops[m.header_type].get_size(&m));
 
 	ASSERTeq(off, 0);
 
 	return m;
+}
+
+/*
+ * memblock_from_offset -- returns memory block with size
+ */
+struct memory_block
+memblock_from_offset(struct palloc_heap *heap, uint64_t off)
+{
+	return memblock_from_offset_opt(heap, off, 1);
 }
 
 /*

--- a/src/libpmemobj/memblock.h
+++ b/src/libpmemobj/memblock.h
@@ -243,6 +243,8 @@ enum memblock_state memblock_validate_offset(struct palloc_heap *heap,
 	uint64_t off);
 struct memory_block memblock_from_offset(struct palloc_heap *heap,
 	uint64_t off);
+struct memory_block memblock_from_offset_opt(struct palloc_heap *heap,
+	uint64_t off, int size);
 void memblock_rebuild_state(struct palloc_heap *heap, struct memory_block *m);
 
 #endif

--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -753,6 +753,16 @@ palloc_vg_register_alloc(const struct memory_block *m, void *arg)
 }
 
 /*
+ * palloc_vg_register_off -- registers an object in valgrind
+ */
+void
+palloc_vg_register_off(struct palloc_heap *heap, uint64_t off)
+{
+	struct memory_block m = memblock_from_offset_opt(heap, off, 0);
+	palloc_vg_register_alloc(&m, heap);
+}
+
+/*
  * palloc_heap_vg_open -- notifies Valgrind about heap layout
  */
 void

--- a/src/libpmemobj/palloc.h
+++ b/src/libpmemobj/palloc.h
@@ -43,6 +43,7 @@
 #include "libpmemobj.h"
 #include "memops.h"
 #include "redo.h"
+#include "valgrind_internal.h"
 
 struct palloc_heap {
 	struct pmem_ops p_ops;
@@ -106,6 +107,7 @@ void palloc_heap_cleanup(struct palloc_heap *heap);
 typedef int (*object_callback)(const struct memory_block *m, void *arg);
 
 #ifdef USE_VG_MEMCHECK
+void palloc_vg_register_off(struct palloc_heap *heap, uint64_t off);
 void palloc_heap_vg_open(struct palloc_heap *heap, int objects);
 #endif
 

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -892,15 +892,7 @@ tx_abort_register_valgrind(PMEMobjpool *pop, struct pvector_context *ctx)
 {
 	uint64_t off;
 	for (off = pvector_first(ctx); off != 0; off = pvector_next(ctx)) {
-		/*
-		 * Can't use pmemobj_direct and pmemobj_alloc_usable_size
-		 * because pool has not been registered yet.
-		 */
-		void *p = (char *)pop + off;
-		size_t sz = palloc_usable_size(&pop->heap, off);
-
-		VALGRIND_DO_MEMPOOL_ALLOC(pop->heap.layout, p, sz);
-		VALGRIND_DO_MAKE_MEM_DEFINED(p, sz);
+		palloc_vg_register_off(&pop->heap, off);
 	}
 }
 #endif


### PR DESCRIPTION
Always reinitialize headers of undo logged objects before reading
any values from them.

Ref: pmem/issues#705

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2419)
<!-- Reviewable:end -->
