### PR TITLE
common: switch to Valgrind 3.12

### DIFF
--- a/src/test/vmmalloc_valgrind/TEST1
+++ b/src/test/vmmalloc_valgrind/TEST1
@@ -51,10 +51,6 @@ set_valgrind_exe_name
 configure_valgrind memcheck force-enable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 setup
 
-if [ $(valgrind_version) -ge 312 ]; then
-	export VALGRIND_OPTS="$VALGRIND_OPTS --soname-synonyms=somalloc=nouserintercepts"
-fi
-
 unset VMMALLOC_LOG_LEVEL
 unset VMMALLOC_LOG_FILE
 export TEST_LD_PRELOAD=libvmmalloc.so

--- a/src/test/vmmalloc_valgrind/TEST2
+++ b/src/test/vmmalloc_valgrind/TEST2
@@ -51,10 +51,6 @@ set_valgrind_exe_name
 configure_valgrind memcheck force-enable $TEST_LD_LIBRARY_PATH/libvmmalloc.so
 setup
 
-if [ $(valgrind_version) -ge 312 ]; then
-	 export VALGRIND_OPTS="$VALGRIND_OPTS --soname-synonyms=somalloc=nouserintercepts"
-fi
-
 unset VMMALLOC_LOG_LEVEL
 unset VMMALLOC_LOG_FILE
 

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -36,8 +36,11 @@
 
 set -e
 
-git clone --recursive --depth 1 https://github.com/pmem/valgrind.git
+git clone --recursive https://github.com/pmem/valgrind.git
 cd valgrind
+git checkout pmem-3.12
+git submodule init
+git submodule update
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
For some tests, older versions of valgrind reports false-positives.
Valgrind 3.10 does not even build on current travis environment with clang 3.9 and on 3.11 some valgrind tests fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2448)
<!-- Reviewable:end -->
