### PR TITLE
rpmem: handle huge pages in rpmemd

### DIFF
--- a/src/librpmem/rpmem_fip.c
+++ b/src/librpmem/rpmem_fip.c
@@ -1217,7 +1217,7 @@ rpmem_fip_persist(struct rpmem_fip *fip, size_t offset, size_t len,
 	if (unlikely(lane >= fip->nlanes))
 		return EINVAL; /* it will be passed to errno */
 
-	if (unlikely(offset + len > fip->size))
+	if (unlikely(offset > fip->size || offset + len > fip->size))
 		return EINVAL; /* it will be passed to errno */
 
 	if (unlikely(len == 0)) {

--- a/src/tools/rpmemd/rpmemd.c
+++ b/src/tools/rpmemd/rpmemd.c
@@ -196,11 +196,11 @@ static int
 rpmemd_common_fip_init(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 	struct rpmem_resp_attr *resp, int *status)
 {
-	void *addr = (void *)((uintptr_t)rpmemd->pool->pool_addr +
-			POOL_HDR_SIZE);
+	/* register the whole pool with header in RDMA */
+	void *addr = (void *)((uintptr_t)rpmemd->pool->pool_addr);
 	struct rpmemd_fip_attr fip_attr = {
 		.addr		= addr,
-		.size		= req->pool_size,
+		.size		= req->pool_size + POOL_HDR_SIZE,
 		.nlanes		= req->nlanes,
 		.nthreads	= rpmemd->nthreads,
 		.provider	= req->provider,
@@ -222,6 +222,9 @@ rpmemd_common_fip_init(struct rpmemd *rpmemd, const struct rpmem_req_attr *req,
 		*status = (int)err;
 		goto err_fip_init;
 	}
+
+	/* let user use the pool without header */
+	resp->raddr += POOL_HDR_SIZE;
 
 	return 0;
 err_fip_init:


### PR DESCRIPTION
Rpmemd will register the remote pool with header, but expose without header
to a user. This way rdma will work always with page aligned memory region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2425)
<!-- Reviewable:end -->
