### PR TITLE
obj: add pmemobj_ctl_exec for runnable actions

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -87,7 +87,7 @@ MANPAGES_3_DUMMY = pmem_drain.3 pmem_has_hw_drain.3 \
 		   pmemobj_zalloc.3 pmemobj_xalloc.3 pmemobj_free.3 pmemobj_realloc.3 pmemobj_zrealloc.3 pmemobj_strdup.3 pmemobj_wcsdup.3 pmemobj_alloc_usable_size.3 \
 		   pobj_new.3 pobj_alloc.3 pobj_znew.3 pobj_zalloc.3 pobj_realloc.3 pobj_zrealloc.3 pobj_free.3 \
 		   pobj_layout_toid.3 pobj_layout_root.3 pobj_layout_name.3 pobj_layout_end.3 pobj_layout_types_num.3 \
-		   pmemobj_ctl_set.3 \
+		   pmemobj_ctl_set.3 pmemobj_ctl_exec.3\
 		   pmemobj_create.3 pmemobj_close.3 \
 		   pmemobj_list_insert_new.3 pmemobj_list_remove.3 pmemobj_list_move.3 \
 		   toid_declare_root.3 toid.3 toid_type_num.3 toid_type_num_of.3 toid_valid.3 oid_instanceof.3 toid_assign.3 toid_is_null.3 toid_equals.3 toid_typeof.3 toid_offsetof.3 direct_rw.3 d_rw.3 direct_ro.3 d_ro.3 \

--- a/doc/generated/pmemobj_ctl_exec.3
+++ b/doc/generated/pmemobj_ctl_exec.3
@@ -1,0 +1,1 @@
+.so pmemobj_ctl_get.3

--- a/src/include/libpmemobj/ctl.h
+++ b/src/include/libpmemobj/ctl.h
@@ -160,6 +160,8 @@ struct pobj_alloc_class_desc {
 int pmemobj_ctl_get(PMEMobjpool *pop, const char *name, void *arg);
 /* EXPERIMENTAL */
 int pmemobj_ctl_set(PMEMobjpool *pop, const char *name, void *arg);
+/* EXPERIMENTAL */
+int pmemobj_ctl_exec(PMEMobjpool *pop, const char *name, void *arg);
 #else
 /* EXPERIMENTAL */
 int pmemobj_ctl_getU(PMEMobjpool *pop, const char *name, void *arg);
@@ -169,12 +171,18 @@ int pmemobj_ctl_getW(PMEMobjpool *pop, const wchar_t *name, void *arg);
 int pmemobj_ctl_setU(PMEMobjpool *pop, const char *name, void *arg);
 int pmemobj_ctl_setW(PMEMobjpool *pop, const wchar_t *name, void *arg);
 
+/* EXPERIMENTAL */
+int pmemobj_ctl_execU(PMEMobjpool *pop, const char *name, void *arg);
+int pmemobj_ctl_execW(PMEMobjpool *pop, const wchar_t *name, void *arg);
+
 #ifndef NVML_UTF8_API
 #define pmemobj_ctl_get pmemobj_ctl_getW
 #define pmemobj_ctl_set pmemobj_ctl_setW
+#define pmemobj_ctl_exec pmemobj_ctl_execW
 #else
 #define pmemobj_ctl_get pmemobj_ctl_getU
 #define pmemobj_ctl_set pmemobj_ctl_setU
+#define pmemobj_ctl_exec pmemobj_ctl_execU
 #endif
 
 #endif

--- a/src/libpmemobj/ctl_global.c
+++ b/src/libpmemobj/ctl_global.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Intel Corporation
+ * Copyright 2016-2017, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@
 #include "ctl_global.h"
 
 static int
-CTL_READ_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_READ_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int *arg_out = arg;
@@ -50,7 +50,7 @@ CTL_READ_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_type type,
 }
 
 static int
-CTL_WRITE_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_WRITE_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int arg_in = *(int *)arg;
@@ -61,7 +61,7 @@ CTL_WRITE_HANDLER(at_create)(PMEMobjpool *pop, enum ctl_query_type type,
 }
 
 static int
-CTL_READ_HANDLER(at_open)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_READ_HANDLER(at_open)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int *arg_out = arg;
@@ -71,7 +71,7 @@ CTL_READ_HANDLER(at_open)(PMEMobjpool *pop, enum ctl_query_type type,
 }
 
 static int
-CTL_WRITE_HANDLER(at_open)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_WRITE_HANDLER(at_open)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int arg_in = *(int *)arg;

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -67,6 +67,8 @@ EXPORTS
 	pmemobj_cond_signal
 	pmemobj_cond_timedwait
 	pmemobj_cond_wait
+	pmemobj_ctl_execU;
+	pmemobj_ctl_execW;
 	pmemobj_ctl_getU;
 	pmemobj_ctl_getW;
 	pmemobj_ctl_setU;

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -41,6 +41,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_open;
 		pmemobj_close;
 		pmemobj_check;
