### PR TITLE
obj: implement pmemobj_xreserve()

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -108,7 +108,7 @@ MANPAGES_3_DUMMY = pmem_drain.3 pmem_has_hw_drain.3 \
 		   pmemobj_next.3 pobj_first_type_num.3 pobj_first.3 pobj_next_type_num.3 pobj_next.3 pobj_foreach.3 pobj_foreach_safe.3 pobj_foreach_type.3 pobj_foreach_safe_type.3 \
 		   pmemobj_root_construct.3 pobj_root.3 pmemobj_root_size.3 \
 		   pmemobj_check_version.3 pmemobj_check.3 pmemobj_errormsg.3 pmemobj_set_funcs.3 \
-		   pmemobj_reserve.3 pmemobj_set_value.3 pmemobj_publish.3 pmemobj_tx_publish.3 pmemobj_cancel.3 pobj_reserve_new.3 pobj_reserve_alloc.3\
+		   pmemobj_reserve.3 pmemobj_xreserve.3 pmemobj_set_value.3 pmemobj_publish.3 pmemobj_tx_publish.3 pmemobj_cancel.3 pobj_reserve_new.3 pobj_reserve_alloc.3\
 		   pmemcto_close.3 pmemcto_create.3\
 		   pmemcto_check.3\
 		   pmemcto_calloc.3 pmemcto_realloc.3 pmemcto_free.3\

--- a/doc/generated/pmemobj_xreserve.3
+++ b/doc/generated/pmemobj_xreserve.3
@@ -1,0 +1,2 @@
+.so pmemobj_action.3
+

--- a/doc/libpmemobj/pmemobj_action.3.md
+++ b/doc/libpmemobj/pmemobj_action.3.md
@@ -46,8 +46,8 @@ date: pmemobj API version 2.2
 
 # NAME #
 
-**pmemobj_reserve**(), **pmemobj_set_value**(), **pmemobj_publish**(),
-**pmemobj_tx_publish**(), **pmemobj_cancel**(),
+**pmemobj_reserve**(), **pmemobj_xreserve**(), **pmemobj_set_value**(),
+**pmemobj_publish**(), **pmemobj_tx_publish**(), **pmemobj_cancel**(),
 **POBJ_RESERVE_NEW**(), **POBJ_RESERVE_ALLOC**()
 -- Delayed atomicity actions
 
@@ -59,6 +59,8 @@ date: pmemobj API version 2.2
 
 PMEMoid pmemobj_reserve(PMEMobjpool *pop, struct pobj_action *act,
 	size_t size, uint64_t type_num);
+PMEMoid pmemobj_xreserve(PMEMobjpool *pop, struct pobj_action *act,
+	size_t size, uint64_t type_num, uint64_t flags);
 void pmemobj_set_value(PMEMobjpool *pop, struct pobj_action *act,
 	uint64_t *ptr, uint64_t value);
 void pmemobj_publish(PMEMobjpool *pop, struct pobj_action *actv, int actvcnt);
@@ -101,6 +103,14 @@ persistent state.
 The object returned by this function can be freely modified without worrying
 about fail-safe atomicity until the object has been published. Any modifications
 of the object must be manually persisted, just like in the case of the atomic API.
+
+**pmemobj_xreserve**() is equivalent to **pmemobj_reserve**(), but with an
+additional *flags* argument that is a bitmask of the following values:
+
++ **POBJ_XALLOC_ZERO** - zero the object
+
++ **POBJ_CLASS_ID(class_id)** - allocate the object from allocation class
+*class_id*. The class id cannot be 0.
 
 The **pmemobj_set_value** function prepares an action that, once published, will
 modify the memory location pointed to by *ptr* to *value*.

--- a/src/include/libpmemobj/action_base.h
+++ b/src/include/libpmemobj/action_base.h
@@ -72,9 +72,13 @@ struct pobj_action {
 };
 
 #define POBJ_MAX_ACTIONS 60
+#define POBJ_ACTION_XRESERVE_VALID_FLAGS\
+	(POBJ_XALLOC_CLASS_MASK | POBJ_XALLOC_ZERO)
 
 PMEMoid pmemobj_reserve(PMEMobjpool *pop, struct pobj_action *act,
 	size_t size, uint64_t type_num);
+PMEMoid pmemobj_xreserve(PMEMobjpool *pop, struct pobj_action *act,
+	size_t size, uint64_t type_num, uint64_t flags);
 void pmemobj_set_value(PMEMobjpool *pop, struct pobj_action *act,
 	uint64_t *ptr, uint64_t value);
 

--- a/src/libpmemobj/libpmemobj.def
+++ b/src/libpmemobj/libpmemobj.def
@@ -122,6 +122,7 @@ EXPORTS
 	pmemobj_direct
 	pmemobj_oid
 	pmemobj_reserve
+	pmemobj_xreserve
 	pmemobj_set_value
 	pmemobj_publish
 	pmemobj_tx_publish

--- a/src/libpmemobj/libpmemobj.map
+++ b/src/libpmemobj/libpmemobj.map
@@ -111,6 +111,7 @@ LIBPMEMOBJ_1.0 {
 		pmemobj_drain;
 		pmemobj_direct;
 		pmemobj_reserve;
+		pmemobj_xreserve;
 		pmemobj_set_value;
 		pmemobj_publish;
 		pmemobj_tx_publish;

--- a/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
+++ b/src/test/obj_ctl_alloc_class/obj_ctl_alloc_class.c
@@ -98,6 +98,16 @@ main(int argc, char *argv[])
 	pmemobj_free(&oid);
 
 	/*
+	 * Reserve as above.
+	 */
+	struct pobj_action act;
+	oid = pmemobj_xreserve(pop, &act, 128, 0, POBJ_CLASS_ID(128));
+	UT_ASSERT(!OID_IS_NULL(oid));
+	usable_size = pmemobj_alloc_usable_size(oid);
+	UT_ASSERTeq(usable_size, 128);
+	pmemobj_cancel(pop, &act, 1);
+
+	/*
 	 * One unit from alloc class 128 - 128 bytes unit size, minimal headers,
 	 * but request size 1 byte.
 	 */

--- a/src/test/scope/out4.log.match
+++ b/src/test/scope/out4.log.match
@@ -82,6 +82,7 @@ pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_wcsdup
 pmemobj_xalloc
+pmemobj_xreserve
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)/nondebug/libpmemobj.so:
@@ -167,6 +168,7 @@ pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_wcsdup
 pmemobj_xalloc
+pmemobj_xreserve
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)/debug/libpmemobj.a:
@@ -252,6 +254,7 @@ pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_wcsdup
 pmemobj_xalloc
+pmemobj_xreserve
 pmemobj_zalloc
 pmemobj_zrealloc
 $(*)/nondebug/libpmemobj.a:
@@ -337,5 +340,6 @@ pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_wcsdup
 pmemobj_xalloc
+pmemobj_xreserve
 pmemobj_zalloc
 pmemobj_zrealloc

--- a/src/test/scope/out4w.log.match
+++ b/src/test/scope/out4w.log.match
@@ -89,5 +89,6 @@ pmemobj_tx_zrealloc
 pmemobj_type_num
 pmemobj_wcsdup
 pmemobj_xalloc
+pmemobj_xreserve
 pmemobj_zalloc
 pmemobj_zrealloc


### PR DESCRIPTION
This adds the ability to reserve using a custom allocation class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2447)
<!-- Reviewable:end -->
