### PR TITLE
test: add suppressions for DRD in CTO tests

### DIFF
--- a/src/test/drd-log.supp
+++ b/src/test/drd-log.supp
@@ -8,3 +8,12 @@
     fun:out_common
     fun:out_log
 }
+{
+    <ut_log_suppress>
+    drd:ConflictingAccess
+    fun:*mempcpy
+    fun:_IO_file_xsputn@@GLIBC*
+    fun:fputs
+    ...
+    fun:ut_out
+}

--- a/src/test/obj_pmalloc_mt/TEST3
+++ b/src/test/obj_pmalloc_mt/TEST3
@@ -41,8 +41,6 @@ export UNITTEST_NAME=obj_pmalloc_mt/TEST$UNITTEST_NUM
 # standard unit test setup
 . ../unittest/unittest.sh
 
-export VALGRIND_OPTS="--suppressions=../drd-log.supp"
-
 require_valgrind_dev_version 3.10
 require_fs_type pmem non-pmem
 require_test_type medium


### PR DESCRIPTION
Silences selected data race reports found by Valgrind 3.12 drd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2449)
<!-- Reviewable:end -->