+		pmemobj_ctl_exec;
 		pmemobj_ctl_get;
 		pmemobj_ctl_set;
 		pmemobj_mutex_zero;

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -303,7 +303,7 @@ SECTION_PARM(LANE_SECTION_ALLOCATOR, &allocator_ops);
  */
 static int
 CTL_WRITE_HANDLER(desc)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	uint8_t id;
 	struct alloc_class_collection *ac = heap_alloc_classes(&pop->heap);
@@ -418,7 +418,7 @@ pmalloc_header_type_parser(const void *arg, void *dest, size_t dest_size)
  */
 static int
 CTL_READ_HANDLER(desc)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	uint8_t id;
 

--- a/src/libpmemobj/tx.c
+++ b/src/libpmemobj/tx.c
@@ -2308,7 +2308,7 @@ SECTION_PARM(LANE_SECTION_TRANSACTION, &transaction_ops);
  */
 static int
 CTL_READ_HANDLER(size)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	ssize_t *arg_out = arg;
 
@@ -2322,7 +2322,7 @@ CTL_READ_HANDLER(size)(PMEMobjpool *pop,
  */
 static int
 CTL_WRITE_HANDLER(size)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	ssize_t arg_in = *(int *)arg;
 
@@ -2348,7 +2348,7 @@ static struct ctl_argument CTL_ARG(size) = CTL_ARG_LONG_LONG;
  */
 static int
 CTL_READ_HANDLER(threshold)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	ssize_t *arg_out = arg;
 
@@ -2363,7 +2363,7 @@ CTL_READ_HANDLER(threshold)(PMEMobjpool *pop,
  */
 static int
 CTL_WRITE_HANDLER(threshold)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	ssize_t arg_in = *(int *)arg;
 
@@ -2393,7 +2393,7 @@ static const struct ctl_node CTL_NODE(cache)[] = {
  */
 static int
 CTL_READ_HANDLER(skip_expensive_checks)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	int *arg_out = arg;
 
@@ -2408,7 +2408,7 @@ CTL_READ_HANDLER(skip_expensive_checks)(PMEMobjpool *pop,
  */
 static int
 CTL_WRITE_HANDLER(skip_expensive_checks)(PMEMobjpool *pop,
-	enum ctl_query_type type, void *arg, struct ctl_indexes *indexes)
+	enum ctl_query_source source, void *arg, struct ctl_indexes *indexes)
 {
 	int arg_in = *(int *)arg;
 
@@ -2428,7 +2428,7 @@ static const struct ctl_node CTL_NODE(debug)[] = {
  * CTL_WRITE_HANDLER(queue_depth) -- returns the depth of the post commit queue
  */
 static int
-CTL_READ_HANDLER(queue_depth)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_READ_HANDLER(queue_depth)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int *arg_out = arg;
@@ -2442,7 +2442,7 @@ CTL_READ_HANDLER(queue_depth)(PMEMobjpool *pop, enum ctl_query_type type,
  * CTL_WRITE_HANDLER(queue_depth) -- sets the depth of the post commit queue
  */
 static int
-CTL_WRITE_HANDLER(queue_depth)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_WRITE_HANDLER(queue_depth)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	int arg_in = *(int *)arg;
@@ -2466,7 +2466,7 @@ static struct ctl_argument CTL_ARG(queue_depth) = CTL_ARG_INT;
  * CTL_READ_HANDLER(worker) -- launches the post commit worker thread function
  */
 static int
-CTL_READ_HANDLER(worker)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_READ_HANDLER(worker)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 
@@ -2483,7 +2483,7 @@ CTL_READ_HANDLER(worker)(PMEMobjpool *pop, enum ctl_query_type type,
  * CTL_READ_HANDLER(stop) -- stops all post commit workers
  */
 static int
-CTL_READ_HANDLER(stop)(PMEMobjpool *pop, enum ctl_query_type type,
+CTL_READ_HANDLER(stop)(PMEMobjpool *pop, enum ctl_query_source source,
 	void *arg, struct ctl_indexes *indexes)
 {
 	ringbuf_stop(pop->tx_postcommit_tasks);

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -15,6 +15,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct
@@ -99,6 +100,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct
@@ -183,6 +185,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct
@@ -267,6 +270,7 @@ pmemobj_cond_timedwait
 pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_create
+pmemobj_ctl_exec
 pmemobj_ctl_get
 pmemobj_ctl_set
 pmemobj_direct

--- a/src/test/scope/out4w.log.match
+++ b/src/test/scope/out4w.log.match
@@ -17,6 +17,8 @@ pmemobj_cond_wait
 pmemobj_cond_zero
 pmemobj_createU
 pmemobj_createW
+pmemobj_ctl_execU
+pmemobj_ctl_execW
 pmemobj_ctl_getU
 pmemobj_ctl_getW
 pmemobj_ctl_setU


### PR DESCRIPTION
The initial CTL API had one simple func: pmemobj_ctl(), it served
three functions: read, write or trigger. When we decided to change
it to pmemobj_ctl_set and pmemobj_ctl_get, the trigger functionality
has been forgotten because it didn't have any apparent use cases yet.
This changes with manual pool extension, which will be an example of
such triggerable (or runnable) action.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2426)
<!-- Reviewable:end -->
