### PR TITLE
test: change vmem_multiple_pools/TEST1 to long

### DIFF
--- a/src/test/vmem_multiple_pools/TEST1.PS1
+++ b/src/test/vmem_multiple_pools/TEST1.PS1
@@ -43,7 +43,9 @@ $Env:UNITTEST_NUM = "1"
 # standard unit test setup
 . ..\unittest\unittest.ps1
 
-require_test_type medium
+# this test often fails on CI, change to medium when fixed
+require_test_type long
+
 require_fs_type any
 require_build_type debug nondebug
 


### PR DESCRIPTION
This test fails all the time on AppVeyor, making the appveyor build
almost useless. Since nobody cares enough to fix it, let's disable
it for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/nvml/2451)
<!-- Reviewable:end -->
