### PR TITLE
obj: fix allocs whose size_idx exceed nallocs

### DIFF
--- a/src/libpmemobj/alloc_class.c
+++ b/src/libpmemobj/alloc_class.c
@@ -686,6 +686,8 @@ alloc_class_calc_size_idx(struct alloc_class *c, size_t size)
 			return -1;
 		else if (size_idx > RUN_UNIT_MAX)
 			return -1;
+		else if (size_idx > c->run.bitmap_nallocs)
+			return -1;
 	}
 
 	return size_idx;

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
@@ -207,6 +207,21 @@ main(int argc, char *argv[])
 		POBJ_CLASS_ID(alloc_class_new_max.class_id), NULL, NULL);
 	UT_ASSERTne(ret, 0);
 
+	struct pobj_alloc_class_desc alloc_class_new_loop;
+	alloc_class_new_loop.header_type = POBJ_HEADER_COMPACT;
+	alloc_class_new_loop.unit_size = 16384;
+	alloc_class_new_loop.units_per_block = 63;
+	alloc_class_new_loop.class_id = 0;
+
+	ret = pmemobj_ctl_set(pop, "heap.alloc_class.new.desc",
+		&alloc_class_new_loop);
+	UT_ASSERTeq(ret, 0);
+
+	size_t s = (63 * 16384) - 16;
+	ret = pmemobj_xalloc(pop, &oid, s + 1, 0,
+		POBJ_CLASS_ID(alloc_class_new_loop.class_id), NULL, NULL);
+	UT_ASSERTne(ret, 0);
+
 	pmemobj_close(pop);
 
 	DONE(NULL);


### PR DESCRIPTION
This patch fixes an infinite loop that happened when trying to
allocate objects that are too large for the allocation class.

Ref: pmem/issues#696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2440)
<!-- Reviewable:end -->
