### PR TITLE
obj: speed up pmemobj_open with compiled-in Valgrind support

### DIFF
--- a/src/libpmemobj/container_seglists.c
+++ b/src/libpmemobj/container_seglists.c
@@ -82,11 +82,7 @@ container_seglists_insert_block(struct block_container *bc,
 	ASSERT(m->size_idx <= SEGLIST_BLOCK_LISTS);
 
 	struct seglist_entry *e = m->m_ops->get_user_data(m);
-#ifdef USE_VG_MEMCHECK
-	if (On_valgrind) {
-		VALGRIND_DO_MAKE_MEM_DEFINED(e, sizeof(*e));
-	}
-#endif
+	VALGRIND_DO_MAKE_MEM_DEFINED(e, sizeof(*e));
 
 	struct seglist_entry **last = c->blocks[m->size_idx - 1].stqh_last;
 

--- a/src/libpmemobj/pmalloc.c
+++ b/src/libpmemobj/pmalloc.c
@@ -278,7 +278,8 @@ pmalloc_boot(PMEMobjpool *pop)
 		return ret;
 
 #ifdef USE_VG_MEMCHECK
-	palloc_heap_vg_open(&pop->heap, pop->vg_boot);
+	if (On_valgrind)
+		palloc_heap_vg_open(&pop->heap, pop->vg_boot);
 #endif
 
 	ret = palloc_buckets_init(&pop->heap);


### PR DESCRIPTION
FYI, I discovered those 2 patches today. Yes, discovered :). I wrote them in May, but I forgot to submit them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2443)
<!-- Reviewable:end -->
