### PR TITLE
obj: fix qsort lock ptr comparision

### DIFF
--- a/src/libpmemobj/palloc.c
+++ b/src/libpmemobj/palloc.c
@@ -340,7 +340,15 @@ palloc_action_compare(const void *lhs, const void *rhs)
 {
 	const struct pobj_action_internal *mlhs = lhs;
 	const struct pobj_action_internal *mrhs = rhs;
-	return (int)((int64_t)(mlhs->lock) - (int64_t)(mrhs->lock));
+	uintptr_t vlhs = (uintptr_t)(mlhs->lock);
+	uintptr_t vrhs = (uintptr_t)(mrhs->lock);
+
+	if (vlhs < vrhs)
+		return -1;
+	if (vlhs > vrhs)
+		return 1;
+
+	return 0;
 }
 
 /*


### PR DESCRIPTION
Casting to int loses signedness of the value, which might
cause irregular sorting outcome if the locks are spaced far
apart.

Thanks @mslusarz :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2429)
<!-- Reviewable:end -->
